### PR TITLE
PoC: isolate camas matrix cells in git worktrees (fixes pyrefly fs race)

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -26,10 +26,37 @@ nix = Task("nix flake check --all-systems --print-build-logs")
 all = Sequential(fix, Parallel(typecheck, coverage))
 check = Parallel(format_check, lint, typecheck, test)
 
+# Per-cell filesystem isolation. This is a rare workaround, NOT something camas
+# requires — the matrix / cwd / env primitives below are general; we just
+# compose them here to dodge one flaky type-checker.
+#
+# `check` runs five type-checkers, and the matrix fans it across six Python
+# versions in parallel: ~6 `uv sync`s and ~30 checkers pound ONE working tree at
+# once. pyrefly globs `**/*.py*` over the whole tree and intermittently reads a
+# file that a sibling cell's `uv sync` is mid-way through deleting under its
+# `.venv`, dying with "No such file or directory (os error 2)" and flaking CI.
+# That race is pyrefly's, not ours; the fix is simply to stop sharing the tree.
+#
+# So each cell runs in a throwaway `git worktree` — a sibling dir holding only
+# tracked files, with its own `.venv` — and no two cells ever touch the same
+# path. `rm -rf` then `add --force` is idempotent and safe to run concurrently
+# across cells (no `git worktree prune`, which would race a sibling mid-rebuild).
+# Worktrees check out HEAD, so commit locally before running the matrix if you
+# want it to cover your working changes.
+#
+# The dir name has no leading dot on purpose: pyrefly skips hidden directories,
+# so a `.`-prefixed worktree silently matches zero files and "passes" vacuously.
+_worktree = "../camas-matrix/{PY}"
+
 matrix = Sequential(
-	Task("uv sync"),
-	check,
-	env={"UV_PROJECT_ENVIRONMENT": ".venv-{PY}", "UV_PYTHON": "{PY}"},
+	Task(f"rm -rf {_worktree}"),
+	Task(f"git worktree add --force --detach {_worktree} HEAD"),
+	Sequential(
+		Task("uv sync"),
+		check,
+		cwd=_worktree,
+		env={"UV_PYTHON": "{PY}"},
+	),
 	matrix={
 		"PY": tuple(
 			stripped


### PR DESCRIPTION
**Draft / PoC for review.** Fixes the recurring `example (ubuntu-latest)` CI flake. `tasks.py`-only — no library change.

## The flake

From the failing run (`example` job, `uv run camas matrix`):

```
✗ [pyrefly [PY=3.12]] error exit=1
When resolving pattern `…/camas/**/*.py*`: attempting to read
`…/camas/.venv-3.10/lib/python3.10/site-packages/zuban-0.7.0.data`
resulted in an error: No such file or directory (os error 2)
```

## Root cause — a cross-cell filesystem race

`matrix` fans `check` (five type-checkers) across six Python versions **in parallel, all in one working tree**. pyrefly globs `**/*.py*` over the *whole* tree (it applies `project-excludes` only *after* the walk), so while the `PY=3.10` cell's `uv sync` is creating/removing wheel-staging files under `.venv-3.10`, the `PY=3.12` cell's pyrefly walks into that sibling venv and trips over a file that vanished mid-walk → `os error 2` → the matrix fails. It's non-deterministic because it depends on which cell's `uv sync` overlaps which cell's pyrefly. The bug is pyrefly's; the trigger is the shared tree.

## The fix

Each cell runs in its own throwaway **`git worktree`** — a sibling dir with only tracked files and its own `.venv` — so no two cells ever touch the same path:

```python
matrix = Sequential(
    Task(f"rm -rf {_worktree}"),
    Task(f"git worktree add --force --detach {_worktree} HEAD"),
    Sequential(Task("uv sync"), check, cwd=_worktree, env={"UV_PYTHON": "{PY}"}),
    matrix={"PY": (...)},
)
```

This is pure composition of camas's existing `matrix` / `cwd` / `env` primitives (`{PY}` substitutes into `cwd` and the worktree paths). **Nothing in the library changed** — camas doesn't grow an isolation feature to paper over a type-checker's defect. The `tasks.py` comment says so explicitly, so nobody mistakes this for a pattern camas users need.

Why `git worktree` (not a copy): `worktree add` materializes only tracked files and shares the object store, so it sidesteps `tests/` build junk (~GBs of `node_modules`/`target` locally) and is near-instant. `rm -rf` + `add --force` (no `git worktree prune`, which would race a sibling mid-rebuild) is idempotent and concurrency-safe.

## Validation (local)

- `camas matrix --PY 3.13,3.14` → both cells pass concurrently, **pyrefly ✓ in both**, exit 0; two independent worktrees, each with its own `.venv`.
- Confirmed a tree-walk inside one cell's worktree cannot reach a sibling cell's churning `.venv` (the race is now structurally impossible).
- Caught & fixed a gotcha: a `.`-prefixed worktree dir makes pyrefly skip **all** files (hidden-dir rule) and "pass" vacuously — the dir name is deliberately dot-free.

## Notes for review

- **No PyPI release needed.** CI runs `uv run camas` from the checked-out source, so this is live on the branch's CI immediately — independent of the PyPI block.
- Worktrees check out **HEAD**: locally, commit before running the matrix to cover working changes (documented in `tasks.py`).
- POSIX `rm -rf`; `matrix` is already non-Windows (the Windows leg uses a separate inline expression). That inline leg is **unchanged** here — making Windows use `camas matrix` too (or replicating the worktree dance inline) is a possible follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)