### PR TITLE
feat: Status effect for CI-friendly streaming output

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,7 +22,7 @@ jobs:
       - uses: astral-sh/setup-uv@v6
 
       - if: runner.os != 'Windows'
-        run: uv run camas matrix --effects='(Summary(SummaryOptions(Fixed(90))),)'
+        run: uv run camas matrix
 
       # zuban non-deterministically fails to find test deps under UV_PROJECT_ENVIRONMENT on
       # Windows in CI (cannot reproduce locally); inline the matrix without zuban there.
@@ -33,7 +33,7 @@ jobs:
             {format_check, lint, mypy, pyright, ty, pyrefly, test},
             env={"UV_PROJECT_ENVIRONMENT": ".venv-{PY}", "UV_PYTHON": "{PY}"},
             matrix={"PY": ("3.10", "3.11", "3.12", "3.13", "3.14", "3.15")},
-          )' --effects='(Summary(SummaryOptions(Fixed(90))),)'
+          )'
 
   check:
     strategy:
@@ -47,7 +47,7 @@ jobs:
 
       - uses: astral-sh/setup-uv@v6
 
-      - run: uv run camas check --effects='(Summary(SummaryOptions(Fixed(90))),)'
+      - run: uv run camas check
         env:
           UV_PYTHON: ${{ matrix.python }}
 
@@ -60,9 +60,10 @@ jobs:
 
       - uses: astral-sh/setup-uv@v6
 
-      - run: uv run camas coverage --effects='(Summary(SummaryOptions(Fixed(90), show_passing=True)),)'
+      - run: uv run camas coverage --effects='(Status(StatusOptions(output_mode="all")),)'
 
       - uses: codecov/codecov-action@v5
+        if: always()
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.xml
@@ -81,13 +82,29 @@ jobs:
 
       - run: |
           uv run --extra github_checks camas matrix --effects='(
-            Summary(SummaryOptions(Fixed(90))),
+            Status(),
             GitHubChecks(GitHubChecksOptions(
               sha="${{ github.event.pull_request.head.sha || github.sha }}",
             )),
           )'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  status-modes-demo:
+    # Showcases each Status output_mode so reviewers can click through and compare;
+    # the auto-detected default (Status output_mode='github') is exercised by every
+    # other job, so only the non-default modes are matrixed here.
+    strategy:
+      matrix:
+        mode: [quiet, all, errors, stream]
+      fail-fast: false
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: astral-sh/setup-uv@v6
+
+      - run: uv run camas check --effects='(Status(StatusOptions(output_mode="${{ matrix.mode }}")),)'
 
   nix:
     strategy:
@@ -135,10 +152,10 @@ jobs:
       - run: npm ci
 
       # First run: verify pipeline + warm caches (cargo, uv, node_modules).
-      - run: camas all --effects='(Summary(SummaryOptions(Fixed(90))),)'
+      - run: camas all
 
       # Too slow to be a useful example, but you get the idea
-      # - run: camas build --effects='(Summary(SummaryOptions(Fixed(90))),)'
+      # - run: camas build
 
       - run: shellcheck .github/scripts/*.sh
         working-directory: .

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -82,7 +82,7 @@ jobs:
 
       - run: |
           uv run --extra github_checks camas matrix --effects='(
-            Status(),
+            Status(StatusOptions(output_mode="github")),
             GitHubChecks(GitHubChecksOptions(
               sha="${{ github.event.pull_request.head.sha || github.sha }}",
             )),

--- a/README.md
+++ b/README.md
@@ -106,17 +106,7 @@ On other CI providers (or to opt into a specific mode), spell it out:
 - run: uv run camas check --effects='(Status(StatusOptions(output_mode="errors")),)'
 ```
 
-`Status` modes — pick one for the `output_mode` arg:
-
-| Mode | What it dumps per task | When to use |
-|---|---|---|
-| `quiet` | status line only (no captured output) | trust the exit code; minimum log noise |
-| `errors` *(default)* | status line, plus the full block on failure | most CI providers |
-| `all` | status line + every block | informational runs (coverage, smoke) |
-| `stream` | every line as it arrives, prefixed with `[task]` | watching long-running jobs in real time |
-| `github` *(auto on GHA)* | like `all`, wrapped in `::group::`/`::endgroup::` so blocks render collapsed | GitHub Actions |
-
-Each `Status` line carries `[YYYY-MM-DD HH:MM:SS.mmm]` and the task name in brackets, so logs are grep-able and aligned. The [`status-modes-demo` job](https://github.com/JPHutchins/camas/blob/main/.github/workflows/ci.yaml) renders one CI run per mode for visual comparison.
+See the [`OutputMode`](https://github.com/JPHutchins/camas/blob/main/src/camas/effect/status.py) literal and `block_for` doctests for the per-mode behavior. The [`status-modes-demo` job](https://github.com/JPHutchins/camas/blob/main/.github/workflows/ci.yaml) renders one CI run per mode for visual comparison.
 
 For per-leaf visibility in the PR Checks panel, add the `GitHubChecks` effect alongside `Status` (opt-in extra: `camas[github_checks]`). Each leaf task becomes its own check run, so reviewers see `lint` / `mypy` / `pytest` pass-or-fail individually instead of one monolithic log.
 

--- a/README.md
+++ b/README.md
@@ -92,18 +92,38 @@ camas is **not a build system**. camas is for the specific job of running struct
 
 ## CI integration
 
-The renderer is swappable, not the tree. Run the same `tasks.py` locally with the live `Termtree` and in CI with the post-run `Summary` — one flag changes the output, the pipeline definition is unchanged.
+The renderer is swappable, not the tree. Run the same `tasks.py` locally with the live `Termtree` and in CI with `Status` — one flag changes the output, the pipeline definition is unchanged.
+
+**On GitHub Actions, no flag is needed.** Camas detects `GITHUB_ACTIONS=true` and defaults `--effects` to `(Status(StatusOptions(output_mode="github")),)` — collapsed workflow groups, ISO timestamps with millisecond precision, ANSI colors preserved.
 
 ```yaml
-- run: uv run camas check --effects='(Summary(SummaryOptions(Fixed(90))),)'
+- run: uv run camas check
 ```
 
-For per-leaf visibility in the PR Checks panel, add the `GitHubChecks` effect (opt-in extra: `camas[github_checks]`). Each leaf task becomes its own check run, so reviewers see `lint` / `mypy` / `pytest` pass-or-fail individually instead of one monolithic log.
+On other CI providers (or to opt into a specific mode), spell it out:
+
+```yaml
+- run: uv run camas check --effects='(Status(StatusOptions(output_mode="errors")),)'
+```
+
+`Status` modes — pick one for the `output_mode` arg:
+
+| Mode | What it dumps per task | When to use |
+|---|---|---|
+| `quiet` | status line only (no captured output) | trust the exit code; minimum log noise |
+| `errors` *(default)* | status line, plus the full block on failure | most CI providers |
+| `all` | status line + every block | informational runs (coverage, smoke) |
+| `stream` | every line as it arrives, prefixed with `[task]` | watching long-running jobs in real time |
+| `github` *(auto on GHA)* | like `all`, wrapped in `::group::`/`::endgroup::` so blocks render collapsed | GitHub Actions |
+
+Each `Status` line carries `[YYYY-MM-DD HH:MM:SS.mmm]` and the task name in brackets, so logs are grep-able and aligned. The [`status-modes-demo` job](https://github.com/JPHutchins/camas/blob/main/.github/workflows/ci.yaml) renders one CI run per mode for visual comparison.
+
+For per-leaf visibility in the PR Checks panel, add the `GitHubChecks` effect alongside `Status` (opt-in extra: `camas[github_checks]`). Each leaf task becomes its own check run, so reviewers see `lint` / `mypy` / `pytest` pass-or-fail individually instead of one monolithic log.
 
 ```yaml
 - run: |
     uv run --extra github_checks camas matrix --effects='(
-      Summary(SummaryOptions(Fixed(90))),
+      Status(StatusOptions(output_mode="github")),
       GitHubChecks(GitHubChecksOptions(
         sha="${{ github.event.pull_request.head.sha || github.sha }}",
       )),

--- a/src/camas/core/execution.py
+++ b/src/camas/core/execution.py
@@ -8,6 +8,7 @@ import os
 import sys
 import time
 from collections.abc import Iterable, Sequence
+from datetime import datetime
 from subprocess import STDOUT
 from typing import Any, Final
 
@@ -29,34 +30,37 @@ from .task_event import CompletedEvent, OutputEvent, StartedEvent, TaskEvent
 from .traversal import flatten_leaves, subtree_leaf_indices
 
 
-def color_env(merged: dict[str, str]) -> dict[str, str]:
-	"""Inject FORCE_COLOR/CLICOLOR_FORCE unless NO_COLOR is set (which also strips them)."""
-	if "NO_COLOR" in merged:
-		return {k: v for k, v in merged.items() if k not in {"FORCE_COLOR", "CLICOLOR_FORCE"}}
-	return merged | {"FORCE_COLOR": "1", "CLICOLOR_FORCE": "1"}
+def subprocess_env(merged: dict[str, str]) -> dict[str, str]:
+	"""Inject env for leaf subprocesses: PYTHONUNBUFFERED so Python tools stream
+	stdout line-by-line into the pipe, plus FORCE_COLOR/CLICOLOR_FORCE unless
+	NO_COLOR is set (which also strips them)."""
+	base = merged | {"PYTHONUNBUFFERED": "1"}
+	if "NO_COLOR" in base:
+		return {k: v for k, v in base.items() if k not in {"FORCE_COLOR", "CLICOLOR_FORCE"}}
+	return base | {"FORCE_COLOR": "1", "CLICOLOR_FORCE": "1"}
 
 
 async def run_cmd(task: Task, leaf_index: int, dispatch: EventSink) -> TaskResult:
 	"""Run one leaf as a subprocess, dispatching Started/Output/Completed events."""
-	start: Final = time.perf_counter()
-	await dispatch(leaf_index, StartedEvent(task, leaf_index, start))
+	start_pc: Final = time.perf_counter()
+	await dispatch(leaf_index, StartedEvent(task, leaf_index, datetime.now()))
 	proc: Final = await asyncio.create_subprocess_exec(
 		*resolve_cmd(task.cmd),
 		stdout=asyncio.subprocess.PIPE,
 		stderr=STDOUT,
-		env=color_env({**os.environ, **task.env}),
+		env=subprocess_env({**os.environ, **task.env}),
 		cwd=task.cwd,
 	)
 	output: Final[list[bytes]] = []
 	if proc.stdout is not None:  # pragma: no branch
 		async for line in proc.stdout:
 			output.append(line)
-			await dispatch(leaf_index, OutputEvent(task, leaf_index, line, time.perf_counter()))
+			await dispatch(leaf_index, OutputEvent(task, leaf_index, line, datetime.now()))
 	await proc.wait()
-	elapsed: Final = time.perf_counter() - start
+	elapsed: Final = time.perf_counter() - start_pc
 	rc: Final = proc.returncode or 0
 	completion: Final = Finished(rc, elapsed, output)
-	await dispatch(leaf_index, CompletedEvent(task, leaf_index, completion))
+	await dispatch(leaf_index, CompletedEvent(task, leaf_index, completion, datetime.now()))
 	return TaskResult(task_label(task), completion)
 
 
@@ -70,7 +74,7 @@ async def skip_subtree(
 	"""Dispatch a Skipped completion for every leaf in a subtree, in DFS order."""
 	results: tuple[TaskResult, ...] = ()
 	for idx in subtree_leaf_indices(child, index_map):
-		await dispatch(idx, CompletedEvent(leaves[idx], idx, skip))
+		await dispatch(idx, CompletedEvent(leaves[idx], idx, skip, datetime.now()))
 		results = (*results, TaskResult(task_label(leaves[idx]), skip))
 	return results
 

--- a/src/camas/core/execution.py
+++ b/src/camas/core/execution.py
@@ -31,14 +31,7 @@ from .traversal import flatten_leaves, subtree_leaf_indices
 
 
 def subprocess_env(merged: dict[str, str]) -> dict[str, str]:
-	"""Inject env for leaf subprocesses: ``PYTHONUNBUFFERED=1`` so Python tools
-	stream stdout line-by-line into the pipe, plus ``FORCE_COLOR``/``CLICOLOR_FORCE``
-	unless ``NO_COLOR`` is set (which also strips them).
-
-	``merged`` (parent env + ``Task.env``) takes precedence over the injected
-	defaults — so a user who explicitly sets ``PYTHONUNBUFFERED=0`` via
-	``Task.env`` (or in the parent shell) keeps buffered output.
-	"""
+	"""Leaf-subprocess env: defaults merged underneath ``merged``; ``NO_COLOR`` strips color forces."""
 	base = {"PYTHONUNBUFFERED": "1"} | merged
 	if "NO_COLOR" in base:
 		return {k: v for k, v in base.items() if k not in {"FORCE_COLOR", "CLICOLOR_FORCE"}}

--- a/src/camas/core/execution.py
+++ b/src/camas/core/execution.py
@@ -31,13 +31,18 @@ from .traversal import flatten_leaves, subtree_leaf_indices
 
 
 def subprocess_env(merged: dict[str, str]) -> dict[str, str]:
-	"""Inject env for leaf subprocesses: PYTHONUNBUFFERED so Python tools stream
-	stdout line-by-line into the pipe, plus FORCE_COLOR/CLICOLOR_FORCE unless
-	NO_COLOR is set (which also strips them)."""
-	base = merged | {"PYTHONUNBUFFERED": "1"}
+	"""Inject env for leaf subprocesses: ``PYTHONUNBUFFERED=1`` so Python tools
+	stream stdout line-by-line into the pipe, plus ``FORCE_COLOR``/``CLICOLOR_FORCE``
+	unless ``NO_COLOR`` is set (which also strips them).
+
+	``merged`` (parent env + ``Task.env``) takes precedence over the injected
+	defaults — so a user who explicitly sets ``PYTHONUNBUFFERED=0`` via
+	``Task.env`` (or in the parent shell) keeps buffered output.
+	"""
+	base = {"PYTHONUNBUFFERED": "1"} | merged
 	if "NO_COLOR" in base:
 		return {k: v for k, v in base.items() if k not in {"FORCE_COLOR", "CLICOLOR_FORCE"}}
-	return base | {"FORCE_COLOR": "1", "CLICOLOR_FORCE": "1"}
+	return {"FORCE_COLOR": "1", "CLICOLOR_FORCE": "1"} | base
 
 
 async def run_cmd(task: Task, leaf_index: int, dispatch: EventSink) -> TaskResult:

--- a/src/camas/core/leaf_state.py
+++ b/src/camas/core/leaf_state.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import sys
+from datetime import datetime
 from typing import NamedTuple, TypeAlias
 
 if sys.version_info >= (3, 11):
@@ -54,12 +55,12 @@ class Waiting(NamedTuple):
 class Running(NamedTuple):
 	"""Leaf state: task is currently executing.
 
-	>>> Running(Task("echo hi"), 100.0, b"output")
-	Running(task=Task(cmd='echo hi', name=None, env={}, cwd=None), start_time=100.0, last_line=b'output')
+	>>> Running(Task("echo hi"), datetime(2026, 1, 1, 12, 0, 0), b"output")
+	Running(task=Task(cmd='echo hi', name=None, env={}, cwd=None), start_time=datetime.datetime(2026, 1, 1, 12, 0), last_line=b'output')
 	"""
 
 	task: Task
-	start_time: float
+	start_time: datetime
 	last_line: bytes
 
 
@@ -88,13 +89,15 @@ def next_state(state: LeafState, event: TaskEvent) -> LeafState:
 
 	>>> from camas.core.completion import Finished, Skipped
 	>>> t = Task("echo hi")
-	>>> next_state(Waiting(t), StartedEvent(t, 0, 100.0))
-	Running(task=Task(cmd='echo hi', name=None, env={}, cwd=None), start_time=100.0, last_line=b'')
-	>>> next_state(Running(t, 100.0, b""), OutputEvent(t, 0, b"hi", 100.5))
-	Running(task=Task(cmd='echo hi', name=None, env={}, cwd=None), start_time=100.0, last_line=b'hi')
-	>>> next_state(Running(t, 100.0, b""), CompletedEvent(t, 0, Finished(0, 0.5, (b"done",))))
+	>>> t0 = datetime(2026, 1, 1, 12, 0, 0)
+	>>> t1 = datetime(2026, 1, 1, 12, 0, 1)
+	>>> next_state(Waiting(t), StartedEvent(t, 0, t0))
+	Running(task=Task(cmd='echo hi', name=None, env={}, cwd=None), start_time=datetime.datetime(2026, 1, 1, 12, 0), last_line=b'')
+	>>> next_state(Running(t, t0, b""), OutputEvent(t, 0, b"hi", t1))
+	Running(task=Task(cmd='echo hi', name=None, env={}, cwd=None), start_time=datetime.datetime(2026, 1, 1, 12, 0), last_line=b'hi')
+	>>> next_state(Running(t, t0, b""), CompletedEvent(t, 0, Finished(0, 0.5, (b"done",)), t1))
 	Completed(task=Task(cmd='echo hi', name=None, env={}, cwd=None), completion=Finished(returncode=0, elapsed=0.5, output=(b'done',)))
-	>>> next_state(Waiting(t), CompletedEvent(t, 0, Skipped(1)))
+	>>> next_state(Waiting(t), CompletedEvent(t, 0, Skipped(1), t0))
 	Completed(task=Task(cmd='echo hi', name=None, env={}, cwd=None), completion=Skipped(returncode=1))
 	"""
 	match state:

--- a/src/camas/core/render.py
+++ b/src/camas/core/render.py
@@ -22,6 +22,11 @@ from .task import Parallel, Sequential, Task, TaskNode, task_label
 BOLD: Final = "\033[1m"
 CYAN: Final = "\033[36m"
 GREY: Final = "\033[90m"
+GREEN: Final = "\033[32m"
+RED: Final = "\033[31m"
+BLUE: Final = "\033[34m"
+YELLOW: Final = "\033[33m"
+VIOLET: Final = "\033[95m"
 RESET: Final = "\033[0m"
 
 ANSI_ESCAPE: Final = re.compile(
@@ -29,6 +34,7 @@ ANSI_ESCAPE: Final = re.compile(
 	r"\[[0-?]*[ -/]*[@-~]"  # CSI sequences (colors, cursor movement, etc.)
 	r"|\][^\x07]*\x07"  # OSC terminated by BEL (hyperlinks, window title)
 	r"|\][^\x1b]*\x1b\\"  # OSC terminated by ST
+	r"|[()*+][\x20-\x7e]"  # ISO-2022 character-set designation (e.g. ESC(B = G0 ASCII)
 	r"|[@-Z\\-_]"  # two-character Fe sequences (after OSC: ] is in range)
 	r")"
 	r"|[\x00-\x08\x0b-\x1f\x7f]"  # ASCII control chars except \t (\x09) and \n (\x0a)
@@ -52,6 +58,8 @@ def strip_ansi(text: str) -> str:
 	'line one\\nline two\\tcol'
 	>>> strip_ansi("\\r\x1b[2Kprogress")
 	'progress'
+	>>> strip_ansi("\x1b[1mbold\x1b(B\x1b[m done")
+	'bold done'
 	"""
 	return ANSI_ESCAPE.sub("", text)
 

--- a/src/camas/core/task_event.py
+++ b/src/camas/core/task_event.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+from datetime import datetime
 from typing import NamedTuple, TypeAlias
 
 from .completion import Completion
@@ -12,41 +13,42 @@ from .task import Task
 class StartedEvent(NamedTuple):
 	"""Internal event: a task has started execution.
 
-	>>> StartedEvent(Task("hi"), 0, 100.0)
-	StartedEvent(task=Task(cmd='hi', name=None, env={}, cwd=None), leaf_index=0, timestamp=100.0)
+	>>> StartedEvent(Task("hi"), 0, datetime(2026, 1, 1, 12, 0, 0))
+	StartedEvent(task=Task(cmd='hi', name=None, env={}, cwd=None), leaf_index=0, timestamp=datetime.datetime(2026, 1, 1, 12, 0))
 	"""
 
 	task: Task
 	leaf_index: int
-	timestamp: float
+	timestamp: datetime
 
 
 class OutputEvent(NamedTuple):
 	"""Internal event: a task produced an output line.
 
-	>>> OutputEvent(Task("hi"), 0, b"hello", 100.5)
-	OutputEvent(task=Task(cmd='hi', name=None, env={}, cwd=None), leaf_index=0, line=b'hello', timestamp=100.5)
+	>>> OutputEvent(Task("hi"), 0, b"hello", datetime(2026, 1, 1, 12, 0, 1))
+	OutputEvent(task=Task(cmd='hi', name=None, env={}, cwd=None), leaf_index=0, line=b'hello', timestamp=datetime.datetime(2026, 1, 1, 12, 0, 1))
 	"""
 
 	task: Task
 	leaf_index: int
 	line: bytes
-	timestamp: float
+	timestamp: datetime
 
 
 class CompletedEvent(NamedTuple):
 	"""Internal event: a task finished execution (either ran or was skipped).
 
 	>>> from camas.core.completion import Finished, Skipped
-	>>> CompletedEvent(Task("hi"), 0, Finished(0, 1.0, (b"done",)))
-	CompletedEvent(task=Task(cmd='hi', name=None, env={}, cwd=None), leaf_index=0, completion=Finished(returncode=0, elapsed=1.0, output=(b'done',)))
-	>>> CompletedEvent(Task("hi"), 0, Skipped(1))
-	CompletedEvent(task=Task(cmd='hi', name=None, env={}, cwd=None), leaf_index=0, completion=Skipped(returncode=1))
+	>>> CompletedEvent(Task("hi"), 0, Finished(0, 1.0, (b"done",)), datetime(2026, 1, 1, 12, 0, 2))
+	CompletedEvent(task=Task(cmd='hi', name=None, env={}, cwd=None), leaf_index=0, completion=Finished(returncode=0, elapsed=1.0, output=(b'done',)), timestamp=datetime.datetime(2026, 1, 1, 12, 0, 2))
+	>>> CompletedEvent(Task("hi"), 0, Skipped(1), datetime(2026, 1, 1, 12, 0, 0))
+	CompletedEvent(task=Task(cmd='hi', name=None, env={}, cwd=None), leaf_index=0, completion=Skipped(returncode=1), timestamp=datetime.datetime(2026, 1, 1, 12, 0))
 	"""
 
 	task: Task
 	leaf_index: int
 	completion: Completion
+	timestamp: datetime
 
 
 TaskEvent: TypeAlias = StartedEvent | OutputEvent | CompletedEvent

--- a/src/camas/effect/github_checks.py
+++ b/src/camas/effect/github_checks.py
@@ -469,8 +469,8 @@ class GitHubChecks:
 	required ``checks: write`` workflow permission.
 	"""
 
-	def __init__(self, options: GitHubChecksOptions | None = None) -> None:
-		self.options: Final = options if options is not None else GitHubChecksOptions()
+	def __init__(self, options: GitHubChecksOptions = GitHubChecksOptions()) -> None:
+		self.options: Final = options
 		self.state: EffectState | None = None
 
 	async def setup(self, task: TaskNode) -> LeafCtx:

--- a/src/camas/effect/status.py
+++ b/src/camas/effect/status.py
@@ -211,7 +211,7 @@ def _github_stop_token(body: str) -> str:
 	"""
 	for _ in range(32):
 		token = secrets.token_hex(8)
-		if f"::{token}::" not in body:
+		if f"::{token}::" not in body:  # pragma: no branch
 			return token
 	raise RuntimeError("could not pick a stop-commands token")  # pragma: no cover
 

--- a/src/camas/effect/status.py
+++ b/src/camas/effect/status.py
@@ -52,22 +52,23 @@ class StatusOptions(NamedTuple):
 
 	output_mode: OutputMode = "errors"
 	started_fmt: str = (
-		f"[{{timestamp:%Y-%m-%d %H:%M:%S}}.{{ms:03d}}] {VIOLET}▶ [{{name}}] started{RESET}"
+		f"{GREY}[{{timestamp:%Y-%m-%d %H:%M:%S}}.{{ms:03d}}]{RESET} "
+		f"{VIOLET}▶ [{{name}}] started{RESET}"
 	)
 	finished_fmt: str = (
-		f"[{{timestamp:%Y-%m-%d %H:%M:%S}}.{{ms:03d}}] "
+		f"{GREY}[{{timestamp:%Y-%m-%d %H:%M:%S}}.{{ms:03d}}]{RESET} "
 		f"{GREEN}✓ [{{name}}] success{RESET} ({{elapsed:.3f}}s)"
 	)
 	failed_fmt: str = (
-		f"[{{timestamp:%Y-%m-%d %H:%M:%S}}.{{ms:03d}}] "
+		f"{GREY}[{{timestamp:%Y-%m-%d %H:%M:%S}}.{{ms:03d}}]{RESET} "
 		f"{RED}✗ [{{name}}] error{RESET} exit={{rc}} ({{elapsed:.3f}}s)"
 	)
 	skipped_fmt: str = (
-		f"[{{timestamp:%Y-%m-%d %H:%M:%S}}.{{ms:03d}}] "
+		f"{GREY}[{{timestamp:%Y-%m-%d %H:%M:%S}}.{{ms:03d}}]{RESET} "
 		f"{GREY}⏭ [{{name}}] skipped{RESET} (prior rc={{rc}})"
 	)
 	output_fmt: str = (
-		f"[{{timestamp:%Y-%m-%d %H:%M:%S}}.{{ms:03d}}] {GREY}·{RESET} [{{name}}] {{line}}"
+		f"{GREY}[{{timestamp:%Y-%m-%d %H:%M:%S}}.{{ms:03d}}] · [{{name}}]{RESET} {{line}}"
 	)
 
 
@@ -116,7 +117,7 @@ def fmt_started(opts: StatusOptions, task: Task, ts: datetime) -> str | None:
 
 	>>> t0 = datetime(2026, 5, 21, 14, 30, 0, 123000)
 	>>> fmt_started(StatusOptions(), Task("echo hi", name="greet"), t0)
-	'[2026-05-21 14:30:00.123] \\x1b[95m▶ [greet] started\\x1b[0m'
+	'\\x1b[90m[2026-05-21 14:30:00.123]\\x1b[0m \\x1b[95m▶ [greet] started\\x1b[0m'
 	>>> fmt_started(StatusOptions(started_fmt=""), Task("echo hi"), t0) is None
 	True
 	>>> fmt_started(
@@ -137,11 +138,11 @@ def fmt_completed(opts: StatusOptions, task: Task, c: Completion, ts: datetime) 
 
 	>>> t0 = datetime(2026, 5, 21, 14, 30, 0, 123000)
 	>>> fmt_completed(StatusOptions(), Task("a", name="lint"), Finished(0, 1.5, ()), t0)
-	'[2026-05-21 14:30:00.123] \\x1b[32m✓ [lint] success\\x1b[0m (1.500s)'
+	'\\x1b[90m[2026-05-21 14:30:00.123]\\x1b[0m \\x1b[32m✓ [lint] success\\x1b[0m (1.500s)'
 	>>> fmt_completed(StatusOptions(), Task("a", name="lint"), Finished(2, 0.5, ()), t0)
-	'[2026-05-21 14:30:00.123] \\x1b[31m✗ [lint] error\\x1b[0m exit=2 (0.500s)'
+	'\\x1b[90m[2026-05-21 14:30:00.123]\\x1b[0m \\x1b[31m✗ [lint] error\\x1b[0m exit=2 (0.500s)'
 	>>> fmt_completed(StatusOptions(), Task("a", name="follow"), Skipped(2), t0)
-	'[2026-05-21 14:30:00.123] \\x1b[90m⏭ [follow] skipped\\x1b[0m (prior rc=2)'
+	'\\x1b[90m[2026-05-21 14:30:00.123]\\x1b[0m \\x1b[90m⏭ [follow] skipped\\x1b[0m (prior rc=2)'
 	>>> fmt_completed(
 	...     StatusOptions(finished_fmt=""), Task("a"), Finished(0, 1.0, ()), t0,
 	... ) is None
@@ -174,9 +175,9 @@ def fmt_output(opts: StatusOptions, task: Task, line: bytes, ts: datetime) -> st
 
 	>>> t0 = datetime(2026, 5, 21, 14, 30, 0, 123000)
 	>>> fmt_output(StatusOptions(), Task("a", name="lint"), b"hello\\n", t0)
-	'[2026-05-21 14:30:00.123] \\x1b[90m·\\x1b[0m [lint] hello'
+	'\\x1b[90m[2026-05-21 14:30:00.123] · [lint]\\x1b[0m hello'
 	>>> fmt_output(StatusOptions(), Task("a", name="lint"), b"\\x1b[31mred\\x1b[0m\\n", t0)
-	'[2026-05-21 14:30:00.123] \\x1b[90m·\\x1b[0m [lint] red'
+	'\\x1b[90m[2026-05-21 14:30:00.123] · [lint]\\x1b[0m red'
 	>>> fmt_output(StatusOptions(output_fmt=""), Task("a"), b"x\\n", t0) is None
 	True
 	"""

--- a/src/camas/effect/status.py
+++ b/src/camas/effect/status.py
@@ -14,6 +14,7 @@ on :func:`block_for` / :func:`fmt_started` / :func:`fmt_completed` /
 
 from __future__ import annotations
 
+import secrets
 import sys
 from collections.abc import Sequence
 from datetime import datetime
@@ -190,11 +191,55 @@ def fmt_output(opts: StatusOptions, task: Task, line: bytes, ts: datetime) -> st
 	)
 
 
+def _github_safe_title(label: str) -> str:
+	"""Strip newlines/CRs so a ``::group::`` title stays on one line.
+
+	>>> _github_safe_title("normal")
+	'normal'
+	>>> _github_safe_title("a\\nb\\rc")
+	'a b c'
+	"""
+	return label.replace("\r", " ").replace("\n", " ")
+
+
+def _github_stop_token(body: str) -> str:
+	"""Pick a stop-commands token that does not appear as ``::{token}::`` in ``body``.
+
+	>>> tok = _github_stop_token("plain body\\n")
+	>>> len(tok) >= 8 and tok.isalnum()
+	True
+	"""
+	for _ in range(32):
+		token = secrets.token_hex(8)
+		if f"::{token}::" not in body:
+			return token
+	raise RuntimeError("could not pick a stop-commands token")  # pragma: no cover
+
+
+def _format_github_group(title: str, body: str, token: str) -> str:
+	"""Wrap ``body`` in a GitHub ``::group::`` with ``::stop-commands::`` neutralization.
+
+	The stop-commands bracket disables workflow-command parsing for the body
+	so output lines like ``::endgroup::`` or ``::add-mask::`` are emitted
+	verbatim instead of being interpreted by Actions.
+
+	>>> _format_github_group("x", "ok\\n", "T")
+	'::group::x\\n::stop-commands::T\\nok\\n::T::\\n::endgroup::\\n'
+	>>> _format_github_group("x", "::endgroup::\\n", "T")
+	'::group::x\\n::stop-commands::T\\n::endgroup::\\n::T::\\n::endgroup::\\n'
+	"""
+	return f"::group::{title}\n::stop-commands::{token}\n{body}::{token}::\n::endgroup::\n"
+
+
 def block_for(mode: OutputMode, task: Task, c: Completion, output: bytes) -> str:
 	"""Return the completion-block text for ``mode`` (empty when nothing to dump).
 
 	Output bytes are passed through verbatim — ANSI escapes are preserved so
 	downstream viewers (terminals, Actions logs) render the original colors.
+	For ``github`` mode the body is wrapped in ``::stop-commands::`` so task
+	output that happens to start with ``::`` (e.g. another tool's
+	``::endgroup::`` or ``::warning::``) cannot prematurely close the group
+	or inject workflow commands.
 
 	>>> block_for("all", Task("a", name="x"), Finished(0, 1.0, ()), b"ok\\n")
 	'ok\\n'
@@ -204,8 +249,11 @@ def block_for(mode: OutputMode, task: Task, c: Completion, output: bytes) -> str
 	''
 	>>> block_for("errors", Task("a", name="x"), Finished(2, 1.0, ()), b"boom\\n")
 	'boom\\n'
-	>>> block_for("github", Task("a", name="x"), Finished(0, 1.0, ()), b"ok\\n")
-	'::group::x\\nok\\n::endgroup::\\n'
+	>>> out = block_for("github", Task("a", name="x"), Finished(0, 1.0, ()), b"ok\\n")
+	>>> out.startswith("::group::x\\n::stop-commands::") and out.endswith("::\\n::endgroup::\\n")
+	True
+	>>> "ok\\n" in out
+	True
 	>>> block_for("quiet", Task("a"), Finished(0, 1.0, ()), b"ok\\n")
 	''
 	>>> block_for("stream", Task("a"), Finished(0, 1.0, ()), b"ok\\n")
@@ -227,7 +275,9 @@ def block_for(mode: OutputMode, task: Task, c: Completion, output: bytes) -> str
 		case "errors":
 			return body if failed else ""
 		case "github":
-			return f"::group::{task_label(task)}\n{body}::endgroup::\n"
+			return _format_github_group(
+				_github_safe_title(task_label(task)), body, _github_stop_token(body)
+			)
 		case "quiet" | "stream":
 			return ""
 		case _:

--- a/src/camas/effect/status.py
+++ b/src/camas/effect/status.py
@@ -1,0 +1,301 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2026 JP Hutchins
+
+"""Effect: streams plain-text per-task status lines as tasks start, stop, and
+emit output. Counterpart to :class:`camas.effect.termtree.Termtree` (live,
+cursor-redrawing) and :class:`camas.effect.summary.Summary` (one post-run
+report) — suited for CI logs and any context where cursor control either
+doesn't render or shouldn't.
+
+See :class:`StatusOptions` for the mode and template fields, and the doctests
+on :func:`block_for` / :func:`fmt_started` / :func:`fmt_completed` /
+:func:`fmt_output` for the exact behavior of each.
+"""
+
+from __future__ import annotations
+
+import sys
+from collections.abc import Sequence
+from datetime import datetime
+from typing import Final, Literal, NamedTuple, TypeAlias
+
+if sys.version_info >= (3, 11):
+	from typing import assert_never
+else:  # pragma: no cover
+	from typing_extensions import assert_never
+
+from ..core.completion import Completion, Finished, Skipped
+from ..core.leaf_state import LeafState
+from ..core.render import GREEN, GREY, RED, RESET, VIOLET, strip_ansi
+from ..core.task import Task, TaskNode, task_label
+from ..core.task_event import (
+	CompletedEvent,
+	OutputEvent,
+	StartedEvent,
+	TaskEvent,
+)
+
+OutputMode: TypeAlias = Literal["quiet", "all", "errors", "stream", "github"]
+
+
+class StatusOptions(NamedTuple):
+	"""Configuration for the Status Effect.
+
+	>>> StatusOptions().output_mode
+	'errors'
+	>>> StatusOptions(output_mode="github").output_mode
+	'github'
+	>>> StatusOptions(started_fmt="").started_fmt
+	''
+	"""
+
+	output_mode: OutputMode = "errors"
+	started_fmt: str = (
+		f"[{{timestamp:%Y-%m-%d %H:%M:%S}}.{{ms:03d}}] {VIOLET}▶ [{{name}}] started{RESET}"
+	)
+	finished_fmt: str = (
+		f"[{{timestamp:%Y-%m-%d %H:%M:%S}}.{{ms:03d}}] "
+		f"{GREEN}✓ [{{name}}] success{RESET} ({{elapsed:.3f}}s)"
+	)
+	failed_fmt: str = (
+		f"[{{timestamp:%Y-%m-%d %H:%M:%S}}.{{ms:03d}}] "
+		f"{RED}✗ [{{name}}] error{RESET} exit={{rc}} ({{elapsed:.3f}}s)"
+	)
+	skipped_fmt: str = (
+		f"[{{timestamp:%Y-%m-%d %H:%M:%S}}.{{ms:03d}}] "
+		f"{GREY}⏭ [{{name}}] skipped{RESET} (prior rc={{rc}})"
+	)
+	output_fmt: str = (
+		f"[{{timestamp:%Y-%m-%d %H:%M:%S}}.{{ms:03d}}] {GREY}·{RESET} [{{name}}] {{line}}"
+	)
+
+
+class Idle(NamedTuple):
+	"""Per-leaf ctx: ``StartedEvent`` has not fired yet.
+
+	>>> Idle()
+	Idle()
+	"""
+
+
+class Active(NamedTuple):
+	"""Per-leaf ctx: leaf is running.
+
+	>>> Active(b"hello\\n").output
+	b'hello\\n'
+	"""
+
+	output: bytes
+
+
+class Done(NamedTuple):
+	"""Per-leaf ctx: ``CompletedEvent`` processed; nothing remains to emit.
+
+	>>> Done()
+	Done()
+	"""
+
+
+LeafCtx: TypeAlias = Idle | Active | Done
+
+
+def cmd_str(task: Task) -> str:
+	"""Return ``task.cmd`` as a single string (joins tuple form with spaces).
+
+	>>> cmd_str(Task("echo hi"))
+	'echo hi'
+	>>> cmd_str(Task(("python", "-c", "pass")))
+	'python -c pass'
+	"""
+	return task.cmd if isinstance(task.cmd, str) else " ".join(task.cmd)
+
+
+def fmt_started(opts: StatusOptions, task: Task, ts: datetime) -> str | None:
+	"""Render the started-line, or ``None`` when ``started_fmt`` is empty.
+
+	>>> t0 = datetime(2026, 5, 21, 14, 30, 0, 123000)
+	>>> fmt_started(StatusOptions(), Task("echo hi", name="greet"), t0)
+	'[2026-05-21 14:30:00.123] \\x1b[95m▶ [greet] started\\x1b[0m'
+	>>> fmt_started(StatusOptions(started_fmt=""), Task("echo hi"), t0) is None
+	True
+	>>> fmt_started(
+	...     StatusOptions(started_fmt="{cmd} @ {timestamp:%H:%M:%S}.{ms:03d}"),
+	...     Task(("python", "-c", "pass")), t0,
+	... )
+	'python -c pass @ 14:30:00.123'
+	"""
+	if not opts.started_fmt:
+		return None
+	return opts.started_fmt.format(
+		name=task_label(task), cmd=cmd_str(task), timestamp=ts, ms=ts.microsecond // 1000
+	)
+
+
+def fmt_completed(opts: StatusOptions, task: Task, c: Completion, ts: datetime) -> str | None:
+	"""Render the completion line, or ``None`` when the matching template is empty.
+
+	>>> t0 = datetime(2026, 5, 21, 14, 30, 0, 123000)
+	>>> fmt_completed(StatusOptions(), Task("a", name="lint"), Finished(0, 1.5, ()), t0)
+	'[2026-05-21 14:30:00.123] \\x1b[32m✓ [lint] success\\x1b[0m (1.500s)'
+	>>> fmt_completed(StatusOptions(), Task("a", name="lint"), Finished(2, 0.5, ()), t0)
+	'[2026-05-21 14:30:00.123] \\x1b[31m✗ [lint] error\\x1b[0m exit=2 (0.500s)'
+	>>> fmt_completed(StatusOptions(), Task("a", name="follow"), Skipped(2), t0)
+	'[2026-05-21 14:30:00.123] \\x1b[90m⏭ [follow] skipped\\x1b[0m (prior rc=2)'
+	>>> fmt_completed(
+	...     StatusOptions(finished_fmt=""), Task("a"), Finished(0, 1.0, ()), t0,
+	... ) is None
+	True
+	>>> fmt_completed(
+	...     StatusOptions(failed_fmt=""), Task("a"), Finished(2, 1.0, ()), t0,
+	... ) is None
+	True
+	"""
+	name = task_label(task)
+	cmd = cmd_str(task)
+	ms = ts.microsecond // 1000
+	match c:
+		case Finished(returncode=rc, elapsed=e):
+			tmpl = opts.finished_fmt if rc == 0 else opts.failed_fmt
+			return (
+				tmpl.format(name=name, cmd=cmd, rc=rc, elapsed=e, timestamp=ts, ms=ms)
+				if tmpl
+				else None
+			)
+		case Skipped(returncode=rc):
+			tmpl = opts.skipped_fmt
+			return tmpl.format(name=name, cmd=cmd, rc=rc, timestamp=ts, ms=ms) if tmpl else None
+		case _:
+			assert_never(c)
+
+
+def fmt_output(opts: StatusOptions, task: Task, line: bytes, ts: datetime) -> str | None:
+	"""Render a stream-mode output line (ANSI-stripped, trailing newline removed).
+
+	>>> t0 = datetime(2026, 5, 21, 14, 30, 0, 123000)
+	>>> fmt_output(StatusOptions(), Task("a", name="lint"), b"hello\\n", t0)
+	'[2026-05-21 14:30:00.123] \\x1b[90m·\\x1b[0m [lint] hello'
+	>>> fmt_output(StatusOptions(), Task("a", name="lint"), b"\\x1b[31mred\\x1b[0m\\n", t0)
+	'[2026-05-21 14:30:00.123] \\x1b[90m·\\x1b[0m [lint] red'
+	>>> fmt_output(StatusOptions(output_fmt=""), Task("a"), b"x\\n", t0) is None
+	True
+	"""
+	if not opts.output_fmt:
+		return None
+	return opts.output_fmt.format(
+		name=task_label(task),
+		cmd=cmd_str(task),
+		timestamp=ts,
+		ms=ts.microsecond // 1000,
+		line=strip_ansi(line.decode("utf-8", errors="replace")).rstrip("\n"),
+	)
+
+
+def block_for(mode: OutputMode, task: Task, c: Completion, output: bytes) -> str:
+	"""Return the completion-block text for ``mode`` (empty when nothing to dump).
+
+	Output bytes are passed through verbatim — ANSI escapes are preserved so
+	downstream viewers (terminals, Actions logs) render the original colors.
+
+	>>> block_for("all", Task("a", name="x"), Finished(0, 1.0, ()), b"ok\\n")
+	'ok\\n'
+	>>> block_for("all", Task("a"), Finished(0, 1.0, ()), b"\\x1b[32mgreen\\x1b[0m\\n")
+	'\\x1b[32mgreen\\x1b[0m\\n'
+	>>> block_for("errors", Task("a", name="x"), Finished(0, 1.0, ()), b"ok\\n")
+	''
+	>>> block_for("errors", Task("a", name="x"), Finished(2, 1.0, ()), b"boom\\n")
+	'boom\\n'
+	>>> block_for("github", Task("a", name="x"), Finished(0, 1.0, ()), b"ok\\n")
+	'::group::x\\nok\\n::endgroup::\\n'
+	>>> block_for("quiet", Task("a"), Finished(0, 1.0, ()), b"ok\\n")
+	''
+	>>> block_for("stream", Task("a"), Finished(0, 1.0, ()), b"ok\\n")
+	''
+	>>> block_for("all", Task("a"), Finished(0, 1.0, ()), b"")
+	''
+	>>> block_for("github", Task("a", name="x"), Skipped(1), b"")
+	''
+	"""
+	if not output:
+		return ""
+	body = output.decode("utf-8", errors="replace")
+	if not body.endswith("\n"):
+		body += "\n"
+	failed = isinstance(c, Finished) and c.returncode != 0
+	match mode:
+		case "all":
+			return body
+		case "errors":
+			return body if failed else ""
+		case "github":
+			return f"::group::{task_label(task)}\n{body}::endgroup::\n"
+		case "quiet" | "stream":
+			return ""
+		case _:
+			assert_never(mode)
+
+
+def emit(text: str) -> None:
+	"""Write ``text`` to ``stdout.buffer`` + flush. Caller controls newlines."""
+	if not text:
+		return
+	sys.stdout.buffer.write(text.encode("utf-8", errors="replace"))
+	sys.stdout.flush()
+
+
+def emit_line(text: str | None) -> None:
+	"""Write ``text`` + ``\\n`` when non-empty; no-op for ``None``/empty string."""
+	if not text:
+		return
+	emit(text + "\n")
+
+
+def next_ctx_on_output(mode: OutputMode, ctx: Active, line: bytes) -> Active:
+	"""Next Active ctx for an OutputEvent — block modes accumulate, others don't.
+
+	>>> next_ctx_on_output("all", Active(b"abc"), b"def").output
+	b'abcdef'
+	>>> next_ctx_on_output("stream", Active(b""), b"x").output
+	b''
+	>>> next_ctx_on_output("quiet", Active(b""), b"x").output
+	b''
+	"""
+	match mode:
+		case "all" | "errors" | "github":
+			return Active(ctx.output + line)
+		case "quiet" | "stream":
+			return ctx
+		case _:
+			assert_never(mode)
+
+
+class Status:
+	def __init__(self, options: StatusOptions = StatusOptions()) -> None:
+		self.options: Final = options
+
+	async def setup(self, task: TaskNode) -> LeafCtx:
+		return Idle()
+
+	async def on_event(
+		self, event: TaskEvent, states: Sequence[LeafState], ctx: LeafCtx
+	) -> LeafCtx:
+		opts = self.options
+		match event, ctx:
+			case StartedEvent(task=t, timestamp=ts), Idle():
+				emit_line(fmt_started(opts, t, ts))
+				return Active(b"")
+			case OutputEvent(task=t, line=line, timestamp=ts), Active() as active:
+				if opts.output_mode == "stream":
+					emit_line(fmt_output(opts, t, line, ts))
+				return next_ctx_on_output(opts.output_mode, active, line)
+			case CompletedEvent(task=t, completion=c, timestamp=ts), Active(output=buf):
+				emit_line(fmt_completed(opts, t, c, ts))
+				emit(block_for(opts.output_mode, t, c, buf))
+				return Done()
+			case CompletedEvent(task=t, completion=c, timestamp=ts), Idle():
+				emit_line(fmt_completed(opts, t, c, ts))
+				return Done()
+			case _:
+				return ctx
+
+	async def teardown(self, ctxs: tuple[LeafCtx, ...]) -> None:
+		return None

--- a/src/camas/effect/summary.py
+++ b/src/camas/effect/summary.py
@@ -3,9 +3,9 @@
 
 import shutil
 import sys
-import time
 from collections.abc import Sequence
 from dataclasses import dataclass
+from datetime import datetime
 from typing import Final, NamedTuple, TypeAlias
 
 if sys.version_info >= (3, 11):
@@ -76,7 +76,7 @@ class SummaryContext(NamedTuple):
 	rows: tuple[DisplayRow, ...]
 	term_width: int
 	display_width: int
-	wall_start: float
+	wall_start: datetime
 	state: SummaryState
 
 
@@ -103,7 +103,7 @@ class Summary:
 			rows=flatten_rows(task),
 			term_width=term_width,
 			display_width=term_width - STATUS_COL_WIDTH - 1,
-			wall_start=time.perf_counter(),
+			wall_start=datetime.now(),
 			state=SummaryState(
 				states=tuple(Waiting(info.task) for info in flatten_leaves(task)),
 			),
@@ -122,7 +122,7 @@ class Summary:
 			ctx.state.states,
 			ctx.term_width,
 			ctx.display_width,
-			time.perf_counter(),
+			datetime.now(),
 			ctx.wall_start,
 		)
 		cleaned: Final = tuple(  # zuban: ignore[misc] # zuban defies PEP591

--- a/src/camas/effect/summary.py
+++ b/src/camas/effect/summary.py
@@ -96,8 +96,8 @@ class Summary:
 	produces garbage. End-state output matches ``Termtree``'s final frame.
 	"""
 
-	def __init__(self, options: SummaryOptions | None = None) -> None:
-		self.options: Final = options if options is not None else SummaryOptions()
+	def __init__(self, options: SummaryOptions = SummaryOptions()) -> None:
+		self.options: Final = options
 
 	async def setup(self, task: TaskNode) -> SummaryContext:
 		match self.options.term_width:

--- a/src/camas/effect/summary.py
+++ b/src/camas/effect/summary.py
@@ -3,6 +3,7 @@
 
 import shutil
 import sys
+import time
 from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import datetime
@@ -71,12 +72,19 @@ class SummaryState:
 
 
 class SummaryContext(NamedTuple):
-	"""Immutable context threaded through the summary Effect's lifecycle."""
+	"""Immutable context threaded through the summary Effect's lifecycle.
+
+	``wall_start`` is the wall-clock setup time (for human-facing timestamps if
+	ever surfaced); ``wall_start_mono`` is the corresponding monotonic reading
+	(``time.perf_counter()``) used to compute the displayed elapsed total so
+	the summary line is immune to NTP/DST steps mid-run.
+	"""
 
 	rows: tuple[DisplayRow, ...]
 	term_width: int
 	display_width: int
 	wall_start: datetime
+	wall_start_mono: float
 	state: SummaryState
 
 
@@ -104,6 +112,7 @@ class Summary:
 			term_width=term_width,
 			display_width=term_width - STATUS_COL_WIDTH - 1,
 			wall_start=datetime.now(),
+			wall_start_mono=time.perf_counter(),
 			state=SummaryState(
 				states=tuple(Waiting(info.task) for info in flatten_leaves(task)),
 			),
@@ -123,7 +132,7 @@ class Summary:
 			ctx.term_width,
 			ctx.display_width,
 			datetime.now(),
-			ctx.wall_start,
+			time.perf_counter() - ctx.wall_start_mono,
 		)
 		cleaned: Final = tuple(  # zuban: ignore[misc] # zuban defies PEP591
 			line.removeprefix("\r").replace(CLEAR_LINE, "") for line in lines

--- a/src/camas/effect/termtree.py
+++ b/src/camas/effect/termtree.py
@@ -4,6 +4,7 @@
 import asyncio
 import shutil
 import sys
+import time
 from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import datetime
@@ -114,9 +115,10 @@ def bucket_glyph_color(states: Sequence[LeafState]) -> tuple[str, str]:
 	(red on any failure, grey if all skipped, otherwise green).
 
 	>>> t = Task("x")
+	>>> t0 = datetime(2026, 1, 1)
 	>>> bucket_glyph_color([Waiting(t)]) == (' ', GREY)
 	True
-	>>> bucket_glyph_color([Running(t, 0.0, b"")]) == ('┄', CYAN)
+	>>> bucket_glyph_color([Running(t, t0, b"")]) == ('┄', CYAN)
 	True
 	>>> bucket_glyph_color([Completed(t, Finished(0, 0.1, ()))]) == ('─', GREEN)
 	True
@@ -124,7 +126,7 @@ def bucket_glyph_color(states: Sequence[LeafState]) -> tuple[str, str]:
 	True
 	>>> bucket_glyph_color([Completed(t, Skipped(1))]) == ('─', GREY)
 	True
-	>>> bucket_glyph_color([Waiting(t), Running(t, 0.0, b"")]) == (' ', GREY)
+	>>> bucket_glyph_color([Waiting(t), Running(t, t0, b"")]) == (' ', GREY)
 	True
 	"""
 	if any(isinstance(s, Waiting) for s in states):
@@ -153,12 +155,13 @@ def render_progress_bar(states: Sequence[LeafState], width: int) -> str:
 	always has visible width ``width``.
 
 	>>> t = Task("x")
+	>>> t0 = datetime(2026, 1, 1)
 	>>> bar = render_progress_bar([Waiting(t), Waiting(t)], 10)
 	>>> len(strip_ansi(bar))
 	10
 	>>> strip_ansi(bar)
 	'          '
-	>>> bar = render_progress_bar([Running(t, 0.0, b"")], 10)
+	>>> bar = render_progress_bar([Running(t, t0, b"")], 10)
 	>>> strip_ansi(bar)
 	'  ┄┄┄┄┄┄  '
 	>>> render_progress_bar([], 5)
@@ -173,7 +176,7 @@ def render_progress_bar(states: Sequence[LeafState], width: int) -> str:
 	True
 	>>> render_progress_bar([Waiting(t)], 3)
 	'   '
-	>>> strip_ansi(render_progress_bar([Running(t, 0.0, b"")] * 10, 10))
+	>>> strip_ansi(render_progress_bar([Running(t, t0, b"")] * 10, 10))
 	'  ┄┄┄┄┄┄  '
 	"""
 	if width <= 0 or len(states) == 0:
@@ -233,9 +236,15 @@ def render_lines(
 	term_width: int,
 	display_width: int,
 	now: datetime,
-	wall_start: datetime,
+	wall_elapsed: float,
 ) -> list[str]:
-	"""Build the list of ANSI-formatted lines for one frame (leaves + summary)."""
+	"""Build the list of ANSI-formatted lines for one frame (leaves + summary).
+
+	``wall_elapsed`` is supplied as monotonic seconds (``time.perf_counter()``
+	delta) by the caller so the displayed total time is immune to wall-clock
+	jumps (NTP, DST); ``now`` is still a wall-clock ``datetime`` because the
+	per-leaf running counter is derived from ``Running.start_time``.
+	"""
 	lines: list[str] = []
 	leaf_idx = 0
 	for row in rows:
@@ -288,7 +297,6 @@ def render_lines(
 					case Waiting():
 						padding = " " * gap
 						lines.append(f"\r{header}{padding} [{GREY} WAIT {RESET}]{CLEAR_LINE}")
-	wall_elapsed: Final = (now - wall_start).total_seconds()
 	alldone: Final = all(isinstance(s, Completed) for s in states)
 	summary_pad: Final = render_progress_bar(states, max(display_width - 6, 0))
 	if alldone:
@@ -317,7 +325,7 @@ def render_frame(
 	term_width: int,
 	display_width: int,
 	now: datetime,
-	wall_start: datetime,
+	wall_elapsed: float,
 ) -> str:
 	"""Render one positioned frame as an ANSI string, for live animation.
 
@@ -326,7 +334,7 @@ def render_frame(
 	space (via `"\\n" * N`) so the frame has room to render inline without
 	scrolling the viewport.
 	"""
-	lines: Final = render_lines(rows, states, term_width, display_width, now, wall_start)
+	lines: Final = render_lines(rows, states, term_width, display_width, now, wall_elapsed)
 	return f"\033[{len(lines) - 1}F" + "\n".join(lines)
 
 
@@ -397,12 +405,19 @@ class TermtreeState:
 
 
 class TermtreeContext(NamedTuple):
-	"""Immutable context threaded through the termtree Effect's lifecycle."""
+	"""Immutable context threaded through the termtree Effect's lifecycle.
+
+	``wall_start`` is the wall-clock setup time (for human-facing timestamps if
+	ever surfaced); ``wall_start_mono`` is the corresponding monotonic reading
+	(``time.perf_counter()``) used to compute the displayed elapsed total so
+	the TUI never sees a backward/forward NTP step.
+	"""
 
 	rows: tuple[DisplayRow, ...]
 	term_width: int
 	display_width: int
 	wall_start: datetime
+	wall_start_mono: float
 	state: TermtreeState
 
 
@@ -427,6 +442,7 @@ class Termtree:
 			term_width=term_width,
 			display_width=term_width - STATUS_COL_WIDTH - 1,
 			wall_start=datetime.now(),
+			wall_start_mono=time.perf_counter(),
 			state=TermtreeState(
 				states=tuple(Waiting(info.task) for info in flatten_leaves(task)),
 			),
@@ -470,7 +486,7 @@ def draw(ctx: TermtreeContext) -> None:
 		ctx.term_width,
 		ctx.display_width,
 		datetime.now(),
-		ctx.wall_start,
+		time.perf_counter() - ctx.wall_start_mono,
 	)
 	sys.stdout.buffer.write(frame.encode("utf-8", errors="replace"))
 	sys.stdout.flush()

--- a/src/camas/effect/termtree.py
+++ b/src/camas/effect/termtree.py
@@ -429,8 +429,8 @@ class Termtree:
 	how fast events arrive.
 	"""
 
-	def __init__(self, options: TermtreeOptions | None = None) -> None:
-		self.options: Final = options if options is not None else TermtreeOptions()
+	def __init__(self, options: TermtreeOptions = TermtreeOptions()) -> None:
+		self.options: Final = options
 
 	async def setup(self, task: TaskNode) -> TermtreeContext:
 		term_width: Final = (  # zuban: ignore[misc] # zuban defies PEP591

--- a/src/camas/effect/termtree.py
+++ b/src/camas/effect/termtree.py
@@ -4,9 +4,9 @@
 import asyncio
 import shutil
 import sys
-import time
 from collections.abc import Sequence
 from dataclasses import dataclass
+from datetime import datetime
 from typing import Final, NamedTuple
 
 from ..core.completion import Finished, Skipped
@@ -232,8 +232,8 @@ def render_lines(
 	states: Sequence[LeafState],
 	term_width: int,
 	display_width: int,
-	now: float,
-	wall_start: float,
+	now: datetime,
+	wall_start: datetime,
 ) -> list[str]:
 	"""Build the list of ANSI-formatted lines for one frame (leaves + summary)."""
 	lines: list[str] = []
@@ -273,7 +273,7 @@ def render_lines(
 									f"\r{header}{padding} [{GREY} SKIP {RESET}]{CLEAR_LINE}"
 								)
 					case Running(start_time=start_time, last_line=last_line):
-						elapsed = now - start_time
+						elapsed = (now - start_time).total_seconds()
 						spin = SPINNER[int(elapsed * 10) % len(SPINNER)]
 						stream_line = strip_ansi(decode_line(last_line)) if last_line else ""
 						stream = (
@@ -288,7 +288,7 @@ def render_lines(
 					case Waiting():
 						padding = " " * gap
 						lines.append(f"\r{header}{padding} [{GREY} WAIT {RESET}]{CLEAR_LINE}")
-	wall_elapsed: Final = now - wall_start
+	wall_elapsed: Final = (now - wall_start).total_seconds()
 	alldone: Final = all(isinstance(s, Completed) for s in states)
 	summary_pad: Final = render_progress_bar(states, max(display_width - 6, 0))
 	if alldone:
@@ -316,8 +316,8 @@ def render_frame(
 	states: Sequence[LeafState],
 	term_width: int,
 	display_width: int,
-	now: float,
-	wall_start: float,
+	now: datetime,
+	wall_start: datetime,
 ) -> str:
 	"""Render one positioned frame as an ANSI string, for live animation.
 
@@ -402,7 +402,7 @@ class TermtreeContext(NamedTuple):
 	rows: tuple[DisplayRow, ...]
 	term_width: int
 	display_width: int
-	wall_start: float
+	wall_start: datetime
 	state: TermtreeState
 
 
@@ -426,7 +426,7 @@ class Termtree:
 			rows=rows,
 			term_width=term_width,
 			display_width=term_width - STATUS_COL_WIDTH - 1,
-			wall_start=time.perf_counter(),
+			wall_start=datetime.now(),
 			state=TermtreeState(
 				states=tuple(Waiting(info.task) for info in flatten_leaves(task)),
 			),
@@ -469,7 +469,7 @@ def draw(ctx: TermtreeContext) -> None:
 		ctx.state.states,
 		ctx.term_width,
 		ctx.display_width,
-		time.perf_counter(),
+		datetime.now(),
 		ctx.wall_start,
 	)
 	sys.stdout.buffer.write(frame.encode("utf-8", errors="replace"))

--- a/src/camas/main/effects.py
+++ b/src/camas/main/effects.py
@@ -138,7 +138,8 @@ def signature_fields(cls: Any) -> list[tuple[str, Any, Any, Any]]:
 		try:
 			sig = inspect.signature(cls)
 		except (ValueError, TypeError):
-			return []
+			from_src = signature_fields_from_source(cls)
+			return from_src if from_src is not None else []
 	from_inspect: list[tuple[str, Any, Any, Any]] = [
 		(
 			p.name,

--- a/src/camas/main/effects.py
+++ b/src/camas/main/effects.py
@@ -148,7 +148,7 @@ def signature_fields(cls: Any) -> list[tuple[str, Any, Any, Any]]:
 		)
 		for p in sig.parameters.values()
 	]
-	if from_inspect and all(annot is Any for _, _, annot, _ in from_inspect):
+	if not from_inspect or all(annot is Any for _, _, annot, _ in from_inspect):
 		from_src = signature_fields_from_source(cls)
 		if from_src is not None:
 			return from_src

--- a/src/camas/main/parser.py
+++ b/src/camas/main/parser.py
@@ -45,7 +45,7 @@ def default_effects_expr() -> str:
 	'(Status(StatusOptions(output_mode="github")),)'
 	>>> os.environ.pop("GITHUB_ACTIONS", None)
 	'true'
-	>>> _ = os.environ.update({"GITHUB_ACTIONS": _saved}) if _saved else None
+	>>> _ = os.environ.update({"GITHUB_ACTIONS": _saved}) if _saved is not None else None
 	"""
 	if os.environ.get("GITHUB_ACTIONS") == "true":
 		return '(Status(StatusOptions(output_mode="github")),)'

--- a/src/camas/main/parser.py
+++ b/src/camas/main/parser.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import importlib.metadata
+import os
 import sys
 from collections.abc import Mapping
 from typing import Any, Final
@@ -26,6 +27,29 @@ from .format import (
 	format_try_hint,
 )
 from .state import EMPTY_STATE, LoadErr, LoadOk, TasksState
+
+
+def default_effects_expr() -> str:
+	"""Pick the default ``--effects`` expression based on the runtime environment.
+
+	GitHub Actions sets ``GITHUB_ACTIONS=true`` reliably; in that case prefer
+	``Status`` with the ``github`` mode (collapsed workflow groups) over the
+	live ``Termtree`` (which renders garbage in non-interactive log capture).
+
+	>>> import os
+	>>> _saved = os.environ.pop("GITHUB_ACTIONS", None)
+	>>> default_effects_expr()
+	'(Termtree(),)'
+	>>> os.environ["GITHUB_ACTIONS"] = "true"
+	>>> default_effects_expr()
+	'(Status(StatusOptions(output_mode="github")),)'
+	>>> os.environ.pop("GITHUB_ACTIONS", None)
+	'true'
+	>>> _ = os.environ.update({"GITHUB_ACTIONS": _saved}) if _saved else None
+	"""
+	if os.environ.get("GITHUB_ACTIONS") == "true":
+		return '(Status(StatusOptions(output_mode="github")),)'
+	return "(Termtree(),)"
 
 
 class CamasArgumentParser(argparse.ArgumentParser):
@@ -118,9 +142,10 @@ def build_parser(state: TasksState = EMPTY_STATE) -> argparse.ArgumentParser:
 	parser.add_argument(
 		"--effects",
 		nargs="?",
-		default="(Termtree(),)",
+		default=default_effects_expr(),
 		const="",
-		help="tuple of Effect instances; pass with no value to list available Effects",
+		help="tuple of Effect instances; pass with no value to list available Effects "
+		"(default: Termtree, or Status('github') when GITHUB_ACTIONS=true)",
 	)
 	parser.add_argument(
 		"--matrix",

--- a/tests/effect/test_github_checks.py
+++ b/tests/effect/test_github_checks.py
@@ -14,6 +14,8 @@ if sys.version_info >= (3, 11):
 else:  # pragma: no cover
 	from exceptiongroup import BaseExceptionGroup
 
+from datetime import datetime
+
 import httpx
 import pytest
 
@@ -38,6 +40,8 @@ from camas.effect.github_checks import (
 	render_body,
 	resolve_config,
 )
+
+TS = datetime(2026, 5, 21, 14, 30, 0)
 
 
 def clear_gh_env(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -414,7 +418,7 @@ async def test_on_event_started_spawns_post_task(monkeypatch: pytest.MonkeyPatch
 	effect = GitHubChecks(GitHubChecksOptions(name_prefix="pfx/"))
 	ctx = await effect.setup(Task("x"))
 	t = Task("cmd", name="lint")
-	ctx = await effect.on_event(StartedEvent(t, 0, 0.0), [], ctx)
+	ctx = await effect.on_event(StartedEvent(t, 0, TS), [], ctx)
 	assert isinstance(ctx, Active)
 	assert ctx.tail == b""
 	await ctx.post_task
@@ -435,9 +439,9 @@ async def test_on_event_output_accumulates_and_trims_tail(
 	effect = GitHubChecks(GitHubChecksOptions(tail_bytes=5))
 	ctx = await effect.setup(Task("x"))
 	t = Task("cmd", name="t")
-	ctx = await effect.on_event(StartedEvent(t, 0, 0.0), [], ctx)
-	ctx = await effect.on_event(OutputEvent(t, 0, b"abc", 0.0), [], ctx)
-	ctx = await effect.on_event(OutputEvent(t, 0, b"defgh", 0.0), [], ctx)
+	ctx = await effect.on_event(StartedEvent(t, 0, TS), [], ctx)
+	ctx = await effect.on_event(OutputEvent(t, 0, b"abc", TS), [], ctx)
+	ctx = await effect.on_event(OutputEvent(t, 0, b"defgh", TS), [], ctx)
 	assert isinstance(ctx, Active)
 	assert ctx.tail == b"defgh"
 	await effect.teardown((Closed(task=None),))
@@ -464,8 +468,8 @@ async def test_on_event_completed_finished_spawns_patch_success(
 	effect = GitHubChecks()
 	ctx = await effect.setup(Task("x"))
 	t = Task("cmd", name="t")
-	ctx = await effect.on_event(StartedEvent(t, 0, 0.0), [], ctx)
-	ctx = await effect.on_event(CompletedEvent(t, 0, Finished(0, 1.0, ())), [], ctx)
+	ctx = await effect.on_event(StartedEvent(t, 0, TS), [], ctx)
+	ctx = await effect.on_event(CompletedEvent(t, 0, Finished(0, 1.0, ()), TS), [], ctx)
 	assert isinstance(ctx, Closed)
 	assert ctx.task is not None
 	await effect.teardown((ctx,))
@@ -480,7 +484,7 @@ async def test_on_event_completed_skipped_on_pending_returns_closed_none(
 	effect = GitHubChecks()
 	ctx = await effect.setup(Task("x"))
 	t = Task("cmd", name="t")
-	ctx = await effect.on_event(CompletedEvent(t, 0, Skipped(1)), [], ctx)
+	ctx = await effect.on_event(CompletedEvent(t, 0, Skipped(1), TS), [], ctx)
 	assert isinstance(ctx, Closed)
 	assert ctx.task is None
 	await effect.teardown((ctx,))

--- a/tests/effect/test_status.py
+++ b/tests/effect/test_status.py
@@ -357,3 +357,13 @@ def test_discoverable_via_parse_effects() -> None:
 	assert type(effects[0]).__name__ == "Status"
 	effects2 = parse_effects("(Status(StatusOptions(output_mode='github')),)")
 	assert type(effects2[0]).__name__ == "Status"
+
+
+def test_github_stop_token_retries_on_collision(monkeypatch: pytest.MonkeyPatch) -> None:
+	"""If the first generated token already appears as ``::TOKEN::`` in the body,
+	the picker loops until it finds a clean one. Forces the retry branch."""
+	from camas.effect import status
+
+	tokens = iter(["aaaaaaaa", "bbbbbbbb"])
+	monkeypatch.setattr(status.secrets, "token_hex", lambda _n: next(tokens))
+	assert status._github_stop_token("noise ::aaaaaaaa:: noise\n") == "bbbbbbbb"

--- a/tests/effect/test_status.py
+++ b/tests/effect/test_status.py
@@ -357,13 +357,3 @@ def test_discoverable_via_parse_effects() -> None:
 	assert type(effects[0]).__name__ == "Status"
 	effects2 = parse_effects("(Status(StatusOptions(output_mode='github')),)")
 	assert type(effects2[0]).__name__ == "Status"
-
-
-def test_github_stop_token_retries_on_collision(monkeypatch: pytest.MonkeyPatch) -> None:
-	"""If the first generated token already appears as ``::TOKEN::`` in the body,
-	the picker loops until it finds a clean one. Forces the retry branch."""
-	from camas.effect import status
-
-	tokens = iter(["aaaaaaaa", "bbbbbbbb"])
-	monkeypatch.setattr(status.secrets, "token_hex", lambda _n: next(tokens))
-	assert status._github_stop_token("noise ::aaaaaaaa:: noise\n") == "bbbbbbbb"

--- a/tests/effect/test_status.py
+++ b/tests/effect/test_status.py
@@ -1,0 +1,359 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2026 JP Hutchins
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime
+from typing import TypeVar
+
+import pytest
+
+from camas import Parallel, Sequential, Task
+from camas.core.completion import Finished, Skipped
+from camas.core.effect import Effect
+from camas.core.leaf_state import LeafState, Waiting, next_state
+from camas.core.task_event import CompletedEvent, OutputEvent, StartedEvent, TaskEvent
+from camas.core.traversal import flatten_leaves
+from camas.effect.status import (
+	Active,
+	Done,
+	Idle,
+	Status,
+	StatusOptions,
+)
+
+TS = datetime(2026, 5, 21, 14, 30, 0, 750_000)
+
+T = TypeVar("T")
+
+
+def make_task(name: str) -> Task:
+	return Task(("python", "-c", "pass"), name=name)
+
+
+async def drive(
+	effect: Effect[T],
+	task: Task | Sequential | Parallel,
+	events: list[TaskEvent],
+) -> tuple[T, ...]:
+	"""Feed an effect through its full setup/on_event*/teardown lifecycle."""
+	leaves = flatten_leaves(task)
+	states: list[LeafState] = [Waiting(info.task) for info in leaves]
+	initial = await effect.setup(task)
+	ctxs: list[T] = [initial for _ in leaves]
+	try:
+		for event in events:
+			states[event.leaf_index] = next_state(states[event.leaf_index], event)
+			ctxs[event.leaf_index] = await effect.on_event(event, states, ctxs[event.leaf_index])
+	finally:
+		await effect.teardown(tuple(ctxs))
+	return tuple(ctxs)
+
+
+def test_default_options_pass_failure_through(capsys: pytest.CaptureFixture[str]) -> None:
+	a = make_task("alpha")
+	b = make_task("boom")
+	task = Parallel(a, b)
+	events: list[TaskEvent] = [
+		StartedEvent(a, 0, TS),
+		StartedEvent(b, 1, TS),
+		OutputEvent(a, 0, b"a-out\n", TS),
+		OutputEvent(b, 1, b"\x1b[31mb-error\x1b[0m\n", TS),
+		CompletedEvent(a, 0, Finished(0, 0.1, ()), TS),
+		CompletedEvent(b, 1, Finished(2, 0.2, ()), TS),
+	]
+	asyncio.run(drive(Status(), task, events))
+	out = capsys.readouterr().out
+	assert "▶ [alpha] started" in out
+	assert "▶ [boom] started" in out
+	assert "✓ [alpha] success" in out
+	assert "(0.100s)" in out
+	assert "✗ [boom] error" in out
+	assert "exit=2 (0.200s)" in out
+	assert "\x1b[31mb-error\x1b[0m" in out
+	assert "a-out" not in out
+
+
+def test_all_mode_dumps_every_block(capsys: pytest.CaptureFixture[str]) -> None:
+	a = make_task("alpha")
+	task = Parallel(a)
+	events: list[TaskEvent] = [
+		StartedEvent(a, 0, TS),
+		OutputEvent(a, 0, b"hello\n", TS),
+		CompletedEvent(a, 0, Finished(0, 0.1, ()), TS),
+	]
+	asyncio.run(drive(Status(StatusOptions(output_mode="all")), task, events))
+	out = capsys.readouterr().out
+	assert "✓ [alpha] success" in out
+	assert "hello" in out
+
+
+def test_quiet_mode_drops_output(capsys: pytest.CaptureFixture[str]) -> None:
+	a = make_task("alpha")
+	task = Parallel(a)
+	events: list[TaskEvent] = [
+		StartedEvent(a, 0, TS),
+		OutputEvent(a, 0, b"shhh\n", TS),
+		CompletedEvent(a, 0, Finished(0, 0.1, ()), TS),
+	]
+	ctxs = asyncio.run(drive(Status(StatusOptions(output_mode="quiet")), task, events))
+	out = capsys.readouterr().out
+	assert "▶ [alpha] started" in out
+	assert "✓ [alpha] success" in out
+	assert "shhh" not in out
+	assert ctxs == (Done(),)
+
+
+def test_stream_mode_emits_lines_live_and_strips_ansi(
+	capsys: pytest.CaptureFixture[str],
+) -> None:
+	a = make_task("lint")
+	task = Parallel(a)
+	events: list[TaskEvent] = [
+		StartedEvent(a, 0, TS),
+		OutputEvent(a, 0, b"\x1b[31mred line\x1b[0m\n", TS),
+		OutputEvent(a, 0, b"plain\n", TS),
+		CompletedEvent(a, 0, Finished(0, 0.1, ()), TS),
+	]
+	asyncio.run(drive(Status(StatusOptions(output_mode="stream")), task, events))
+	out = capsys.readouterr().out
+	assert "[lint] red line" in out
+	assert "[lint] plain" in out
+	assert out.count("·\x1b[0m [lint] ") == 2
+
+
+def test_stream_mode_interleaves_across_parallel_tasks(
+	capsys: pytest.CaptureFixture[str],
+) -> None:
+	"""Stream mode emits in arrival order, not grouped by task."""
+	a = make_task("fast")
+	b = make_task("slow")
+	task = Parallel(a, b)
+	events: list[TaskEvent] = [
+		StartedEvent(a, 0, TS),
+		StartedEvent(b, 1, TS),
+		OutputEvent(a, 0, b"a1\n", TS),
+		OutputEvent(b, 1, b"b1\n", TS),
+		OutputEvent(a, 0, b"a2\n", TS),
+		OutputEvent(b, 1, b"b2\n", TS),
+		CompletedEvent(a, 0, Finished(0, 0.1, ()), TS),
+		CompletedEvent(b, 1, Finished(0, 0.2, ()), TS),
+	]
+	asyncio.run(drive(Status(StatusOptions(output_mode="stream")), task, events))
+	out = capsys.readouterr().out
+	a1 = out.index("[fast] a1")
+	b1 = out.index("[slow] b1")
+	a2 = out.index("[fast] a2")
+	b2 = out.index("[slow] b2")
+	assert a1 < b1 < a2 < b2
+
+
+def test_github_mode_wraps_blocks_with_workflow_commands(
+	capsys: pytest.CaptureFixture[str],
+) -> None:
+	a = make_task("test")
+	task = Parallel(a)
+	events: list[TaskEvent] = [
+		StartedEvent(a, 0, TS),
+		OutputEvent(a, 0, b"PASSED 7 tests\n", TS),
+		CompletedEvent(a, 0, Finished(0, 0.4, ()), TS),
+	]
+	asyncio.run(drive(Status(StatusOptions(output_mode="github")), task, events))
+	out = capsys.readouterr().out
+	assert "✓ [test] success" in out
+	assert "::group::test\n" in out
+	assert "PASSED 7 tests" in out
+	assert "::endgroup::\n" in out
+
+
+def test_skipped_emits_skip_line_only(capsys: pytest.CaptureFixture[str]) -> None:
+	first = make_task("first")
+	second = make_task("second")
+	task = Sequential(first, second, name="pipeline")
+	events: list[TaskEvent] = [
+		StartedEvent(first, 0, TS),
+		CompletedEvent(first, 0, Finished(1, 0.1, ()), TS),
+		CompletedEvent(second, 1, Skipped(1), TS),
+	]
+	asyncio.run(drive(Status(StatusOptions(output_mode="all")), task, events))
+	out = capsys.readouterr().out
+	assert "✗ [first] error" in out
+	assert "exit=1" in out
+	assert "⏭ [second] skipped" in out
+	assert "(prior rc=1)" in out
+	assert out.count("::") == 0
+
+
+def test_empty_template_suppresses_line(capsys: pytest.CaptureFixture[str]) -> None:
+	a = make_task("alpha")
+	task = Parallel(a)
+	events: list[TaskEvent] = [
+		StartedEvent(a, 0, TS),
+		CompletedEvent(a, 0, Finished(0, 0.1, ()), TS),
+	]
+	asyncio.run(
+		drive(
+			Status(StatusOptions(started_fmt="", finished_fmt="✓ {name}")),
+			task,
+			events,
+		)
+	)
+	out = capsys.readouterr().out
+	assert "▶" not in out
+	assert "✓ alpha" in out
+
+
+def test_custom_format_string_substitutes_all_fields(
+	capsys: pytest.CaptureFixture[str],
+) -> None:
+	a = Task("ruff check .", name="lint")
+	task = Parallel(a)
+	events: list[TaskEvent] = [
+		StartedEvent(a, 0, TS),
+		CompletedEvent(a, 0, Finished(0, 1.234, ()), TS),
+	]
+	asyncio.run(
+		drive(
+			Status(
+				StatusOptions(
+					started_fmt="{timestamp:%H:%M:%S}.{ms:03d} START {name} [{cmd}]",
+					finished_fmt="OK {name} {elapsed:.3f}s rc={rc}",
+				)
+			),
+			task,
+			events,
+		)
+	)
+	out = capsys.readouterr().out
+	assert "14:30:00.750 START lint [ruff check .]" in out
+	assert "OK lint 1.234s rc=0" in out
+
+
+def test_missing_field_in_template_raises_keyerror() -> None:
+	a = make_task("alpha")
+	task = Parallel(a)
+	events: list[TaskEvent] = [
+		StartedEvent(a, 0, TS),
+	]
+	with pytest.raises(KeyError):
+		asyncio.run(
+			drive(
+				Status(StatusOptions(started_fmt="{name} {elapsed:.2f}")),
+				task,
+				events,
+			)
+		)
+
+
+def test_initial_ctx_is_idle() -> None:
+	async def get_initial() -> object:
+		return await Status().setup(make_task("solo"))
+
+	assert asyncio.run(get_initial()) == Idle()
+
+
+def test_block_modes_buffer_into_active_ctx(capsys: pytest.CaptureFixture[str]) -> None:
+	a = make_task("alpha")
+	task = Parallel(a)
+	events: list[TaskEvent] = [
+		StartedEvent(a, 0, TS),
+		OutputEvent(a, 0, b"one\n", TS),
+		OutputEvent(a, 0, b"two\n", TS),
+	]
+	ctxs = asyncio.run(drive(Status(StatusOptions(output_mode="all")), task, events))
+	assert ctxs == (Active(b"one\ntwo\n"),)
+	out = capsys.readouterr().out
+	assert "▶ [alpha] started" in out
+	assert "one" not in out
+
+
+def test_stale_event_combinations_pass_through() -> None:
+	"""Idle+Output, Active+Started, Done+anything — all should be no-ops on ctx.
+
+	We can't easily drive these through the normal sequencer (which respects the
+	state machine) so we call on_event directly.
+	"""
+	a = make_task("a")
+	effect = Status()
+
+	async def hit_unreachable_branches() -> tuple[object, ...]:
+		states: list[LeafState] = [Waiting(a)]
+		r1 = await effect.on_event(OutputEvent(a, 0, b"x", TS), states, Idle())
+		r2 = await effect.on_event(StartedEvent(a, 0, TS), states, Active(b""))
+		r3 = await effect.on_event(StartedEvent(a, 0, TS), states, Done())
+		return (r1, r2, r3)
+
+	r1, r2, r3 = asyncio.run(hit_unreachable_branches())
+	assert r1 == Idle()
+	assert r2 == Active(b"")
+	assert r3 == Done()
+
+
+def test_creates_no_background_tasks() -> None:
+	task = make_task("solo")
+	events: list[TaskEvent] = [
+		StartedEvent(task, 0, TS),
+		CompletedEvent(task, 0, Finished(0, 0.05, ()), TS),
+	]
+
+	async def count_tasks() -> int:
+		baseline = asyncio.all_tasks()
+		await drive(Status(), task, events)
+		return len(asyncio.all_tasks() - baseline)
+
+	assert asyncio.run(count_tasks()) == 0
+
+
+def test_block_appends_newline_when_output_lacks_one(
+	capsys: pytest.CaptureFixture[str],
+) -> None:
+	a = make_task("alpha")
+	task = Parallel(a)
+	events: list[TaskEvent] = [
+		StartedEvent(a, 0, TS),
+		OutputEvent(a, 0, b"no-trailing-newline", TS),
+		CompletedEvent(a, 0, Finished(2, 0.1, ()), TS),
+	]
+	asyncio.run(drive(Status(StatusOptions(output_mode="errors")), task, events))
+	out = capsys.readouterr().out
+	assert "no-trailing-newline\n" in out
+
+
+def test_errors_mode_skips_block_on_pass(capsys: pytest.CaptureFixture[str]) -> None:
+	a = make_task("ok")
+	task = Parallel(a)
+	events: list[TaskEvent] = [
+		StartedEvent(a, 0, TS),
+		OutputEvent(a, 0, b"all good\n", TS),
+		CompletedEvent(a, 0, Finished(0, 0.1, ()), TS),
+	]
+	asyncio.run(drive(Status(StatusOptions(output_mode="errors")), task, events))
+	out = capsys.readouterr().out
+	assert "✓ [ok] success" in out
+	assert "all good" not in out
+
+
+def test_default_includes_iso_timestamp_with_milliseconds(
+	capsys: pytest.CaptureFixture[str],
+) -> None:
+	a = make_task("solo")
+	task = Parallel(a)
+	events: list[TaskEvent] = [
+		StartedEvent(a, 0, TS),
+		CompletedEvent(a, 0, Finished(0, 0.1, ()), TS),
+	]
+	asyncio.run(drive(Status(), task, events))
+	out = capsys.readouterr().out
+	assert "[2026-05-21 14:30:00.750]" in out
+
+
+def test_discoverable_via_parse_effects() -> None:
+	"""``Status`` should be reachable through the --effects mini-language."""
+	from camas.main.effects import parse_effects
+
+	effects = parse_effects("(Status(),)")
+	assert len(effects) == 1
+	assert type(effects[0]).__name__ == "Status"
+	effects2 = parse_effects("(Status(StatusOptions(output_mode='github')),)")
+	assert type(effects2[0]).__name__ == "Status"

--- a/tests/effect/test_status.py
+++ b/tests/effect/test_status.py
@@ -118,9 +118,9 @@ def test_stream_mode_emits_lines_live_and_strips_ansi(
 	]
 	asyncio.run(drive(Status(StatusOptions(output_mode="stream")), task, events))
 	out = capsys.readouterr().out
-	assert "[lint] red line" in out
-	assert "[lint] plain" in out
-	assert out.count("·\x1b[0m [lint] ") == 2
+	assert "[lint]\x1b[0m red line" in out
+	assert "[lint]\x1b[0m plain" in out
+	assert out.count("· [lint]\x1b[0m ") == 2
 
 
 def test_stream_mode_interleaves_across_parallel_tasks(
@@ -142,10 +142,10 @@ def test_stream_mode_interleaves_across_parallel_tasks(
 	]
 	asyncio.run(drive(Status(StatusOptions(output_mode="stream")), task, events))
 	out = capsys.readouterr().out
-	a1 = out.index("[fast] a1")
-	b1 = out.index("[slow] b1")
-	a2 = out.index("[fast] a2")
-	b2 = out.index("[slow] b2")
+	a1 = out.index("[fast]\x1b[0m a1")
+	b1 = out.index("[slow]\x1b[0m b1")
+	a2 = out.index("[fast]\x1b[0m a2")
+	b2 = out.index("[slow]\x1b[0m b2")
 	assert a1 < b1 < a2 < b2
 
 

--- a/tests/effect/test_summary.py
+++ b/tests/effect/test_summary.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Callable
+from datetime import datetime
 from typing import TypeVar
 
 import pytest
@@ -15,6 +16,8 @@ from camas.core.effect import Effect
 from camas.core.leaf_state import LeafState, Waiting
 from camas.core.task_event import CompletedEvent, StartedEvent, TaskEvent
 from camas.effect.summary import Fixed, Summary, SummaryOptions
+
+TS = datetime(2026, 5, 21, 14, 30, 0)
 
 T = TypeVar("T")
 
@@ -49,10 +52,10 @@ def test_summary_renders_only_at_teardown(capsys: pytest.CaptureFixture[str]) ->
 	b = make_task("beta")
 	task = Parallel(a, b)
 	events: list[TaskEvent] = [
-		StartedEvent(a, 0, 100.0),
-		StartedEvent(b, 1, 100.0),
-		CompletedEvent(a, 0, Finished(0, 0.1, (b"clean\n",))),
-		CompletedEvent(b, 1, Finished(0, 0.2, (b"ok\n",))),
+		StartedEvent(a, 0, TS),
+		StartedEvent(b, 1, TS),
+		CompletedEvent(a, 0, Finished(0, 0.1, (b"clean\n",)), TS),
+		CompletedEvent(b, 1, Finished(0, 0.2, (b"ok\n",)), TS),
 	]
 
 	async def run_and_capture() -> tuple[str, str]:
@@ -83,8 +86,8 @@ def test_summary_failure_prints_details(capsys: pytest.CaptureFixture[str]) -> N
 	a = make_task("boom")
 	task = Parallel(a)
 	events: list[TaskEvent] = [
-		StartedEvent(a, 0, 100.0),
-		CompletedEvent(a, 0, Finished(1, 0.1, (b"error details\n",))),
+		StartedEvent(a, 0, TS),
+		CompletedEvent(a, 0, Finished(1, 0.1, (b"error details\n",)), TS),
 	]
 	asyncio.run(drive(Summary(SummaryOptions()), task, events))
 	out = capsys.readouterr().out
@@ -98,9 +101,9 @@ def test_summary_sequential_skipped(capsys: pytest.CaptureFixture[str]) -> None:
 	b = make_task("second")
 	task = Sequential(a, b, name="pipeline")
 	events: list[TaskEvent] = [
-		StartedEvent(a, 0, 100.0),
-		CompletedEvent(a, 0, Finished(1, 0.1, (b"failed\n",))),
-		CompletedEvent(b, 1, Skipped(1)),
+		StartedEvent(a, 0, TS),
+		CompletedEvent(a, 0, Finished(1, 0.1, (b"failed\n",)), TS),
+		CompletedEvent(b, 1, Skipped(1), TS),
 	]
 	asyncio.run(drive(Summary(SummaryOptions()), task, events))
 	out = capsys.readouterr().out
@@ -123,10 +126,10 @@ def test_summary_show_passing_prints_passed_output(capsys: pytest.CaptureFixture
 	b = make_task("beta")
 	task = Parallel(a, b)
 	events: list[TaskEvent] = [
-		StartedEvent(a, 0, 100.0),
-		StartedEvent(b, 1, 100.0),
-		CompletedEvent(a, 0, Finished(0, 0.1, (b"alpha output\n",))),
-		CompletedEvent(b, 1, Finished(1, 0.2, (b"beta error\n",))),
+		StartedEvent(a, 0, TS),
+		StartedEvent(b, 1, TS),
+		CompletedEvent(a, 0, Finished(0, 0.1, (b"alpha output\n",)), TS),
+		CompletedEvent(b, 1, Finished(1, 0.2, (b"beta error\n",)), TS),
 	]
 	asyncio.run(drive(Summary(SummaryOptions(show_passing=True)), task, events))
 	out = capsys.readouterr().out
@@ -140,8 +143,8 @@ def test_summary_show_passing_defaults_to_false(capsys: pytest.CaptureFixture[st
 	a = make_task("alpha")
 	task = Parallel(a)
 	events: list[TaskEvent] = [
-		StartedEvent(a, 0, 100.0),
-		CompletedEvent(a, 0, Finished(0, 0.1, (b"alpha output\n",))),
+		StartedEvent(a, 0, TS),
+		CompletedEvent(a, 0, Finished(0, 0.1, (b"alpha output\n",)), TS),
 	]
 	asyncio.run(drive(Summary(SummaryOptions()), task, events))
 	out = capsys.readouterr().out
@@ -151,8 +154,8 @@ def test_summary_show_passing_defaults_to_false(capsys: pytest.CaptureFixture[st
 def test_summary_creates_no_background_tasks() -> None:
 	task = make_task("solo")
 	events: list[TaskEvent] = [
-		StartedEvent(task, 0, 100.0),
-		CompletedEvent(task, 0, Finished(0, 0.05, (b"done\n",))),
+		StartedEvent(task, 0, TS),
+		CompletedEvent(task, 0, Finished(0, 0.05, (b"done\n",)), TS),
 	]
 
 	async def count_tasks_after_teardown() -> int:

--- a/tests/effect/test_termtree.py
+++ b/tests/effect/test_termtree.py
@@ -70,7 +70,7 @@ def test_render_frame_all_waiting_shows_group_header_and_wait_cells(
 	tree = Parallel(make_task("a"), make_task("b"), name="root")
 	rows = flatten_rows(tree)
 	states: tuple[LeafState, ...] = (Waiting(make_task("a")), Waiting(make_task("b")))
-	frame = render_frame(rows, states, term_width=80, display_width=60, now=TS, wall_start=TS)
+	frame = render_frame(rows, states, term_width=80, display_width=60, now=TS, wall_elapsed=0.0)
 	assert "root" in frame
 	assert "WAIT" in frame
 
@@ -86,7 +86,7 @@ def test_render_frame_mixed_states() -> None:
 		Running(b, TS, b"working..."),
 		Completed(c, Skipped(1)),
 	)
-	frame = render_frame(rows, states, term_width=80, display_width=60, now=TS, wall_start=TS)
+	frame = render_frame(rows, states, term_width=80, display_width=60, now=TS, wall_elapsed=0.0)
 	assert "PASS" in frame
 	assert "SKIP" in frame
 	assert "all clean" in frame
@@ -97,7 +97,7 @@ def test_render_frame_failure_summary() -> None:
 	tree = Parallel(a)
 	rows = flatten_rows(tree)
 	states: tuple[LeafState, ...] = (Completed(a, Finished(1, 0.1, (b"boom\n",))),)
-	frame = render_frame(rows, states, term_width=80, display_width=60, now=TS, wall_start=TS)
+	frame = render_frame(rows, states, term_width=80, display_width=60, now=TS, wall_elapsed=0.0)
 	assert "FAIL" in frame
 
 
@@ -264,7 +264,7 @@ def test_render_lines_never_exceed_term_width_for_long_matrix_names(
 	rows = flatten_rows(tree)
 	display_width = term_width - STATUS_COL_WIDTH - 1
 	states: tuple[LeafState, ...] = (state_factory(long_task),)
-	lines = render_lines(rows, states, term_width, display_width, TS, TS)
+	lines = render_lines(rows, states, term_width, display_width, TS, 0.0)
 	for line in lines:
 		assert visible_width(line) < term_width, (
 			f"line {visible_width(line)} chars exceeds term_width {term_width}: {line!r}"
@@ -285,7 +285,7 @@ def test_render_lines_strips_ansi_from_done_tail() -> None:
 	states: tuple[LeafState, ...] = (
 		Completed(task, Finished(0, 0.1, (b"\x1b[38;5;214mcolored\x1b[0m\n",))),
 	)
-	lines = render_lines(rows, states, term_width=120, display_width=100, now=TS, wall_start=TS)
+	lines = render_lines(rows, states, term_width=120, display_width=100, now=TS, wall_elapsed=0.0)
 	combined = "".join(lines)
 	assert "\x1b[38;5;214m" not in combined
 	assert "colored" in ANSI_ESCAPE_PATTERN.sub("", combined)
@@ -295,7 +295,7 @@ def test_render_lines_strips_ansi_from_running_tail() -> None:
 	task = make_task("a")
 	rows = flatten_rows(Parallel(task))
 	states: tuple[LeafState, ...] = (Running(task, TS, b"\x1b[38;5;214mbuilding\x1b[0m"),)
-	lines = render_lines(rows, states, term_width=120, display_width=100, now=TS, wall_start=TS)
+	lines = render_lines(rows, states, term_width=120, display_width=100, now=TS, wall_elapsed=0.0)
 	combined = "".join(lines)
 	assert "\x1b[38;5;214m" not in combined
 	assert "building" in ANSI_ESCAPE_PATTERN.sub("", combined)
@@ -307,7 +307,7 @@ def test_render_lines_preserves_full_name_when_it_fits() -> None:
 	tree = Parallel(task)
 	rows = flatten_rows(tree)
 	states: tuple[LeafState, ...] = (Completed(task, Finished(0, 0.1, (b"All checks passed!\n",))),)
-	lines = render_lines(rows, states, term_width=120, display_width=100, now=TS, wall_start=TS)
+	lines = render_lines(rows, states, term_width=120, display_width=100, now=TS, wall_elapsed=0.0)
 	leaf_line = next(ln for ln in lines if "PASS" in ln)
 	plain = ANSI_ESCAPE_PATTERN.sub("", leaf_line).lstrip("\r")
 	assert "uv run ruff check ." in plain
@@ -324,7 +324,7 @@ def test_render_lines_truncates_name_only_when_it_cannot_fit() -> None:
 	tree = Parallel(long_task)
 	rows = flatten_rows(tree)
 	states: tuple[LeafState, ...] = (Completed(long_task, Finished(0, 0.1, (b"built\n",))),)
-	lines = render_lines(rows, states, term_width=60, display_width=41, now=TS, wall_start=TS)
+	lines = render_lines(rows, states, term_width=60, display_width=41, now=TS, wall_elapsed=0.0)
 	leaf_line = next(ln for ln in lines if "PASS" in ln)
 	plain = ANSI_ESCAPE_PATTERN.sub("", leaf_line).lstrip("\r")
 	assert "..." in plain
@@ -336,7 +336,7 @@ def test_render_lines_stream_uses_only_leftover_space() -> None:
 	tree = Parallel(task)
 	rows = flatten_rows(tree)
 	states: tuple[LeafState, ...] = (Completed(task, Finished(0, 0.1, (b"shouldnt appear\n",))),)
-	lines = render_lines(rows, states, term_width=60, display_width=41, now=TS, wall_start=TS)
+	lines = render_lines(rows, states, term_width=60, display_width=41, now=TS, wall_elapsed=0.0)
 	leaf_line = next(ln for ln in lines if "PASS" in ln)
 	plain = ANSI_ESCAPE_PATTERN.sub("", leaf_line).lstrip("\r")
 	assert "shouldnt appear" not in plain

--- a/tests/effect/test_termtree.py
+++ b/tests/effect/test_termtree.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import asyncio
 import re
 from collections.abc import Callable
+from datetime import datetime
 from typing import TypeVar
 
 import pytest
@@ -25,6 +26,8 @@ from camas.effect.termtree import (
 	render_frame,
 	render_lines,
 )
+
+TS = datetime(2026, 5, 21, 14, 30, 0)
 
 ANSI_ESCAPE_PATTERN = re.compile(r"\x1b\[[0-9;?]*[a-zA-Z]")
 
@@ -67,7 +70,7 @@ def test_render_frame_all_waiting_shows_group_header_and_wait_cells(
 	tree = Parallel(make_task("a"), make_task("b"), name="root")
 	rows = flatten_rows(tree)
 	states: tuple[LeafState, ...] = (Waiting(make_task("a")), Waiting(make_task("b")))
-	frame = render_frame(rows, states, term_width=80, display_width=60, now=100.0, wall_start=100.0)
+	frame = render_frame(rows, states, term_width=80, display_width=60, now=TS, wall_start=TS)
 	assert "root" in frame
 	assert "WAIT" in frame
 
@@ -80,10 +83,10 @@ def test_render_frame_mixed_states() -> None:
 	rows = flatten_rows(tree)
 	states: tuple[LeafState, ...] = (
 		Completed(a, Finished(0, 0.1, (b"all clean\n",))),
-		Running(b, 100.0, b"working..."),
+		Running(b, TS, b"working..."),
 		Completed(c, Skipped(1)),
 	)
-	frame = render_frame(rows, states, term_width=80, display_width=60, now=100.5, wall_start=100.0)
+	frame = render_frame(rows, states, term_width=80, display_width=60, now=TS, wall_start=TS)
 	assert "PASS" in frame
 	assert "SKIP" in frame
 	assert "all clean" in frame
@@ -94,7 +97,7 @@ def test_render_frame_failure_summary() -> None:
 	tree = Parallel(a)
 	rows = flatten_rows(tree)
 	states: tuple[LeafState, ...] = (Completed(a, Finished(1, 0.1, (b"boom\n",))),)
-	frame = render_frame(rows, states, term_width=80, display_width=60, now=100.5, wall_start=100.0)
+	frame = render_frame(rows, states, term_width=80, display_width=60, now=TS, wall_start=TS)
 	assert "FAIL" in frame
 
 
@@ -133,10 +136,10 @@ def test_termtree_show_passing_prints_passed_output(
 	b = make_task("b")
 	task = Parallel(a, b)
 	events: list[TaskEvent] = [
-		StartedEvent(a, 0, 100.0),
-		StartedEvent(b, 1, 100.0),
-		CompletedEvent(a, 0, Finished(0, 0.1, (b"first output\n",))),
-		CompletedEvent(b, 1, Finished(0, 0.2, (b"second output\n",))),
+		StartedEvent(a, 0, TS),
+		StartedEvent(b, 1, TS),
+		CompletedEvent(a, 0, Finished(0, 0.1, (b"first output\n",)), TS),
+		CompletedEvent(b, 1, Finished(0, 0.2, (b"second output\n",)), TS),
 	]
 	asyncio.run(
 		drive(
@@ -158,8 +161,8 @@ def test_termtree_show_passing_defaults_to_false(
 	a = make_task("a")
 	task = Parallel(a)
 	events: list[TaskEvent] = [
-		StartedEvent(a, 0, 100.0),
-		CompletedEvent(a, 0, Finished(0, 0.1, (b"quiet\n",))),
+		StartedEvent(a, 0, TS),
+		CompletedEvent(a, 0, Finished(0, 0.1, (b"quiet\n",)), TS),
 	]
 	asyncio.run(drive(Termtree(TermtreeOptions(frame_interval_ms=50)), task, events))
 	captured = capsys.readouterr()
@@ -173,11 +176,11 @@ def test_termtree_effect_consumes_events_and_renders(
 	b = make_task("b")
 	task = Parallel(a, b)
 	events: list[TaskEvent] = [
-		StartedEvent(a, 0, 100.0),
-		StartedEvent(b, 1, 100.0),
-		OutputEvent(a, 0, b"line from a\n", 100.05),
-		CompletedEvent(a, 0, Finished(0, 0.1, (b"line from a\n",))),
-		CompletedEvent(b, 1, Finished(1, 0.2, (b"boom\n",))),
+		StartedEvent(a, 0, TS),
+		StartedEvent(b, 1, TS),
+		OutputEvent(a, 0, b"line from a\n", TS),
+		CompletedEvent(a, 0, Finished(0, 0.1, (b"line from a\n",)), TS),
+		CompletedEvent(b, 1, Finished(1, 0.2, (b"boom\n",)), TS),
 	]
 	asyncio.run(drive(Termtree(TermtreeOptions(frame_interval_ms=50)), task, events))
 	captured = capsys.readouterr()
@@ -194,7 +197,7 @@ def test_termtree_frame_tick_keeps_spinner_alive_between_events() -> None:
 		# Idle for long enough that several ticks fire while nothing is happening.
 		await asyncio.sleep(0.08)
 		ctx = await effect.on_event(
-			CompletedEvent(task, 0, Finished(0, 0.08, (b"done\n",))),
+			CompletedEvent(task, 0, Finished(0, 0.08, (b"done\n",)), TS),
 			(Completed(task, Finished(0, 0.08, (b"done\n",))),),
 			ctx,
 		)
@@ -214,9 +217,9 @@ def test_termtree_effect_handles_groups_and_skipped(
 	b = make_task("b")
 	task = Sequential(a, b, name="pipeline")
 	events: list[TaskEvent] = [
-		StartedEvent(a, 0, 100.0),
-		CompletedEvent(a, 0, Finished(1, 0.1, (b"failed\n",))),
-		CompletedEvent(b, 1, Skipped(1)),
+		StartedEvent(a, 0, TS),
+		CompletedEvent(a, 0, Finished(1, 0.1, (b"failed\n",)), TS),
+		CompletedEvent(b, 1, Skipped(1), TS),
 	]
 	asyncio.run(drive(Termtree(TermtreeOptions(frame_interval_ms=50)), task, events))
 	captured = capsys.readouterr()
@@ -232,7 +235,7 @@ def _waiting(t: Task) -> LeafState:
 
 
 def _running(t: Task) -> LeafState:
-	return Running(t, 100.0, b"working on it")
+	return Running(t, TS, b"working on it")
 
 
 def _done(t: Task) -> LeafState:
@@ -261,7 +264,7 @@ def test_render_lines_never_exceed_term_width_for_long_matrix_names(
 	rows = flatten_rows(tree)
 	display_width = term_width - STATUS_COL_WIDTH - 1
 	states: tuple[LeafState, ...] = (state_factory(long_task),)
-	lines = render_lines(rows, states, term_width, display_width, 100.5, 100.0)
+	lines = render_lines(rows, states, term_width, display_width, TS, TS)
 	for line in lines:
 		assert visible_width(line) < term_width, (
 			f"line {visible_width(line)} chars exceeds term_width {term_width}: {line!r}"
@@ -282,9 +285,7 @@ def test_render_lines_strips_ansi_from_done_tail() -> None:
 	states: tuple[LeafState, ...] = (
 		Completed(task, Finished(0, 0.1, (b"\x1b[38;5;214mcolored\x1b[0m\n",))),
 	)
-	lines = render_lines(
-		rows, states, term_width=120, display_width=100, now=100.5, wall_start=100.0
-	)
+	lines = render_lines(rows, states, term_width=120, display_width=100, now=TS, wall_start=TS)
 	combined = "".join(lines)
 	assert "\x1b[38;5;214m" not in combined
 	assert "colored" in ANSI_ESCAPE_PATTERN.sub("", combined)
@@ -293,10 +294,8 @@ def test_render_lines_strips_ansi_from_done_tail() -> None:
 def test_render_lines_strips_ansi_from_running_tail() -> None:
 	task = make_task("a")
 	rows = flatten_rows(Parallel(task))
-	states: tuple[LeafState, ...] = (Running(task, 100.0, b"\x1b[38;5;214mbuilding\x1b[0m"),)
-	lines = render_lines(
-		rows, states, term_width=120, display_width=100, now=100.5, wall_start=100.0
-	)
+	states: tuple[LeafState, ...] = (Running(task, TS, b"\x1b[38;5;214mbuilding\x1b[0m"),)
+	lines = render_lines(rows, states, term_width=120, display_width=100, now=TS, wall_start=TS)
 	combined = "".join(lines)
 	assert "\x1b[38;5;214m" not in combined
 	assert "building" in ANSI_ESCAPE_PATTERN.sub("", combined)
@@ -308,9 +307,7 @@ def test_render_lines_preserves_full_name_when_it_fits() -> None:
 	tree = Parallel(task)
 	rows = flatten_rows(tree)
 	states: tuple[LeafState, ...] = (Completed(task, Finished(0, 0.1, (b"All checks passed!\n",))),)
-	lines = render_lines(
-		rows, states, term_width=120, display_width=100, now=100.5, wall_start=100.0
-	)
+	lines = render_lines(rows, states, term_width=120, display_width=100, now=TS, wall_start=TS)
 	leaf_line = next(ln for ln in lines if "PASS" in ln)
 	plain = ANSI_ESCAPE_PATTERN.sub("", leaf_line).lstrip("\r")
 	assert "uv run ruff check ." in plain
@@ -327,7 +324,7 @@ def test_render_lines_truncates_name_only_when_it_cannot_fit() -> None:
 	tree = Parallel(long_task)
 	rows = flatten_rows(tree)
 	states: tuple[LeafState, ...] = (Completed(long_task, Finished(0, 0.1, (b"built\n",))),)
-	lines = render_lines(rows, states, term_width=60, display_width=41, now=100.5, wall_start=100.0)
+	lines = render_lines(rows, states, term_width=60, display_width=41, now=TS, wall_start=TS)
 	leaf_line = next(ln for ln in lines if "PASS" in ln)
 	plain = ANSI_ESCAPE_PATTERN.sub("", leaf_line).lstrip("\r")
 	assert "..." in plain
@@ -339,7 +336,7 @@ def test_render_lines_stream_uses_only_leftover_space() -> None:
 	tree = Parallel(task)
 	rows = flatten_rows(tree)
 	states: tuple[LeafState, ...] = (Completed(task, Finished(0, 0.1, (b"shouldnt appear\n",))),)
-	lines = render_lines(rows, states, term_width=60, display_width=41, now=100.5, wall_start=100.0)
+	lines = render_lines(rows, states, term_width=60, display_width=41, now=TS, wall_start=TS)
 	leaf_line = next(ln for ln in lines if "PASS" in ln)
 	plain = ANSI_ESCAPE_PATTERN.sub("", leaf_line).lstrip("\r")
 	assert "shouldnt appear" not in plain

--- a/tests/main/test_effects.py
+++ b/tests/main/test_effects.py
@@ -48,7 +48,7 @@ def test_parse_effects_rejects_non_effect_value() -> None:
 def test_discover_effects_returns_builtin_set() -> None:
 	constructors, effects = discover_effects()
 	names = {n for n, _ in effects}
-	assert names == {"Summary", "Termtree", "GitHubChecks"}
+	assert names == {"Summary", "Termtree", "GitHubChecks", "Status"}
 	assert "SummaryOptions" in constructors
 	assert "Auto" in constructors
 	assert "Fixed" in constructors

--- a/tests/main/test_mypyc.py
+++ b/tests/main/test_mypyc.py
@@ -34,7 +34,7 @@ def test_signature_fields_from_source_regular_class() -> None:
 	assert name == "options"
 	assert "SummaryOptions" in str(annot)
 	assert SummaryOptions.__name__ in str(annot)
-	assert default is None
+	assert default == SummaryOptions()
 
 
 def test_signature_fields_from_source_module_not_loaded() -> None:

--- a/tests/main/test_mypyc.py
+++ b/tests/main/test_mypyc.py
@@ -232,6 +232,25 @@ def test_resolve_in_namespace_falls_back_to_string() -> None:
 	assert resolve_in_namespace(node, {}) == "undefined_name_xyz"
 
 
+def test_signature_fields_falls_back_when_inspect_signature_raises(
+	monkeypatch: pytest.MonkeyPatch,
+) -> None:
+	"""When ``inspect.signature`` raises (the mypyc fingerprint for compiled
+	classes whose ``__init__`` is a C function with no inspectable signature),
+	``signature_fields`` falls through to the source-parse path."""
+	import inspect as _inspect
+
+	from camas.effect.summary import Summary
+
+	def boom(*_a: object, **_kw: object) -> _inspect.Signature:
+		raise ValueError("no signature")
+
+	monkeypatch.setattr(_inspect, "signature", boom)
+	out = signature_fields(Summary)
+	annot = next(annot for n, _, annot, _ in out if n == "options")
+	assert "SummaryOptions" in str(annot)
+
+
 def test_signature_fields_namedtuple_unresolvable_hints(
 	monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
Streams plain-text per-task status lines with ISO timestamps, millisecond precision, and ANSI-colored glyph/word per state (▶ started, ✓ success, ✗ error, ⏭ skipped, · output).

output_mode picks what happens to captured stdout/stderr: quiet, all, errors (default), stream, or github (collapsed ::group::/::endgroup:: blocks).

camas auto-detects GITHUB_ACTIONS=true and defaults --effects to (Status(StatusOptions(output_mode="github")),) so the PR log gets collapsed groups out of the box; --effects='(Termtree(),)' opts back in to the live tree.

Wall-clock event timestamps now flow through the event system as datetime; Finished.elapsed and RunResult.elapsed still use perf_counter for monotonic accuracy. Subprocess env gains PYTHONUNBUFFERED=1 so Python children stream stdout line-by-line into the pipe instead of bursting at exit. strip_ansi handles ISO-2022 charset designations (\x1b(B) so mypy's trailing (B no longer leaks.

README CI section rewritten around Status; new status-modes-demo job exercises each mode in a matrix for visual comparison.