### PR TITLE
feat: matrix override from CLI (closes #5)

### DIFF
--- a/examples/playwright-matrix-override
+++ b/examples/playwright-matrix-override
@@ -1,0 +1,1 @@
+../tests/fixtures/playwright-matrix-override

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ dev = [
 
 [tool.pytest.ini_options]
 testpaths = ["src", "tests"]
-norecursedirs = ["fixtures"]
+norecursedirs = ["fixtures", "examples"]
 markers = ["slow: visual demo tests with real delays"]
 
 [tool.ruff]

--- a/src/camas/__init__.py
+++ b/src/camas/__init__.py
@@ -438,6 +438,87 @@ def specialize_node(task: TaskNode, binding: MatrixBinding, suffix: str) -> Task
 			assert_never(task)
 
 
+def matrix_axes(task: TaskNode) -> dict[str, tuple[str, ...]]:
+	"""Walk a task tree and collect every matrix axis with its values.
+
+	When the same axis name appears in multiple matrices, the outermost (closest
+	to the root) wins — that's the value the user sees in ``--list`` and the one
+	overrides should target. Inner duplicates with the same key but different
+	values are unusual; users almost never write them.
+
+	>>> matrix_axes(Task("hi"))
+	{}
+	>>> matrix_axes(Parallel(Task("test"), matrix={"PY": ("3.12", "3.13")}))
+	{'PY': ('3.12', '3.13')}
+	>>> matrix_axes(Sequential(Parallel(Task("t"), matrix={"OS": ("a", "b")}), matrix={"PY": ("3.12",)}))
+	{'PY': ('3.12',), 'OS': ('a', 'b')}
+	"""
+	match task:
+		case Task():
+			return {}
+		case Sequential(tasks=tasks, matrix=matrix) | Parallel(tasks=tasks, matrix=matrix):
+			result: dict[str, tuple[str, ...]] = dict(matrix) if matrix else {}
+			for child in tasks:
+				for k, v in matrix_axes(child).items():
+					result.setdefault(k, v)
+			return result
+		case _:
+			assert_never(task)
+
+
+def override_matrix(task: TaskNode, overrides: Mapping[str, tuple[str, ...]]) -> TaskNode:
+	"""Return a tree with each ``matrix[k]`` replaced by ``overrides[k]`` everywhere
+	the key appears. Strict on keys: every override must match an axis present in
+	the tree. Permissive on values: any tuple is accepted.
+
+	>>> override_matrix(Parallel(Task("t"), matrix={"PY": ("3.12", "3.13")}), {"PY": ("3.13",)}).matrix  # type: ignore[union-attr]
+	{'PY': ('3.13',)}
+	>>> override_matrix(Task("hi"), {})
+	Task(cmd='hi', name=None, env={}, cwd=None)
+	>>> override_matrix(Parallel(Task("t"), matrix={"PY": ("3.12",)}), {"XX": ("a",)})
+	Traceback (most recent call last):
+	    ...
+	ValueError: unknown matrix axis 'XX' (known: PY)
+	"""
+	if not overrides:
+		return task
+	axes: Final = matrix_axes(task)
+	for key in overrides:
+		if key not in axes:
+			known = ", ".join(sorted(axes)) or "none"
+			raise ValueError(f"unknown matrix axis {key!r} (known: {known})")
+	return _override_matrix(task, overrides)
+
+
+def _override_matrix(task: TaskNode, overrides: Mapping[str, tuple[str, ...]]) -> TaskNode:
+	def applied(matrix: dict[str, tuple[str, ...]] | None) -> dict[str, tuple[str, ...]] | None:
+		if matrix is None:
+			return None
+		return {k: overrides.get(k, v) for k, v in matrix.items()}
+
+	match task:
+		case Task():
+			return task
+		case Sequential(tasks=tasks, name=name, matrix=matrix, env=env, cwd=cwd):
+			return Sequential(
+				*(_override_matrix(t, overrides) for t in tasks),
+				name=name,
+				matrix=applied(matrix),
+				env=env,
+				cwd=cwd,
+			)
+		case Parallel(tasks=tasks, name=name, matrix=matrix, env=env, cwd=cwd):
+			return Parallel(
+				*(_override_matrix(t, overrides) for t in tasks),
+				name=name,
+				matrix=applied(matrix),
+				env=env,
+				cwd=cwd,
+			)
+		case _:
+			assert_never(task)
+
+
 def matrix_bindings(matrix: dict[str, tuple[str, ...]]) -> tuple[MatrixBinding, ...]:
 	"""Generate all cartesian product bindings from a matrix definition.
 

--- a/src/camas/main.py
+++ b/src/camas/main.py
@@ -26,7 +26,7 @@ else:  # pragma: no cover
 	import tomli as tomllib
 	from typing_extensions import assert_never
 
-from camas import Effect, Parallel, Sequential, Task, TaskNode, run
+from camas import Effect, Parallel, Sequential, Task, TaskNode, matrix_axes, override_matrix, run
 from camas.effect.termtree import GREY, RESET, print_tree
 
 BLUE: Final = "\033[34m"
@@ -609,7 +609,51 @@ def build_parser(
 		const="",
 		help="tuple of Effect instances; pass with no value to list available Effects",
 	)
+	parser.add_argument(
+		"--matrix",
+		action="append",
+		default=[],
+		metavar="KEY=VAL[,VAL...]",
+		help="override a matrix axis (repeatable; e.g. --matrix PY=3.13)",
+	)
 	return parser
+
+
+RESERVED_FLAGS: Final = frozenset(
+	{"help", "version", "dry-run", "list", "tree", "effects", "matrix"}
+)
+
+
+def parse_matrix_kv(raw: str) -> tuple[str, tuple[str, ...]]:
+	"""Parse ``KEY=VAL[,VAL...]`` into ``(key, values)``.
+
+	>>> parse_matrix_kv("PY=3.13")
+	('PY', ('3.13',))
+	>>> parse_matrix_kv("PY=3.13,3.14")
+	('PY', ('3.13', '3.14'))
+	"""
+	if "=" not in raw:
+		raise ValueError(f"--matrix expects KEY=VAL[,VAL...], got {raw!r}")
+	key, _, rest = raw.partition("=")
+	if not key:
+		raise ValueError(f"--matrix expects KEY=VAL[,VAL...], got {raw!r}")
+	values = parse_axis_values(rest)
+	if not values:
+		raise ValueError(f"--matrix {key!r}: at least one value required")
+	return key, values
+
+
+def parse_axis_values(raw: str) -> tuple[str, ...]:
+	"""Comma-separated values into a tuple, trimming whitespace and dropping empties.
+
+	>>> parse_axis_values("3.13")
+	('3.13',)
+	>>> parse_axis_values("3.13, 3.14")
+	('3.13', '3.14')
+	>>> parse_axis_values("")
+	()
+	"""
+	return tuple(s for v in raw.split(",") if (s := v.strip()))
 
 
 def _expression_metavar(tasks: Mapping[str, TaskNode] | None) -> str:
@@ -670,12 +714,33 @@ def task_summary(node: TaskNode, names: frozenset[str], is_root: bool = True) ->
 			assert_never(node)
 
 
+def format_axis(name: str, values: tuple[str, ...]) -> str:
+	"""Render a matrix axis for the listing annotation.
+
+	>>> format_axis("PY", ("3.13",))
+	'PY=3.13'
+	>>> format_axis("PY", ("3.10", "3.11", "3.12", "3.13", "3.14", "3.15"))
+	'PY×6 (3.10..3.15)'
+	"""
+	if len(values) == 1:
+		return f"{name}={values[0]}"
+	return f"{name}×{len(values)} ({values[0]}..{values[-1]})"
+
+
 def summary_annotation(node: TaskNode) -> str:
 	"""Annotate a top-level entry with its matrix axes — important context that
-	doesn't appear in the body otherwise."""
+	doesn't appear in the body otherwise.
+
+	>>> summary_annotation(Task("hi"))
+	''
+	>>> summary_annotation(Parallel(Task("t"), matrix={"PY": ("3.12", "3.13")}))
+	'  [matrix: PY×2 (3.12..3.13)]'
+	>>> summary_annotation(Parallel(Task("t"), matrix={"DB": ("sqlite", "postgres"), "OPT": ("debug",)}))
+	'  [matrix: DB×2 (sqlite..postgres) OPT=debug]'
+	"""
 	if isinstance(node, Task) or node.matrix is None:
 		return ""
-	axes = ", ".join(node.matrix)
+	axes = " ".join(format_axis(k, v) for k, v in node.matrix.items())
 	return f"  [matrix: {axes}]"
 
 
@@ -734,12 +799,37 @@ def print_task_trees(tasks: Mapping[str, TaskNode], source: Path | None) -> None
 		print()
 
 
+def format_matrix_axes_help(axes: Mapping[str, tuple[str, ...]], color: bool) -> str:
+	"""Render the ``Matrix axes:`` block for per-task ``--help``.
+
+	>>> "Matrix axes" in format_matrix_axes_help({"PY": ("3.13", "3.14")}, color=False)
+	True
+	>>> "--PY" in format_matrix_axes_help({"PY": ("3.13",)}, color=False)
+	True
+	"""
+	width = max(len(name) for name in axes)
+	lines = [maybe_color("Matrix axes (override with --AXIS VAL[,VAL...]):", BOLD_BLUE, color)]
+	for name, values in axes.items():
+		flag = f"--{name}".ljust(width + 2)
+		current = ", ".join(values)
+		lines.append(
+			f"  {maybe_color(flag, BOLD_CYAN, color)}  {maybe_color(current, GREY, color)}"
+		)
+	return "\n".join(lines)
+
+
 def print_task_help(name: str, task: TaskNode) -> None:
-	"""Print subcommand help for a single task: its expanded tree."""
-	print(f"usage: camas {name} [-h] [--dry-run] [--effects EFFECTS]")
+	"""Print subcommand help for a single task: its expanded tree and any
+	matrix axes the user can override from the CLI."""
+	axes = matrix_axes(task)
+	axis_flags = "".join(f" [--{k} VAL[,VAL...]]" for k in axes)
+	print(f"usage: camas {name} [-h] [--dry-run] [--effects EFFECTS]{axis_flags}")
 	print()
 	print(f"runs the {name!r} task:")
 	print_tree(task, show_cmd=True)
+	if axes:
+		print()
+		print(format_matrix_axes_help(axes, color_on()))
 
 
 def run_cli(scope: Mapping[str, object]) -> None:
@@ -1142,7 +1232,23 @@ def dispatch(
 		sys.exit(0)
 
 	parser: Final = build_parser(tasks, source)
-	args: Final = parser.parse_args(split.head)
+	args, _leftover = parser.parse_known_args(split.head)
+
+	augmented_axes: dict[str, tuple[str, ...]] = {}
+	if isinstance(args.expression, str) and args.expression in tasks:
+		for name, values in matrix_axes(tasks[args.expression]).items():
+			if name.lower() in RESERVED_FLAGS:
+				continue
+			parser.add_argument(
+				f"--{name}",
+				dest=name,
+				action="store",
+				default=None,
+				metavar="VAL[,VAL...]",
+				help=f"override matrix axis {name!r} (current: {', '.join(values)})",
+			)
+			augmented_axes[name] = values
+	args = parser.parse_args(split.head)
 
 	if args.list:
 		print_task_summary_listing(tasks, source)
@@ -1175,7 +1281,30 @@ def dispatch(
 		print(f"error: --effects: {e}", file=sys.stderr)
 		sys.exit(2)
 
-	resolved: Final = dispatch_arg(args.expression, tasks)
+	overrides: dict[str, tuple[str, ...]] = {}
+	for raw in args.matrix:
+		try:
+			k, v = parse_matrix_kv(raw)
+		except ValueError as e:
+			print(f"error: {e}", file=sys.stderr)
+			sys.exit(2)
+		overrides[k] = v
+	for axis_name in augmented_axes:
+		val = getattr(args, axis_name, None)
+		if val is not None:
+			values = parse_axis_values(val)
+			if not values:
+				print(f"error: --{axis_name}: at least one value required", file=sys.stderr)
+				sys.exit(2)
+			overrides[axis_name] = values
+
+	resolved = dispatch_arg(args.expression, tasks)
+	if overrides:
+		try:
+			resolved = override_matrix(resolved, overrides)
+		except ValueError as e:
+			print(f"error: {e}", file=sys.stderr)
+			sys.exit(2)
 	try:
 		task: Final = (
 			apply_passthrough(resolved, split.passthrough) if split.passthrough else resolved

--- a/tests/fixtures/playwright-matrix-override/README.md
+++ b/tests/fixtures/playwright-matrix-override/README.md
@@ -1,0 +1,15 @@
+# playwright-matrix-override
+
+Fixture demonstrating CLI matrix overrides on a 2-axis matrix
+(`BROWSER × VIEWPORT`). The Playwright shape is incidental — what's
+shown is how `--AXIS` flags scope a matrix run from the command line:
+
+```
+camas e2e                                       # all 6: 3 browsers × 2 viewports
+camas e2e --BROWSER chromium                    # 2: chromium × {desktop, mobile}
+camas e2e --VIEWPORT mobile                     # 3: {chromium, firefox, webkit} × mobile
+camas e2e --BROWSER chromium --VIEWPORT mobile  # 1: single combo
+camas e2e --BROWSER chromium,firefox            # 4: two browsers × both viewports
+```
+
+`camas e2e --help` lists the available axes and their current values.

--- a/tests/fixtures/playwright-matrix-override/package.json
+++ b/tests/fixtures/playwright-matrix-override/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "playwright-e2e-fixture",
+  "version": "0.0.0",
+  "private": true,
+  "devDependencies": {
+    "@playwright/test": "^1.50.0"
+  }
+}

--- a/tests/fixtures/playwright-matrix-override/playwright.config.ts
+++ b/tests/fixtures/playwright-matrix-override/playwright.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig, devices } from "@playwright/test";
+
+const browsers = ["chromium", "firefox", "webkit"] as const;
+const viewports = {
+	desktop: devices["Desktop Chrome"],
+	mobile: devices["Pixel 5"],
+} as const;
+
+export default defineConfig({
+	testDir: "./tests",
+	projects: browsers.flatMap((browser) =>
+		(Object.keys(viewports) as Array<keyof typeof viewports>).map((viewport) => ({
+			name: `${browser}-${viewport}`,
+			use: { ...viewports[viewport], browserName: browser },
+		})),
+	),
+});

--- a/tests/fixtures/playwright-matrix-override/tasks.py
+++ b/tests/fixtures/playwright-matrix-override/tasks.py
@@ -1,0 +1,28 @@
+"""camas tasks for the playwright-matrix-override fixture.
+
+A 2-axis matrix (BROWSER x VIEWPORT = 6 combinations) is the natural shape
+of cross-browser end-to-end testing. The matrix override CLI lets you scope
+a run to a slice without editing tasks.py.
+"""
+
+from camas import Parallel, Sequential, Task
+
+install = Task("npx playwright install --with-deps")
+
+e2e = Parallel(
+	Task("npx playwright test --project={BROWSER}-{VIEWPORT}"),
+	matrix={
+		"BROWSER": ("chromium", "firefox", "webkit"),
+		"VIEWPORT": ("desktop", "mobile"),
+	},
+)
+
+smoke = Parallel(
+	Task("npx playwright test --grep @smoke --project={BROWSER}-{VIEWPORT}"),
+	matrix={
+		"BROWSER": ("chromium", "firefox", "webkit"),
+		"VIEWPORT": ("desktop", "mobile"),
+	},
+)
+
+ci = Sequential(install, e2e)

--- a/tests/fixtures/playwright-matrix-override/tests/example.spec.ts
+++ b/tests/fixtures/playwright-matrix-override/tests/example.spec.ts
@@ -1,0 +1,6 @@
+import { test, expect } from "@playwright/test";
+
+test("homepage has title @smoke", async ({ page }) => {
+	await page.goto("https://example.com/");
+	await expect(page).toHaveTitle(/Example/);
+});

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -16,6 +16,7 @@ from camas.main import (
 	apply_passthrough,
 	build_parser,
 	discover_effects,
+	dispatch,
 	first_line_doc,
 	format_annotation,
 	format_available_effects,
@@ -201,6 +202,65 @@ def test_dry_run_matrix(capsys: pytest.CaptureFixture[str]) -> None:
 	captured = capsys.readouterr()
 	assert "3.12" in captured.out
 	assert "3.13" in captured.out
+
+
+def test_print_task_help_with_axes(capsys: pytest.CaptureFixture[str]) -> None:
+	task = Parallel(Task("echo {PY}"), matrix={"PY": ("3.12", "3.13")})
+	with pytest.raises(SystemExit, match="0"):
+		dispatch({"check": task}, ["check", "--help"])
+	out = capsys.readouterr().out
+	assert "Matrix axes" in out
+	assert "--PY" in out
+
+
+def test_dispatch_per_axis_flag_overrides(capsys: pytest.CaptureFixture[str]) -> None:
+	task = Parallel(Task("echo {PY}"), matrix={"PY": ("3.12", "3.13")})
+	with pytest.raises(SystemExit, match="0"):
+		dispatch({"check": task}, ["--dry-run", "check", "--PY", "3.13"])
+	out = capsys.readouterr().out
+	assert "[PY=3.13]" in out
+	assert "[PY=3.12]" not in out
+
+
+def test_dispatch_matrix_flag_overrides(capsys: pytest.CaptureFixture[str]) -> None:
+	task = Parallel(Task("echo {PY}"), matrix={"PY": ("3.12", "3.13")})
+	with pytest.raises(SystemExit, match="0"):
+		dispatch({"check": task}, ["--dry-run", "check", "--matrix", "PY=3.13"])
+	out = capsys.readouterr().out
+	assert "[PY=3.13]" in out
+	assert "[PY=3.12]" not in out
+
+
+def test_dispatch_matrix_flag_bad_syntax_errors(capsys: pytest.CaptureFixture[str]) -> None:
+	task = Parallel(Task("echo {PY}"), matrix={"PY": ("3.12",)})
+	with pytest.raises(SystemExit, match="2"):
+		dispatch({"check": task}, ["check", "--matrix", "noequals"])
+	assert "--matrix expects KEY=VAL" in capsys.readouterr().err
+
+
+def test_dispatch_per_axis_flag_empty_value_errors(capsys: pytest.CaptureFixture[str]) -> None:
+	task = Parallel(Task("echo {PY}"), matrix={"PY": ("3.12",)})
+	with pytest.raises(SystemExit, match="2"):
+		dispatch({"check": task}, ["check", "--PY", ""])
+	assert "--PY" in capsys.readouterr().err
+
+
+def test_dispatch_matrix_unknown_axis_errors(capsys: pytest.CaptureFixture[str]) -> None:
+	task = Parallel(Task("echo {PY}"), matrix={"PY": ("3.12",)})
+	with pytest.raises(SystemExit, match="2"):
+		dispatch({"check": task}, ["check", "--matrix", "XX=1"])
+	assert "unknown matrix axis" in capsys.readouterr().err
+
+
+def test_dispatch_skips_reserved_axis_name_for_auto_flag(
+	capsys: pytest.CaptureFixture[str],
+) -> None:
+	task = Parallel(Task("echo {matrix}"), matrix={"matrix": ("a", "b")})
+	with pytest.raises(SystemExit, match="0"):
+		dispatch({"check": task}, ["--dry-run", "check", "--matrix", "matrix=b"])
+	out = capsys.readouterr().out
+	assert "[matrix=b]" in out
+	assert "[matrix=a]" not in out
 
 
 def test_successful_execution() -> None:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -330,7 +330,29 @@ def test_print_listing_matrix_annotation(capsys: pytest.CaptureFixture[str]) -> 
 	matrix = Sequential(Task("uv sync"), name="matrix", matrix={"PY": ("3.12", "3.13")})
 	print_task_summary_listing({"matrix": matrix}, None)
 	out = capsys.readouterr().out
-	assert "[matrix: PY]" in out
+	assert "[matrix: PY×2 (3.12..3.13)]" in out
+
+
+def test_print_listing_matrix_single_value_annotation(
+	capsys: pytest.CaptureFixture[str],
+) -> None:
+	matrix = Sequential(Task("uv sync"), name="matrix", matrix={"PY": ("3.13",)})
+	print_task_summary_listing({"matrix": matrix}, None)
+	out = capsys.readouterr().out
+	assert "[matrix: PY=3.13]" in out
+
+
+def test_print_listing_matrix_multi_axis_annotation(
+	capsys: pytest.CaptureFixture[str],
+) -> None:
+	t = Sequential(
+		Task("x"),
+		name="ci",
+		matrix={"DB": ("sqlite", "postgres"), "OPT": ("debug",)},
+	)
+	print_task_summary_listing({"ci": t}, None)
+	out = capsys.readouterr().out
+	assert "[matrix: DB×2 (sqlite..postgres) OPT=debug]" in out
 
 
 def test_format_task_summary_listing_no_tasks_with_source(tmp_path: Path) -> None:

--- a/tests/test_override_matrix.py
+++ b/tests/test_override_matrix.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import pytest
 
 from camas import Parallel, Sequential, Task, matrix_axes, override_matrix
+from camas.main import parse_matrix_kv
 
 
 def test_matrix_axes_empty_for_task() -> None:
@@ -78,3 +79,28 @@ def test_override_matrix_permissive_on_values() -> None:
 	result = override_matrix(t, {"PY": ("3.99",)})
 	assert isinstance(result, Parallel)
 	assert result.matrix == {"PY": ("3.99",)}
+
+
+def test_override_matrix_walks_through_node_without_matrix() -> None:
+	inner = Parallel(Task("x"), matrix={"PY": ("3.12", "3.13")})
+	tree = Sequential(inner)
+	result = override_matrix(tree, {"PY": ("3.99",)})
+	assert isinstance(result, Sequential)
+	assert result.matrix is None
+	assert isinstance(result.tasks[0], Parallel)
+	assert result.tasks[0].matrix == {"PY": ("3.99",)}
+
+
+def test_parse_matrix_kv_missing_equals() -> None:
+	with pytest.raises(ValueError, match="--matrix expects KEY=VAL"):
+		parse_matrix_kv("PY")
+
+
+def test_parse_matrix_kv_empty_key() -> None:
+	with pytest.raises(ValueError, match="--matrix expects KEY=VAL"):
+		parse_matrix_kv("=3.13")
+
+
+def test_parse_matrix_kv_empty_values() -> None:
+	with pytest.raises(ValueError, match="at least one value required"):
+		parse_matrix_kv("PY=")

--- a/tests/test_override_matrix.py
+++ b/tests/test_override_matrix.py
@@ -1,0 +1,80 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2026 JP Hutchins
+
+from __future__ import annotations
+
+import pytest
+
+from camas import Parallel, Sequential, Task, matrix_axes, override_matrix
+
+
+def test_matrix_axes_empty_for_task() -> None:
+	assert matrix_axes(Task("hi")) == {}
+
+
+def test_matrix_axes_single_axis() -> None:
+	t = Parallel(Task("x"), matrix={"PY": ("3.12", "3.13")})
+	assert matrix_axes(t) == {"PY": ("3.12", "3.13")}
+
+
+def test_matrix_axes_collects_from_nested_tree() -> None:
+	t = Sequential(
+		Parallel(Task("a"), matrix={"OS": ("linux", "macos")}),
+		Task("b"),
+		matrix={"PY": ("3.12",)},
+	)
+	axes = matrix_axes(t)
+	assert axes == {"PY": ("3.12",), "OS": ("linux", "macos")}
+
+
+def test_matrix_axes_outermost_wins_on_duplicate_key() -> None:
+	t = Sequential(
+		Parallel(Task("a"), matrix={"PY": ("3.12",)}),
+		matrix={"PY": ("3.13", "3.14")},
+	)
+	assert matrix_axes(t) == {"PY": ("3.13", "3.14")}
+
+
+def test_override_matrix_replaces_top_level() -> None:
+	t = Parallel(Task("x"), matrix={"PY": ("3.12", "3.13", "3.14")})
+	result = override_matrix(t, {"PY": ("3.13",)})
+	assert isinstance(result, Parallel)
+	assert result.matrix == {"PY": ("3.13",)}
+
+
+def test_override_matrix_replaces_at_every_node() -> None:
+	t = Sequential(
+		Parallel(Task("a"), matrix={"PY": ("3.12", "3.13")}),
+		matrix={"PY": ("3.12", "3.13", "3.14")},
+	)
+	result = override_matrix(t, {"PY": ("3.13",)})
+	assert isinstance(result, Sequential)
+	assert result.matrix == {"PY": ("3.13",)}
+	inner = result.tasks[0]
+	assert isinstance(inner, Parallel)
+	assert inner.matrix == {"PY": ("3.13",)}
+
+
+def test_override_matrix_leaves_unrelated_axes_alone() -> None:
+	t = Parallel(Task("x"), matrix={"PY": ("3.12",), "DB": ("sqlite",)})
+	result = override_matrix(t, {"PY": ("3.13",)})
+	assert isinstance(result, Parallel)
+	assert result.matrix == {"PY": ("3.13",), "DB": ("sqlite",)}
+
+
+def test_override_matrix_unknown_axis_raises() -> None:
+	t = Parallel(Task("x"), matrix={"PY": ("3.12",)})
+	with pytest.raises(ValueError, match="unknown matrix axis 'XX'"):
+		override_matrix(t, {"XX": ("1",)})
+
+
+def test_override_matrix_no_overrides_returns_input() -> None:
+	t = Parallel(Task("x"), matrix={"PY": ("3.12",)})
+	assert override_matrix(t, {}) is t
+
+
+def test_override_matrix_permissive_on_values() -> None:
+	t = Parallel(Task("x"), matrix={"PY": ("3.12", "3.13")})
+	result = override_matrix(t, {"PY": ("3.99",)})
+	assert isinstance(result, Parallel)
+	assert result.matrix == {"PY": ("3.99",)}

--- a/tests/test_playwright_matrix_override_fixture.py
+++ b/tests/test_playwright_matrix_override_fixture.py
@@ -1,0 +1,87 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2026 JP Hutchins
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Final
+
+FIXTURE: Final = Path(__file__).parent / "fixtures" / "playwright-matrix-override"
+
+
+def _camas(*args: str) -> subprocess.CompletedProcess[str]:
+	return subprocess.run(
+		[sys.executable, "-m", "camas", *args],
+		cwd=FIXTURE,
+		capture_output=True,
+		text=True,
+		encoding="utf-8",
+		env={**os.environ, "NO_COLOR": "1"},
+	)
+
+
+def _count_combos(stdout: str) -> int:
+	return sum("[BROWSER=" in line for line in stdout.splitlines())
+
+
+def test_list_shows_two_axis_matrix_annotation() -> None:
+	r = _camas("--list")
+	assert r.returncode == 0, r.stderr
+	assert "[matrix: BROWSER×3 (chromium..webkit) VIEWPORT×2 (desktop..mobile)]" in r.stdout, (
+		r.stdout
+	)
+
+
+def test_e2e_default_expands_to_six_combos() -> None:
+	r = _camas("--dry-run", "e2e")
+	assert r.returncode == 0, r.stderr
+	assert _count_combos(r.stdout) == 6, r.stdout
+
+
+def test_pin_browser_collapses_to_two() -> None:
+	r = _camas("--dry-run", "e2e", "--BROWSER", "chromium")
+	assert r.returncode == 0, r.stderr
+	assert _count_combos(r.stdout) == 2, r.stdout
+	assert "[BROWSER=chromium, VIEWPORT=desktop]" in r.stdout
+	assert "[BROWSER=chromium, VIEWPORT=mobile]" in r.stdout
+	assert "BROWSER=firefox" not in r.stdout
+	assert "BROWSER=webkit" not in r.stdout
+
+
+def test_pin_viewport_collapses_to_three() -> None:
+	r = _camas("--dry-run", "e2e", "--VIEWPORT", "mobile")
+	assert r.returncode == 0, r.stderr
+	assert _count_combos(r.stdout) == 3, r.stdout
+	assert "VIEWPORT=desktop" not in r.stdout
+
+
+def test_pin_both_axes_collapses_to_one() -> None:
+	r = _camas("--dry-run", "e2e", "--BROWSER", "chromium", "--VIEWPORT", "mobile")
+	assert r.returncode == 0, r.stderr
+	assert _count_combos(r.stdout) == 1, r.stdout
+	assert "[BROWSER=chromium, VIEWPORT=mobile]" in r.stdout
+
+
+def test_comma_browser_expands_to_four() -> None:
+	r = _camas("--dry-run", "e2e", "--BROWSER", "chromium,firefox")
+	assert r.returncode == 0, r.stderr
+	assert _count_combos(r.stdout) == 4, r.stdout
+	assert "BROWSER=webkit" not in r.stdout
+
+
+def test_per_task_help_lists_both_axes() -> None:
+	r = _camas("e2e", "--help")
+	assert r.returncode == 0, r.stderr
+	assert "--BROWSER VAL[,VAL...]" in r.stdout, r.stdout
+	assert "--VIEWPORT VAL[,VAL...]" in r.stdout, r.stdout
+	assert "chromium, firefox, webkit" in r.stdout
+	assert "desktop, mobile" in r.stdout
+
+
+def test_unknown_axis_errors() -> None:
+	r = _camas("e2e", "--matrix", "OS=linux")
+	assert r.returncode == 2
+	assert "unknown matrix axis 'OS'" in r.stderr, r.stderr

--- a/tests/test_python_version_matrix_fixture.py
+++ b/tests/test_python_version_matrix_fixture.py
@@ -35,7 +35,43 @@ def test_list_shows_check_with_matrix_annotation() -> None:
 	r = _camas("--list")
 	assert r.returncode == 0, r.stderr
 	assert "check" in r.stdout, r.stdout
-	assert "[matrix: PY]" in r.stdout, r.stdout
+	assert "[matrix: PY×6 (3.10..3.15)]" in r.stdout, r.stdout
+
+
+def test_per_axis_flag_overrides_matrix() -> None:
+	r = _camas("--dry-run", "check", "--PY", "3.13")
+	assert r.returncode == 0, r.stderr
+	assert "[PY=3.13]" in r.stdout, r.stdout
+	for v in ("3.10", "3.11", "3.12", "3.14", "3.15"):
+		assert f"[PY={v}]" not in r.stdout, r.stdout
+
+
+def test_per_axis_flag_accepts_comma_separated_values() -> None:
+	r = _camas("--dry-run", "check", "--PY", "3.13,3.14")
+	assert r.returncode == 0, r.stderr
+	assert "[PY=3.13]" in r.stdout
+	assert "[PY=3.14]" in r.stdout
+	assert "[PY=3.12]" not in r.stdout
+
+
+def test_generic_matrix_flag_overrides_axis() -> None:
+	r = _camas("--dry-run", "check", "--matrix", "PY=3.13")
+	assert r.returncode == 0, r.stderr
+	assert "[PY=3.13]" in r.stdout
+	assert "[PY=3.14]" not in r.stdout
+
+
+def test_unknown_axis_errors() -> None:
+	r = _camas("check", "--matrix", "XX=1")
+	assert r.returncode == 2
+	assert "unknown matrix axis 'XX'" in r.stderr, r.stderr
+
+
+def test_per_task_help_lists_axes() -> None:
+	r = _camas("check", "--help")
+	assert r.returncode == 0, r.stderr
+	assert "--PY VAL[,VAL...]" in r.stdout, r.stdout
+	assert "Matrix axes" in r.stdout, r.stdout
 
 
 def test_check_dry_run_expands_one_clone_per_python_version() -> None:


### PR DESCRIPTION
Adds --matrix KEY=VAL[,VAL...] (always available) and dynamic per-axis flags --AXIS VAL[,VAL...] (added to the parser per task after the first parse pass). Override values are comma-separated.

- matrix_axes(task) and override_matrix(task, overrides) in camas/__init__.py walk and rewrite the tree purely; strict on keys (axis must exist), permissive on values (any tuple accepted).
- summary_annotation upgraded from `[matrix: PY]` to `[matrix: PY×6 (3.10..3.15)]` (or `PY=3.13` for single value); multi-axis joined with spaces.
- Per-task `camas <task> --help` lists axes with current values and the --AXIS syntax.
- Two-stage dispatch: first parse_known_args resolves the task name; if it's a known task, per-axis flags are added and parser is re-run.
- New playwright-e2e fixture (BROWSER × VIEWPORT = 6) demonstrates the override on a 2-axis matrix.