### PR TITLE
Drive the CLI from an argtree Cli spec (argtree 0.1.2)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -18,6 +18,24 @@
 
       version = "0.0.0+${self.shortRev or self.dirtyShortRev or "unknown"}";
 
+      # argtree isn't in nixpkgs yet; add it to every python package set so
+      # nix/package.nix can depend on it as plain `python3Packages.argtree`
+      # (the form a future nixpkgs build will use). Drop once it lands upstream.
+      argtreeOverlay = final: prev: {
+        pythonPackagesExtensions = prev.pythonPackagesExtensions ++ [
+          (pyfinal: pyprev: {
+            argtree = pyfinal.callPackage ./nix/argtree.nix { };
+          })
+        ];
+      };
+
+      pkgsFor =
+        system:
+        import nixpkgs {
+          inherit system;
+          overlays = [ argtreeOverlay ];
+        };
+
       mkCamas =
         pkgs: args:
         pkgs.callPackage ./nix/package.nix (
@@ -32,7 +50,7 @@
       packages = forAllSystems (
         system:
         let
-          pkgs = nixpkgs.legacyPackages.${system};
+          pkgs = pkgsFor system;
         in
         {
           default = mkCamas pkgs { };
@@ -104,7 +122,7 @@
                 nativeBuildInputs = [ pkgs.nixfmt ];
               }
               ''
-                nixfmt --check ${./flake.nix} ${./nix/package.nix}
+                nixfmt --check ${./flake.nix} ${./nix/package.nix} ${./nix/argtree.nix}
                 touch $out
               '';
 

--- a/nix/argtree.nix
+++ b/nix/argtree.nix
@@ -1,0 +1,42 @@
+# argtree — JP Hutchins's typed/declarative argparse layer that camas depends on
+# at runtime (see camas.main.parser). Not yet in nixpkgs (first released 2026-05),
+# so the flake packages it out of tree and injects it into python3Packages via an
+# overlay (see flake.nix). Drop this file and the overlay once argtree is in nixpkgs.
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  hatchling,
+  hatch-vcs,
+}:
+
+buildPythonPackage rec {
+  pname = "argtree";
+  version = "0.1.2";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-qRu68JO/Jt0D86h7aTIXWw1vj9AuBUVMbqoIuvLxgNE=";
+  };
+
+  # hatch-vcs reads the version from the sdist's baked PKG-INFO (no .git needed).
+  build-system = [
+    hatchling
+    hatch-vcs
+  ];
+
+  # No runtime dependencies. Upstream's test suite dev-depends on camas — which
+  # depends on argtree — so running it here would be a build cycle; skip it and
+  # rely on the import check.
+  doCheck = false;
+
+  pythonImportsCheck = [ "argtree" ];
+
+  meta = {
+    description = "Typed, declarative, faithful argparse: a command is a dataclass/NamedTuple tree";
+    homepage = "https://github.com/JPHutchins/argtree";
+    changelog = "https://github.com/JPHutchins/argtree/releases";
+    license = lib.licenses.mit;
+  };
+}

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -33,9 +33,11 @@ python3Packages.buildPythonApplication {
     mypy
   ];
 
-  dependencies =
-    lib.optionals (lib.elem "github_checks" extras) [ python3Packages.httpx ]
-    ++ lib.optionals (lib.elem "check" extras) [ python3Packages.ty ];
+  dependencies = [
+    python3Packages.argtree
+  ]
+  ++ lib.optionals (lib.elem "github_checks" extras) [ python3Packages.httpx ]
+  ++ lib.optionals (lib.elem "check" extras) [ python3Packages.ty ];
 
   nativeCheckInputs = with python3Packages; [
     pytestCheckHook

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,10 +6,11 @@ license = "MIT"
 authors = [{ name = "JP Hutchins", email = "jphutchins@gmail.com" }]
 requires-python = ">=3.10"
 dependencies = [
-"exceptiongroup>=1.2,<2; python_version < '3.11'",
-"taskgroup>=0.2,<1; python_version < '3.11'",
-"tomli>=2,<3; python_version < '3.11'",
-"typing_extensions>=4.12,<5; python_version < '3.11'",
+    "argtree>=0.1,<1",
+    "exceptiongroup>=1.2,<2; python_version < '3.11'",
+    "taskgroup>=0.2,<1; python_version < '3.11'",
+    "tomli>=2,<3; python_version < '3.11'",
+    "typing_extensions>=4.12,<5; python_version < '3.11'",
 ]
 dynamic = ["version"]
 keywords = [
@@ -53,6 +54,10 @@ requires = [
 "setuptools>=68",
 "setuptools-scm>=8",
 "mypy[mypyc]>=1.19",
+# argtree backs camas.main.parser's CLI spec; the compiled dispatch.py imports
+# it, so mypy must resolve it in the isolated build env even though parser.py
+# itself stays interpreted (see _main_excluded in setup.py).
+"argtree>=0.1,<1",
 "exceptiongroup>=1.2; python_version < '3.11'",
 "taskgroup>=0.2; python_version < '3.11'",
 "tomli>=2; python_version < '3.11'",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ license = "MIT"
 authors = [{ name = "JP Hutchins", email = "jphutchins@gmail.com" }]
 requires-python = ">=3.10"
 dependencies = [
-    "argtree>=0.1,<1",
+    "argtree>=0.1.2,<1",
     "exceptiongroup>=1.2,<2; python_version < '3.11'",
     "taskgroup>=0.2,<1; python_version < '3.11'",
     "tomli>=2,<3; python_version < '3.11'",
@@ -56,8 +56,9 @@ requires = [
 "mypy[mypyc]>=1.19",
 # argtree backs camas.main.parser's CLI spec; the compiled dispatch.py imports
 # it, so mypy must resolve it in the isolated build env even though parser.py
-# itself stays interpreted (see _main_excluded in setup.py).
-"argtree>=0.1,<1",
+# itself stays interpreted (see _main_excluded in setup.py). >=0.1.2 for the
+# parser_class= kwarg that parser.py uses.
+"argtree>=0.1.2,<1",
 "exceptiongroup>=1.2; python_version < '3.11'",
 "taskgroup>=0.2; python_version < '3.11'",
 "tomli>=2; python_version < '3.11'",

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,9 @@ if use_mypyc:
 	# in the isolated build env, so mypy/mypyc compilation can't resolve it.
 	# check.py and state.py stay interpreted: mypyc's NamedTuple codegen rejects
 	# the built-in ``Exception`` as a field type (KeyError: 'Exception' at import).
-	_main_excluded = {"check.py", "state.py"}
+	# parser.py stays interpreted: its ``Cli`` argtree spec is parsed at runtime
+	# via ``typing.get_type_hints``, which mypyc's annotation erasure defeats.
+	_main_excluded = {"check.py", "state.py", "parser.py"}
 	ext_modules = mypycify(
 		[
 			*(

--- a/src/camas/main/dispatch.py
+++ b/src/camas/main/dispatch.py
@@ -32,7 +32,7 @@ from .format import (
 	print_task_trees,
 	print_tree,
 )
-from .parser import RESERVED_FLAGS, build_parser
+from .parser import RESERVED_FLAGS, build_parser, default_effects_expr, reconstruct
 from .state import EMPTY_STATE, LoadErr, LoadOk, TasksState
 from .tasks import load_tasks, load_tasks_from_py, name_scope_bindings, name_scope_effects
 
@@ -110,20 +110,20 @@ def dispatch(state: TasksState, argv: list[str] | None = None) -> None:
 		case LoadErr() as err:
 			# No per-task matrix axes to augment; parse strictly so typos in
 			# flags surface instead of being silently consumed.
-			args = parser.parse_args(split.head)
-			if args.list or args.tree:
+			cli = reconstruct(parser.parse_args(split.head))
+			if cli.list_ or cli.tree:
 				print(format_load_error_hint(err.source, err.exception))
 				sys.exit(0)
-			if args.effects == "":
+			if cli.effects == "":
 				print_available_effects({})
 				sys.exit(0)
 			exit_for_load_err(err)
 
 		case LoadOk(tasks=tasks, source=source, scope_effects=scope_effects):
-			args, _leftover = parser.parse_known_args(split.head)
+			peek = reconstruct(parser.parse_known_args(split.head)[0])
 			augmented_axes: dict[str, tuple[str, ...]] = {}
-			if isinstance(args.expression, str) and args.expression in tasks:
-				for name, values in matrix_axes(tasks[args.expression]).items():
+			if isinstance(peek.expression, str) and peek.expression in tasks:
+				for name, values in matrix_axes(tasks[peek.expression]).items():
 					if name.lower() in RESERVED_FLAGS:
 						continue
 					parser.add_argument(
@@ -135,26 +135,27 @@ def dispatch(state: TasksState, argv: list[str] | None = None) -> None:
 						help=f"override matrix axis {name!r} (current: {', '.join(values)})",
 					)
 					augmented_axes[name] = values
-			args = parser.parse_args(split.head)
+			namespace = parser.parse_args(split.head)
+			cli = reconstruct(namespace)
 
-			if args.list:
+			if cli.list_:
 				print_task_summary_listing(tasks, source)
 				sys.exit(0)
 
-			if args.tree:
+			if cli.tree:
 				print_task_trees(tasks, source)
 				sys.exit(0)
 
-			if args.check:
+			if cli.check:
 				from .check import run_typecheck_only
 
 				sys.exit(run_typecheck_only(source))
 
-			if args.effects == "":
+			if cli.effects == "":
 				print_available_effects(scope_effects)
 				sys.exit(0)
 
-			if args.expression is None:
+			if cli.expression is None:
 				if tasks:
 					print(parser.format_usage().rstrip())
 					print()
@@ -169,14 +170,15 @@ def dispatch(state: TasksState, argv: list[str] | None = None) -> None:
 					sys.exit(2)
 				parser.error("task or expression is required (no tasks defined)")
 
+			effects_expr: Final = cli.effects if cli.effects is not None else default_effects_expr()
 			try:
-				effects: Final = parse_effects(args.effects, scope_effects)
+				effects: Final = parse_effects(effects_expr, scope_effects)
 			except ValueError as e:
 				print(f"error: --effects: {e}", file=sys.stderr)
 				sys.exit(2)
 
 			overrides: dict[str, tuple[str, ...]] = {}
-			for raw in args.matrix:
+			for raw in cli.matrix:
 				try:
 					k, v = parse_matrix_kv(raw)
 				except ValueError as e:
@@ -184,7 +186,7 @@ def dispatch(state: TasksState, argv: list[str] | None = None) -> None:
 					sys.exit(2)
 				overrides[k] = v
 			for axis_name in augmented_axes:
-				val = getattr(args, axis_name, None)
+				val = getattr(namespace, axis_name, None)
 				if val is not None:
 					values = parse_axis_values(val)
 					if not values:
@@ -192,7 +194,7 @@ def dispatch(state: TasksState, argv: list[str] | None = None) -> None:
 						sys.exit(2)
 					overrides[axis_name] = values
 
-			resolved = dispatch_arg(args.expression, tasks)
+			resolved = dispatch_arg(cli.expression, tasks)
 			if overrides:
 				try:
 					resolved = override_matrix(resolved, overrides)
@@ -208,7 +210,7 @@ def dispatch(state: TasksState, argv: list[str] | None = None) -> None:
 			except ValueError as e:
 				print(f"error: {e}", file=sys.stderr)
 				sys.exit(2)
-			if args.dry_run:
+			if cli.dry_run:
 				print_tree(task, show_cmd=True)
 				sys.exit(0)
 			sys.exit(asyncio.run(run(task, effects=effects)).returncode)

--- a/src/camas/main/parser.py
+++ b/src/camas/main/parser.py
@@ -139,11 +139,10 @@ def build_parser(state: TasksState = EMPTY_STATE) -> argparse.ArgumentParser:
 	"""Build the CLI argument parser.
 
 	The argument surface is declared once on :class:`Cli`; :func:`argtree.build_parser`
-	turns it into a vanilla ``ArgumentParser``, which a :class:`CamasArgumentParser`
-	adopts via argparse's ``parents=`` so the custom ``--help`` (tasks/Effects/Try
-	listings) layers on top. When ``state`` is :class:`LoadOk` with tasks, known task
-	names appear in the positional metavar so the usage line reads like a list of
-	subcommands.
+	constructs it straight into a :class:`CamasArgumentParser` (via ``parser_class=``)
+	so the custom ``--help`` (tasks/Effects/Try listings) layers on top. When ``state``
+	is :class:`LoadOk` with tasks, known task names appear in the positional metavar so
+	the usage line reads like a list of subcommands.
 
 	>>> from camas.core.task import Task
 	>>> from camas.main.state import LoadOk
@@ -155,12 +154,12 @@ def build_parser(state: TasksState = EMPTY_STATE) -> argparse.ArgumentParser:
 	True
 	"""
 	tasks_for_metavar: Mapping[str, TaskNode] = state.tasks if isinstance(state, LoadOk) else {}
-	vanilla: Final = argtree_build_parser(Cli, add_help=False)
-	parser: Final = CamasArgumentParser(
+	parser: Final = argtree_build_parser(
+		Cli,
+		parser_class=CamasArgumentParser,
 		prog="camas",
 		description=DESCRIPTION,
 		formatter_class=argparse.RawDescriptionHelpFormatter,
-		parents=[vanilla],
 	)
 	parser.state = state
 	metavar: Final = expression_metavar(tasks_for_metavar)

--- a/src/camas/main/parser.py
+++ b/src/camas/main/parser.py
@@ -8,7 +8,10 @@ import importlib.metadata
 import os
 import sys
 from collections.abc import Mapping
-from typing import Any, Final
+from typing import Any, Final, NamedTuple
+
+from argtree import arg, from_namespace
+from argtree import build_parser as argtree_build_parser
 
 if sys.version_info >= (3, 11):
 	from typing import assert_never
@@ -52,6 +55,54 @@ def default_effects_expr() -> str:
 	return "(Termtree(),)"
 
 
+class Cli(NamedTuple):
+	"""The ``camas`` command line as an :mod:`argtree` spec — one field per
+	``argparse`` argument, recovered as a typed value by :func:`reconstruct`.
+
+	``effects`` is ``str | None`` rather than carrying the environment-sensitive
+	default directly: a field default is frozen at class-definition time, but the
+	``--effects`` default depends on ``GITHUB_ACTIONS`` *at parse time*, so the
+	resolution is deferred to :func:`camas.main.dispatch` (``None`` ⇒ absent ⇒
+	:func:`default_effects_expr`, ``""`` ⇒ given without a value ⇒ list Effects).
+	"""
+
+	expression: str | None = arg(
+		positional=True,
+		nargs="?",
+		help="name of a defined task, or a camas expression "
+		"(trailing '-- ARGS' append to a Task's command)",
+	)
+	version: bool = arg(
+		"--version",
+		action="version",
+		version=f"camas {importlib.metadata.version('camas')}",
+	)
+	dry_run: bool = arg("--dry-run", help="print the task tree without executing")
+	list_: bool = arg(
+		"--list",
+		help="list all defined tasks and exit (also the default with no args)",
+	)
+	tree: bool = arg("--tree", help="print every defined task's expanded tree and exit")
+	check: bool = arg("--check", help=describe_check_help())
+	effects: str | None = arg(
+		"--effects",
+		nargs="?",
+		const="",
+		help="tuple of Effect instances; pass with no value to list available Effects "
+		"(default: Termtree, or Status('github') when GITHUB_ACTIONS=true)",
+	)
+	matrix: list[str] = arg(
+		"--matrix",
+		action="append",
+		default=[],
+		metavar="KEY=VAL[,VAL...]",
+		help="override a matrix axis (repeatable; e.g. --matrix PY=3.13)",
+	)
+
+
+DESCRIPTION: Final = "Generic parallel/sequential task runner with TUI output."
+
+
 class CamasArgumentParser(argparse.ArgumentParser):
 	"""``ArgumentParser`` whose ``--help`` appends the discovered tasks listing
 	(or load-error hint), the Effects listing, and the Try hint after argparse's
@@ -87,74 +138,46 @@ class CamasArgumentParser(argparse.ArgumentParser):
 def build_parser(state: TasksState = EMPTY_STATE) -> argparse.ArgumentParser:
 	"""Build the CLI argument parser.
 
-	When ``state`` is :class:`LoadOk` with tasks, known task names appear in the
-	positional metavar so the usage line reads like a list of subcommands.
+	The argument surface is declared once on :class:`Cli`; :func:`argtree.build_parser`
+	turns it into a vanilla ``ArgumentParser``, which a :class:`CamasArgumentParser`
+	adopts via argparse's ``parents=`` so the custom ``--help`` (tasks/Effects/Try
+	listings) layers on top. When ``state`` is :class:`LoadOk` with tasks, known task
+	names appear in the positional metavar so the usage line reads like a list of
+	subcommands.
 
 	>>> from camas.core.task import Task
 	>>> from camas.main.state import LoadOk
-	>>> parser = build_parser()
-	>>> parser.parse_args(['Task("echo hi")']).expression
+	>>> reconstruct(build_parser().parse_args(['Task("echo hi")'])).expression
 	'Task("echo hi")'
-	>>> parser.parse_args(["--list"]).list
+	>>> reconstruct(build_parser().parse_args(["--list"])).list_
 	True
 	>>> "task | expression" in build_parser(LoadOk({"all": Task("x")}, None, {})).format_usage()
 	True
 	"""
 	tasks_for_metavar: Mapping[str, TaskNode] = state.tasks if isinstance(state, LoadOk) else {}
+	vanilla: Final = argtree_build_parser(Cli, add_help=False)
 	parser: Final = CamasArgumentParser(
 		prog="camas",
-		description="Generic parallel/sequential task runner with TUI output.",
+		description=DESCRIPTION,
 		formatter_class=argparse.RawDescriptionHelpFormatter,
+		parents=[vanilla],
 	)
 	parser.state = state
-	parser.add_argument(
-		"expression",
-		nargs="?",
-		metavar=expression_metavar(tasks_for_metavar),
-		help="name of a defined task, or a camas expression "
-		"(trailing '-- ARGS' append to a Task's command)",
-	)
-	parser.add_argument(
-		"--version",
-		action="version",
-		version=f"camas {importlib.metadata.version('camas')}",
-	)
-	parser.add_argument(
-		"--dry-run",
-		action="store_true",
-		help="print the task tree without executing",
-	)
-	parser.add_argument(
-		"--list",
-		action="store_true",
-		help="list all defined tasks and exit (also the default with no args)",
-	)
-	parser.add_argument(
-		"--tree",
-		action="store_true",
-		help="print every defined task's expanded tree and exit",
-	)
-	parser.add_argument(
-		"--check",
-		action="store_true",
-		help=describe_check_help(),
-	)
-	parser.add_argument(
-		"--effects",
-		nargs="?",
-		default=default_effects_expr(),
-		const="",
-		help="tuple of Effect instances; pass with no value to list available Effects "
-		"(default: Termtree, or Status('github') when GITHUB_ACTIONS=true)",
-	)
-	parser.add_argument(
-		"--matrix",
-		action="append",
-		default=[],
-		metavar="KEY=VAL[,VAL...]",
-		help="override a matrix axis (repeatable; e.g. --matrix PY=3.13)",
-	)
+	metavar: Final = expression_metavar(tasks_for_metavar)
+	for action in parser._actions:
+		if not action.option_strings:
+			action.metavar = metavar
 	return parser
+
+
+def reconstruct(namespace: argparse.Namespace) -> Cli:
+	"""Rebuild the typed :class:`Cli` from a parsed argparse namespace.
+
+	The dynamically-added per-matrix-axis flags (e.g. ``--PY``) are not part of
+	:class:`Cli`; :func:`argtree.from_namespace` ignores them, and the dispatcher
+	reads them off the raw namespace by their (clean) dest.
+	"""
+	return from_namespace(Cli, namespace)
 
 
 RESERVED_FLAGS: Final = frozenset(

--- a/tests/main/test_parser.py
+++ b/tests/main/test_parser.py
@@ -5,20 +5,20 @@ from __future__ import annotations
 
 import pytest
 
-from camas.main.parser import build_parser
+from camas.main.parser import build_parser, reconstruct
 
 
 def test_parser_has_expression_arg() -> None:
 	parser = build_parser()
-	args = parser.parse_args(['Task("echo hi")'])
-	assert args.expression == 'Task("echo hi")'
-	assert args.dry_run is False
+	cli = reconstruct(parser.parse_args(['Task("echo hi")']))
+	assert cli.expression == 'Task("echo hi")'
+	assert cli.dry_run is False
 
 
 def test_parser_dry_run_flag() -> None:
 	parser = build_parser()
-	args = parser.parse_args(["--dry-run", 'Task("echo hi")'])
-	assert args.dry_run is True
+	cli = reconstruct(parser.parse_args(["--dry-run", 'Task("echo hi")']))
+	assert cli.dry_run is True
 
 
 def test_build_parser_format_help_no_tasks_no_effects(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -22,11 +22,10 @@ wheels = [
 
 [[package]]
 name = "argtree"
-version = "0.1.0"
+version = "0.1.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0c/c1/c2117bad1a43bf6d9f63b654bc2bf1c372b7a645b9a0fd3fcf515bff49b1/argtree-0.1.0.tar.gz", hash = "sha256:5d7cd8724b12455330cf8994542d85e351d4a027bd08a2b8a5cdcaddd4c67bdd", size = 61732, upload-time = "2026-05-31T20:48:39.132Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c4/4b/a19f7b9c404f4a8853036e32448052ea4c4f889ad913d9cee9ff00719b76/argtree-0.1.0-py3-none-any.whl", hash = "sha256:de0b7935f8d0e297e16f0a49a0cfa451720a855954d40467847c5d06421c5f14", size = 16497, upload-time = "2026-05-31T20:48:37.951Z" },
+    { url = "https://files.pythonhosted.org/packages/42/fa/486e161cd6f3aefb99f57672735f02b779ad165d20953f401fcb0ceb4d21/argtree-0.1.2-py3-none-any.whl", hash = "sha256:5d231c541b394d6670b1d26ae77e5aa7888c4bb325150db1de06f4dadf5b3805", size = 20057, upload-time = "2026-06-05T00:19:50.955Z" },
 ]
 
 [[package]]
@@ -92,7 +91,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "argtree", specifier = ">=0.1,<1" },
+    { name = "argtree", specifier = ">=0.1.2,<1" },
     { name = "exceptiongroup", marker = "python_full_version < '3.11'", specifier = ">=1.2,<2" },
     { name = "httpx", marker = "extra == 'all'", specifier = ">=0.28,<1" },
     { name = "httpx", marker = "extra == 'github-checks'", specifier = ">=0.28,<1" },

--- a/uv.lock
+++ b/uv.lock
@@ -21,6 +21,15 @@ wheels = [
 ]
 
 [[package]]
+name = "argtree"
+version = "0.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0c/c1/c2117bad1a43bf6d9f63b654bc2bf1c372b7a645b9a0fd3fcf515bff49b1/argtree-0.1.0.tar.gz", hash = "sha256:5d7cd8724b12455330cf8994542d85e351d4a027bd08a2b8a5cdcaddd4c67bdd", size = 61732, upload-time = "2026-05-31T20:48:39.132Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c4/4b/a19f7b9c404f4a8853036e32448052ea4c4f889ad913d9cee9ff00719b76/argtree-0.1.0-py3-none-any.whl", hash = "sha256:de0b7935f8d0e297e16f0a49a0cfa451720a855954d40467847c5d06421c5f14", size = 16497, upload-time = "2026-05-31T20:48:37.951Z" },
+]
+
+[[package]]
 name = "attrs"
 version = "26.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -42,6 +51,7 @@ wheels = [
 name = "camas"
 source = { editable = "." }
 dependencies = [
+    { name = "argtree" },
     { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
     { name = "taskgroup", marker = "python_full_version < '3.11'" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
@@ -82,6 +92,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "argtree", specifier = ">=0.1,<1" },
     { name = "exceptiongroup", marker = "python_full_version < '3.11'", specifier = ">=1.2,<2" },
     { name = "httpx", marker = "extra == 'all'", specifier = ">=0.28,<1" },
     { name = "httpx", marker = "extra == 'github-checks'", specifier = ">=0.28,<1" },


### PR DESCRIPTION
## What this is

Replaces camas's hand-rolled `argparse` parser with a declarative [`argtree`](https://github.com/JPHutchins/argtree) `Cli` spec, and consumes the **typed** result in dispatch instead of an `Any`-typed `argparse.Namespace`.

Originally opened as an experiment gated on three argtree gaps. **Those shipped in argtree 0.1.2**, so this now uses the real APIs and is ready for review.

## ✅ Blockers resolved in argtree 0.1.2

| Issue | Shipped as | Used here |
|---|---|---|
| JPHutchins/argtree#9 | `build_parser(..., parser_class=)` + public `add_arguments()` | `build_parser(Cli, parser_class=CamasArgumentParser, ...)` — no more `parents=[vanilla]` dance |
| JPHutchins/argtree#10 | documented "keep the spec in an interpreted module" pattern | `parser.py` excluded from `mypycify`; argtree added to `[build-system] requires` |
| JPHutchins/argtree#11 | clear `ConfigError` naming the shadowing field | confirmed the `list` → `list_` rename (flag stays `--list`) |

## What changed

| File | Change |
|---|---|
| `src/camas/main/parser.py` | `Cli` NamedTuple spec (one field per arg); `build_parser` constructs it directly into `CamasArgumentParser` via `parser_class=`; new `reconstruct()` wraps `from_namespace`. Stays interpreted (excluded from mypyc). |
| `src/camas/main/dispatch.py` | Reads a typed `Cli` instead of poking the namespace; resolves the env-dependent `--effects` default here (`None` ⇒ absent ⇒ `default_effects_expr()`, `""` ⇒ list Effects). |
| `setup.py` | `parser.py` added to `_main_excluded` (mypyc). |
| `pyproject.toml` | `argtree>=0.1.2` in runtime deps **and** `[build-system] requires`. |
| `tests/main/test_parser.py` | Read the typed `Cli` via `reconstruct` rather than the raw namespace. |

The declarative spec is the **core**; three runtime/state-dependent behaviors stay imperative *around* it — the dynamic per-matrix-axis `--PY` flags, the `task | expression` positional metavar, and the `--effects` default. argtree gives the real parser back, so these escape hatches remain available; camas just lands as "declarative core + imperative shell."

## Why bother — the payoff

The win isn't the prettier spec; it's **types**. `dispatch` now consumes `Cli` (`expression: str | None`, `dry_run: bool`, …) instead of an `argparse.Namespace` where every field is `Any`. Under five strict type-checkers that removes a class of implicit-`Any` reads.

## Verification (all green)

- `--help` output **byte-identical** to the current parser
- **639 tests pass**, **100% coverage** maintained
- **All 5 type-checkers clean** — mypy, pyright, ty, zuban, pyrefly
- **mypyc wheel builds and runs end-to-end**: compiled `dispatch.so` → interpreted `parser.py`; `build_parser()` returns a `CamasArgumentParser` through `parser_class=`, dynamic `--PY` axis flags work

## Open question for review

Is the typed-dispatch readability worth (a) a runtime dependency on argtree and (b) `parser.py` no longer being mypyc-compiled? Leaning yes; not an obvious slam-dunk over the working argparse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
