### PR TITLE
feat(lint): extend ruff selection to the mainstream set plus doclint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,7 +99,99 @@ line-length = 100
 exclude = ["tests/fixtures/"]
 
 [tool.ruff.lint]
-extend-select = ["I"]
+# preview is on solely to reach the DOC rules; explicit-preview-rules keeps
+# every other preview rule out until selected by exact code. select (not
+# extend-select) because preview also broadens ruff's default selection.
+preview = true
+explicit-preview-rules = true
+select = [
+"ASYNC", # flake8-async
+"B", # flake8-bugbear
+"C4", # flake8-comprehensions
+"D", # pydocstyle
+"DOC102", # pydoclint (preview): documented params that don't exist
+"DOC202", # pydoclint (preview): documented returns that don't exist
+"DOC403", # pydoclint (preview): documented yields that don't exist
+"DOC501", # pydoclint (preview): raised exceptions must be documented
+"DOC502", # pydoclint (preview): documented exceptions that aren't raised
+"E", # pycodestyle errors
+"F", # pyflakes
+"FA", # flake8-future-annotations
+"FLY", # flynt
+"FURB", # refurb
+"G", # flake8-logging-format
+"I", # isort
+"ICN", # flake8-import-conventions
+"INP", # flake8-no-pep420
+"ISC", # flake8-implicit-str-concat
+"LOG", # flake8-logging
+"N", # pep8-naming
+"PERF", # perflint
+"PGH", # pygrep-hooks
+"PIE", # flake8-pie
+"PL", # pylint
+"PT", # flake8-pytest-style
+"PTH", # flake8-use-pathlib
+"PYI", # flake8-pyi
+"RET", # flake8-return
+"RSE", # flake8-raise
+"RUF", # ruff-specific
+"SIM", # flake8-simplify
+"SLF", # flake8-self
+"SLOT", # flake8-slots
+"TC", # flake8-type-checking
+"TRY", # tryceratops
+"UP", # pyupgrade
+"W", # pycodestyle warnings
+"YTT", # flake8-2020
+]
+# DOC201/DOC402 (missing returns/yields sections) are deliberately absent:
+# annotations are the single source of truth for parameter and return types,
+# so docstrings document only what the type system cannot — raised exceptions.
+ignore = [
+# tab indentation + formatter conflicts
+# (https://docs.astral.sh/ruff/formatter/#conflicting-lint-rules)
+"W191",
+"E101",
+"E111",
+"E114",
+"E117",
+"D206",
+"D300",
+"ISC001",
+"ISC002",
+"E501", # the formatter owns line length; the rest is unbreakable doctest output
+"D102", # effect methods implement the documented Effect protocol contract
+"D103", # code should document itself; a needed comment is a symptom
+"D105", # magic method contracts are defined by the data model, not prose
+"D107", # __init__ is documented by its class
+"D205", # summaries here are flowing paragraphs, not one-liners
+"D417", # params belong to the type system, not prose (see DOC201/DOC402 above)
+"PLC0415", # imports are scoped as narrowly as possible, by design
+"PLR0911", # complexity thresholds reward fragmentation over clarity
+"PLR0912",
+"PLR0913",
+"PLR0915",
+"PLR2004", # renderer geometry is full of honest small numbers
+"TRY003", # messages live in the raise; no exception-class zoo
+"TRY004", # ValueError is the CLI's user-error channel (dispatch catches it)
+]
+allowed-confusables = ["×"] # matrix axes render as PY×6
+
+[tool.ruff.lint.pydocstyle]
+convention = "google"
+
+[tool.ruff.lint.flake8-bugbear]
+# Options are immutable NamedTuples; constructing defaults in signatures is safe.
+extend-immutable-calls = [
+"camas.effect.github_checks.GitHubChecksOptions",
+"camas.effect.status.StatusOptions",
+"camas.effect.summary.SummaryOptions",
+"camas.effect.termtree.TermtreeOptions",
+]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/**" = ["D"] # test functions document themselves by name
 
 [tool.ruff.format]
 indent-style = "tab"

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,8 @@
-import glob
+"""Optionally compile the hot modules with mypyc (CAMAS_USE_MYPYC=1)."""
+
 import os
 import sys
+from pathlib import Path
 
 from setuptools import setup
 
@@ -19,15 +21,11 @@ if use_mypyc:
 	_main_excluded = {"check.py", "state.py"}
 	ext_modules = mypycify(
 		[
+			*(str(p) for p in Path("src/camas/main").glob("*.py") if p.name not in _main_excluded),
 			*(
-				p
-				for p in glob.glob("src/camas/main/*.py")
-				if os.path.basename(p) not in _main_excluded
-			),
-			*(
-				p
-				for p in glob.glob("src/camas/effect/[!_]*.py")
-				if os.path.basename(p) != "github_checks.py"
+				str(p)
+				for p in Path("src/camas/effect").glob("[!_]*.py")
+				if p.name != "github_checks.py"
 			),
 		],
 		opt_level="3",

--- a/src/camas/__init__.py
+++ b/src/camas/__init__.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: 2026 JP Hutchins
-"""camas — parallel and sequential task-tree runner.
+r"""camas — parallel and sequential task-tree runner.
 
 Define your task tree in ``tasks.py``. ``camas <name>`` runs a task by
 name, ``camas --list`` enumerates them, ``camas --help`` shows
@@ -66,7 +66,7 @@ task's stdout so the leaf's output is verifiable from the run record;
 
 	>>> with tempfile.TemporaryDirectory() as tmp:
 	...     camas = make_camas(tmp)
-	...     _ = (Path(tmp) / "tasks.py").write_text(dedent('''\\
+	...     _ = (Path(tmp) / "tasks.py").write_text(dedent('''\
 	...         from camas import Task
 	...         hello = Task(("python", "-c", "print('hello world')"))
 	...     '''))
@@ -90,7 +90,7 @@ the dispatched task's command:
 	>>> with tempfile.TemporaryDirectory() as tmp:
 	...     camas = make_camas(tmp)
 	...     (Path(tmp) / "subdir").mkdir()
-	...     _ = (Path(tmp) / "tasks.py").write_text(dedent('''\\
+	...     _ = (Path(tmp) / "tasks.py").write_text(dedent('''\
 	...         from pathlib import Path
 	...         from camas import Parallel, Sequential, Task
 	...
@@ -134,7 +134,7 @@ than executed, and the camas process exits non-zero:
 
 	>>> with tempfile.TemporaryDirectory() as tmp:
 	...     camas = make_camas(tmp)
-	...     _ = (Path(tmp) / "tasks.py").write_text(dedent('''\\
+	...     _ = (Path(tmp) / "tasks.py").write_text(dedent('''\
 	...         from camas import Sequential, Task
 	...         pipeline = Sequential(
 	...             Task(("python", "-c", "raise SystemExit(2)"), name="boom"),
@@ -156,7 +156,7 @@ documents the matrix override flag:
 
 	>>> with tempfile.TemporaryDirectory() as tmp:
 	...     camas = make_camas(tmp)
-	...     _ = (Path(tmp) / "tasks.py").write_text(dedent('''\\
+	...     _ = (Path(tmp) / "tasks.py").write_text(dedent('''\
 	...         from camas import Parallel, Task
 	...         greet = Parallel(
 	...             Task(("python", "-c", "print('hello, {NAME}')")),
@@ -183,7 +183,7 @@ axes:
 
 	>>> with tempfile.TemporaryDirectory() as tmp:
 	...     camas = make_camas(tmp)
-	...     _ = (Path(tmp) / "tasks.py").write_text(dedent('''\\
+	...     _ = (Path(tmp) / "tasks.py").write_text(dedent('''\
 	...         from camas import Parallel, Task
 	...         meet = Parallel(
 	...             Task(("python", "-c", "print('hi {NAME1}, meet {NAME2}')")),
@@ -233,7 +233,7 @@ report and the streaming per-task lines:
 
 	>>> with tempfile.TemporaryDirectory() as tmp:
 	...     camas = make_camas(tmp)
-	...     _ = (Path(tmp) / "tasks.py").write_text(dedent('''\\
+	...     _ = (Path(tmp) / "tasks.py").write_text(dedent('''\
 	...         from collections.abc import Sequence
 	...         from camas import Effect, Parallel, Task
 	...         from camas.core.leaf_state import LeafState

--- a/src/camas/core/__init__.py
+++ b/src/camas/core/__init__.py
@@ -1,2 +1,3 @@
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: 2026 JP Hutchins
+"""Engine: the task-tree AST, matrix expansion, async execution, and the Effect protocol."""

--- a/src/camas/core/completion.py
+++ b/src/camas/core/completion.py
@@ -1,10 +1,14 @@
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: 2026 JP Hutchins
 
+"""Completion outcomes (``Finished`` | ``Skipped``) and the per-run result aggregates."""
+
 from __future__ import annotations
 
-from collections.abc import Sequence
-from typing import NamedTuple, TypeAlias
+from typing import TYPE_CHECKING, NamedTuple, TypeAlias
+
+if TYPE_CHECKING:
+	from collections.abc import Sequence
 
 
 class Finished(NamedTuple):

--- a/src/camas/core/effect.py
+++ b/src/camas/core/effect.py
@@ -1,14 +1,18 @@
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: 2026 JP Hutchins
 
+"""The ``Effect`` protocol: observers over a run's event stream with per-leaf contexts."""
+
 from __future__ import annotations
 
 from collections.abc import Awaitable, Callable, Sequence
-from typing import Protocol, TypeAlias, TypeVar, runtime_checkable
+from typing import TYPE_CHECKING, Protocol, TypeAlias, TypeVar, runtime_checkable
 
-from .leaf_state import LeafState
-from .task import TaskNode
 from .task_event import TaskEvent
+
+if TYPE_CHECKING:
+	from .leaf_state import LeafState
+	from .task import TaskNode
 
 EventSink: TypeAlias = Callable[[int, TaskEvent], Awaitable[None]]
 """Per-leaf event dispatcher: await sink(leaf_idx, event)."""

--- a/src/camas/core/execution.py
+++ b/src/camas/core/execution.py
@@ -1,16 +1,17 @@
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: 2026 JP Hutchins
 
+"""Async tree execution: leaves run as subprocesses, events fan out to Effects."""
+
 from __future__ import annotations
 
 import asyncio
 import os
 import sys
 import time
-from collections.abc import Iterable, Sequence
 from datetime import datetime
 from subprocess import STDOUT
-from typing import Any, Final
+from typing import TYPE_CHECKING, Any, Final
 
 if sys.version_info >= (3, 11):
 	from asyncio import TaskGroup
@@ -22,12 +23,16 @@ else:  # pragma: no cover
 	from typing_extensions import assert_never
 
 from .completion import Finished, RunResult, Skipped, TaskResult
-from .effect import Effect, EventSink
 from .leaf_state import LeafState, Waiting, next_state
 from .matrix import expand_matrix, resolve_cmd
 from .task import Parallel, Sequential, Task, TaskNode, task_label
 from .task_event import CompletedEvent, OutputEvent, StartedEvent, TaskEvent
 from .traversal import flatten_leaves, subtree_leaf_indices
+
+if TYPE_CHECKING:
+	from collections.abc import Iterable, Sequence
+
+	from .effect import Effect, EventSink
 
 
 def subprocess_env(merged: dict[str, str]) -> dict[str, str]:
@@ -126,6 +131,10 @@ async def execute(
 
 async def run(task: TaskNode, effects: Sequence[Effect[Any]] = ()) -> RunResult:
 	"""Execute a task tree, dispatching events to every effect.
+
+	Raises:
+		BaseExceptionGroup: every error raised by Effects during setup,
+			on_event, or teardown, collected per phase.
 
 	>>> import asyncio
 	>>> asyncio.run(run(Task(("python", "-c", "pass")))).returncode

--- a/src/camas/core/leaf_state.py
+++ b/src/camas/core/leaf_state.py
@@ -1,20 +1,25 @@
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: 2026 JP Hutchins
 
+"""Per-leaf state machine: ``Waiting`` → ``Running`` → ``Completed``."""
+
 from __future__ import annotations
 
 import sys
-from datetime import datetime
-from typing import NamedTuple, TypeAlias
+from typing import TYPE_CHECKING, NamedTuple, TypeAlias
 
 if sys.version_info >= (3, 11):
 	from typing import assert_never
 else:  # pragma: no cover
 	from typing_extensions import assert_never
 
-from .completion import Completion
-from .task import Task
 from .task_event import CompletedEvent, OutputEvent, StartedEvent, TaskEvent
+
+if TYPE_CHECKING:
+	from datetime import datetime
+
+	from .completion import Completion
+	from .task import Task
 
 
 class ChainLink(NamedTuple):
@@ -33,6 +38,7 @@ class ChainLink(NamedTuple):
 class LeafInfo(NamedTuple):
 	"""A leaf's position in the task tree: depth and chain of ancestor links.
 
+	>>> from camas.core.task import Task
 	>>> LeafInfo(Task("echo hi"), 0, ())
 	LeafInfo(task=Task(cmd='echo hi', name=None, env={}, cwd=None), depth=0, is_last_chain=())
 	"""
@@ -45,6 +51,7 @@ class LeafInfo(NamedTuple):
 class Waiting(NamedTuple):
 	"""Leaf state: task has not started yet.
 
+	>>> from camas.core.task import Task
 	>>> Waiting(Task("echo hi"))
 	Waiting(task=Task(cmd='echo hi', name=None, env={}, cwd=None))
 	"""
@@ -55,6 +62,8 @@ class Waiting(NamedTuple):
 class Running(NamedTuple):
 	"""Leaf state: task is currently executing.
 
+	>>> from datetime import datetime
+	>>> from camas.core.task import Task
 	>>> Running(Task("echo hi"), datetime(2026, 1, 1, 12, 0, 0), b"output")
 	Running(task=Task(cmd='echo hi', name=None, env={}, cwd=None), start_time=datetime.datetime(2026, 1, 1, 12, 0), last_line=b'output')
 	"""
@@ -71,6 +80,7 @@ class Completed(NamedTuple):
 	vs `Skipped(...)` to distinguish the two cases.
 
 	>>> from camas.core.completion import Finished, Skipped
+	>>> from camas.core.task import Task
 	>>> Completed(Task("echo hi"), Finished(0, 0.5, ()))
 	Completed(task=Task(cmd='echo hi', name=None, env={}, cwd=None), completion=Finished(returncode=0, elapsed=0.5, output=()))
 	>>> Completed(Task("echo hi"), Skipped(1))
@@ -87,7 +97,9 @@ LeafState: TypeAlias = Waiting | Running | Completed
 def next_state(state: LeafState, event: TaskEvent) -> LeafState:
 	"""Pure state machine: apply a TaskEvent to a LeafState to produce the next state.
 
+	>>> from datetime import datetime
 	>>> from camas.core.completion import Finished, Skipped
+	>>> from camas.core.task import Task
 	>>> t = Task("echo hi")
 	>>> t0 = datetime(2026, 1, 1, 12, 0, 0)
 	>>> t1 = datetime(2026, 1, 1, 12, 0, 1)

--- a/src/camas/core/matrix.py
+++ b/src/camas/core/matrix.py
@@ -1,15 +1,16 @@
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: 2026 JP Hutchins
 
+"""Matrix expansion: bind axis values, specialize subtrees, and apply CLI overrides."""
+
 from __future__ import annotations
 
 import functools
 import itertools
 import shlex
 import sys
-from collections.abc import Mapping
 from pathlib import Path
-from typing import Final
+from typing import TYPE_CHECKING, Final
 
 if sys.version_info >= (3, 11):
 	from typing import assert_never
@@ -17,6 +18,9 @@ else:  # pragma: no cover
 	from typing_extensions import assert_never
 
 from .task import MatrixBinding, Parallel, Sequential, Task, TaskNode, VarBinding, task_label
+
+if TYPE_CHECKING:
+	from collections.abc import Mapping
 
 
 def resolve_cmd(cmd: str | tuple[str, ...]) -> tuple[str, ...]:
@@ -148,6 +152,9 @@ def override_matrix(task: TaskNode, overrides: Mapping[str, tuple[str, ...]]) ->
 	"""Return a tree with each ``matrix[k]`` replaced by ``overrides[k]`` everywhere
 	the key appears. Strict on keys: every override must match an axis present in
 	the tree. Permissive on values: any tuple is accepted.
+
+	Raises:
+		ValueError: if an override key matches no matrix axis in the tree.
 
 	>>> override_matrix(Parallel(Task("t"), matrix={"PY": ("3.12", "3.13")}), {"PY": ("3.13",)}).matrix  # type: ignore[union-attr]
 	{'PY': ('3.13',)}

--- a/src/camas/core/render.py
+++ b/src/camas/core/render.py
@@ -1,14 +1,14 @@
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: 2026 JP Hutchins
 
+"""ANSI primitives and tree-layout rendering shared by the display Effects."""
+
 from __future__ import annotations
 
 import os
 import re
 import sys
-from collections.abc import Iterator, Mapping
-from pathlib import Path
-from typing import Final, NamedTuple, TypeAlias
+from typing import TYPE_CHECKING, Final, NamedTuple, TypeAlias
 
 if sys.version_info >= (3, 11):
 	from typing import assert_never
@@ -18,6 +18,10 @@ else:  # pragma: no cover
 from .leaf_state import ChainLink, LeafInfo
 from .matrix import expand_matrix
 from .task import Parallel, Sequential, Task, TaskNode, task_label
+
+if TYPE_CHECKING:
+	from collections.abc import Iterator, Mapping
+	from pathlib import Path
 
 BOLD: Final = "\033[1m"
 CYAN: Final = "\033[36m"
@@ -42,10 +46,10 @@ ANSI_ESCAPE: Final = re.compile(
 
 
 def strip_ansi(text: str) -> str:
-	"""Remove ANSI escape sequences and ASCII control characters from a string.
+	r"""Remove ANSI escape sequences and ASCII control characters from a string.
 
-	Tab (``\\t``) and newline (``\\n``) are preserved — they're load-bearing for
-	formatted log output. Carriage return (``\\r``), BEL, BS, and other
+	Tab (``\t``) and newline (``\n``) are preserved — they're load-bearing for
+	formatted log output. Carriage return (``\r``), BEL, BS, and other
 	control chars are stripped.
 
 	>>> strip_ansi("\x1b[32mgreen\x1b[0m text")
@@ -54,9 +58,9 @@ def strip_ansi(text: str) -> str:
 	'link text'
 	>>> strip_ansi("no escapes")
 	'no escapes'
-	>>> strip_ansi("line one\\nline two\\tcol")
-	'line one\\nline two\\tcol'
-	>>> strip_ansi("\\r\x1b[2Kprogress")
+	>>> strip_ansi("line one\nline two\tcol")
+	'line one\nline two\tcol'
+	>>> strip_ansi("\r\x1b[2Kprogress")
 	'progress'
 	>>> strip_ansi("\x1b[1mbold\x1b(B\x1b[m done")
 	'bold done'

--- a/src/camas/core/task.py
+++ b/src/camas/core/task.py
@@ -1,13 +1,17 @@
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: 2026 JP Hutchins
 
+"""Task-tree AST: ``Task`` leaves composed by ``Sequential`` and ``Parallel`` groups."""
+
 from __future__ import annotations
 
-from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
 from types import MappingProxyType
-from typing import NamedTuple, TypeAlias
+from typing import TYPE_CHECKING, NamedTuple, TypeAlias
+
+if TYPE_CHECKING:
+	from collections.abc import Mapping
 
 
 class VarBinding(NamedTuple):

--- a/src/camas/core/task_event.py
+++ b/src/camas/core/task_event.py
@@ -1,18 +1,24 @@
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: 2026 JP Hutchins
 
+"""Internal event sum type emitted by execution: started, output, completed."""
+
 from __future__ import annotations
 
-from datetime import datetime
-from typing import NamedTuple, TypeAlias
+from typing import TYPE_CHECKING, NamedTuple, TypeAlias
 
-from .completion import Completion
-from .task import Task
+if TYPE_CHECKING:
+	from datetime import datetime
+
+	from .completion import Completion
+	from .task import Task
 
 
 class StartedEvent(NamedTuple):
 	"""Internal event: a task has started execution.
 
+	>>> from datetime import datetime
+	>>> from camas.core.task import Task
 	>>> StartedEvent(Task("hi"), 0, datetime(2026, 1, 1, 12, 0, 0))
 	StartedEvent(task=Task(cmd='hi', name=None, env={}, cwd=None), leaf_index=0, timestamp=datetime.datetime(2026, 1, 1, 12, 0))
 	"""
@@ -25,6 +31,8 @@ class StartedEvent(NamedTuple):
 class OutputEvent(NamedTuple):
 	"""Internal event: a task produced an output line.
 
+	>>> from datetime import datetime
+	>>> from camas.core.task import Task
 	>>> OutputEvent(Task("hi"), 0, b"hello", datetime(2026, 1, 1, 12, 0, 1))
 	OutputEvent(task=Task(cmd='hi', name=None, env={}, cwd=None), leaf_index=0, line=b'hello', timestamp=datetime.datetime(2026, 1, 1, 12, 0, 1))
 	"""
@@ -38,7 +46,9 @@ class OutputEvent(NamedTuple):
 class CompletedEvent(NamedTuple):
 	"""Internal event: a task finished execution (either ran or was skipped).
 
+	>>> from datetime import datetime
 	>>> from camas.core.completion import Finished, Skipped
+	>>> from camas.core.task import Task
 	>>> CompletedEvent(Task("hi"), 0, Finished(0, 1.0, (b"done",)), datetime(2026, 1, 1, 12, 0, 2))
 	CompletedEvent(task=Task(cmd='hi', name=None, env={}, cwd=None), leaf_index=0, completion=Finished(returncode=0, elapsed=1.0, output=(b'done',)), timestamp=datetime.datetime(2026, 1, 1, 12, 0, 2))
 	>>> CompletedEvent(Task("hi"), 0, Skipped(1), datetime(2026, 1, 1, 12, 0, 0))

--- a/src/camas/core/traversal.py
+++ b/src/camas/core/traversal.py
@@ -1,11 +1,12 @@
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: 2026 JP Hutchins
 
+"""Depth-first tree walks and leaf-index bookkeeping."""
+
 from __future__ import annotations
 
 import sys
-from collections.abc import Iterator
-from typing import Final
+from typing import TYPE_CHECKING, Final
 
 if sys.version_info >= (3, 11):
 	from typing import assert_never
@@ -14,6 +15,9 @@ else:  # pragma: no cover
 
 from .leaf_state import ChainLink, LeafInfo
 from .task import Parallel, Sequential, Task, TaskNode
+
+if TYPE_CHECKING:
+	from collections.abc import Iterator
 
 
 def iter_leaves(

--- a/src/camas/effect/__init__.py
+++ b/src/camas/effect/__init__.py
@@ -1,2 +1,3 @@
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: 2026 JP Hutchins
+"""Built-in Effects: ``Termtree``, ``Status``, ``Summary``, and ``GitHubChecks``."""

--- a/src/camas/effect/github_checks.py
+++ b/src/camas/effect/github_checks.py
@@ -27,9 +27,7 @@ from __future__ import annotations
 import asyncio
 import os
 import sys
-from collections.abc import Sequence
 from datetime import datetime, timezone
-from types import ModuleType
 from typing import TYPE_CHECKING, Final, NamedTuple, TypeAlias
 
 if sys.version_info >= (3, 11):
@@ -40,10 +38,14 @@ else:  # pragma: no cover
 	from typing_extensions import assert_never
 
 if TYPE_CHECKING:
+	from collections.abc import Sequence
+	from types import ModuleType
+
 	import httpx
 
+	from ..core.leaf_state import LeafState
+
 from ..core.completion import Completion, Finished, Skipped
-from ..core.leaf_state import LeafState
 from ..core.render import strip_ansi
 from ..core.task import Task, TaskNode, task_label
 from ..core.task_event import (
@@ -128,7 +130,8 @@ class Active(NamedTuple):
 class Closed(NamedTuple):
 	"""All HTTP for this leaf is scheduled (awaited in teardown).
 
-	``task`` is ``None`` when the leaf was Skipped before any Started fired."""
+	``task`` is ``None`` when the leaf was Skipped before any Started fired.
+	"""
 
 	task: asyncio.Task[None] | None
 
@@ -145,7 +148,11 @@ class EffectState(NamedTuple):
 
 
 def require_httpx() -> ModuleType:
-	"""Import httpx lazily; raise with the install hint when the extra is missing."""
+	"""Import httpx lazily; raise with the install hint when the extra is missing.
+
+	Raises:
+		RuntimeError: when the ``camas[github_checks]`` extra is not installed.
+	"""
 	try:
 		import httpx
 	except ImportError as e:
@@ -155,6 +162,10 @@ def require_httpx() -> ModuleType:
 
 def resolve_config(opts: GitHubChecksOptions) -> ResolvedConfig:
 	"""Resolve options + env vars into a fully-specified ResolvedConfig.
+
+	Raises:
+		RuntimeError: when token, repository, or sha is unset, or repository
+			is not ``owner/repo``.
 
 	>>> resolve_config(GitHubChecksOptions(token="t", repository="o/r", sha="s")).repo
 	'r'
@@ -257,13 +268,14 @@ _FENCE_OVERHEAD: Final = len("```\n\n```")
 
 
 def render_body(task: Task, tail: bytes, completion: Completion | None) -> tuple[str, str, str]:
-	"""Return ``(title, summary, text)`` for the check-run output object.
+	r"""Return ``(title, summary, text)`` for the check-run output object.
 
 	ANSI escape sequences are stripped from ``tail`` — GitHub renders the
 	output text as plain text in a fenced code block, so escapes would
-	otherwise appear as literal ``\\x1b[...m`` noise. ``text`` is clamped to
+	otherwise appear as literal ``\x1b[...m`` noise. ``text`` is clamped to
 	``OUTPUT_TEXT_LIMIT`` characters so an over-eager ``tail_bytes`` setting
-	can't exceed GitHub's 65535-char ``output.text`` cap."""
+	can't exceed GitHub's 65535-char ``output.text`` cap.
+	"""
 	cmd_str = task.cmd if isinstance(task.cmd, str) else " ".join(task.cmd)
 	decoded = strip_ansi(tail.decode("utf-8", errors="replace")) if tail else ""
 	if len(decoded) > OUTPUT_TEXT_LIMIT - _FENCE_OVERHEAD:
@@ -302,7 +314,8 @@ async def post_check_run(
 
 	``external_id`` is a stable identifier per leaf (derived from name_prefix +
 	task_label) — lets integrators correlate check_runs back to camas leaves
-	via the API even when names collide."""
+	via the API even when names collide.
+	"""
 	response = await http.post(
 		f"https://{GH_API_HOST}/repos/{cfg.owner}/{cfg.repo}/check-runs",
 		json={
@@ -368,7 +381,8 @@ async def post_then_cancel(
 ) -> None:
 	"""Teardown path for Active leaves whose event stream was truncated:
 	wait for POST, then PATCH ``conclusion="cancelled"`` so the check
-	doesn't linger ``in_progress`` in the GH UI."""
+	doesn't linger ``in_progress`` in the GH UI.
+	"""
 	await post_then_patch(
 		http,
 		cfg,
@@ -387,7 +401,8 @@ def started_to_active(state: EffectState, task: Task) -> Active:
 
 	Creates the POST task; the returned Active holds the task handle, so the
 	ctx itself is what keeps the task referenced (the runtime stores ctxs in
-	ctx_grid for the duration of the run)."""
+	ctx_grid for the duration of the run).
+	"""
 	name = build_name(state.cfg.name_prefix, task)
 	return Active(
 		post_task=asyncio.create_task(
@@ -415,7 +430,8 @@ def completed_to_closed(
 	"""Pure: build the next ctx for a CompletedEvent on an Active leaf.
 
 	Spawns the wrap task that awaits the prior POST and PATCHes the result.
-	The wrap task is stored in the returned Closed."""
+	The wrap task is stored in the returned Closed.
+	"""
 	return Closed(
 		task=asyncio.create_task(
 			post_then_patch(
@@ -444,7 +460,8 @@ def pipelines_from_ctxs(
 
 	The cancel pipelines for Active leaves are created here, not held on the
 	effect; their refs live in the returned tuple until ``teardown`` awaits
-	them."""
+	them.
+	"""
 	return tuple(extracted for ctx in ctxs if (extracted := pipeline_of(state, ctx)) is not None)
 
 

--- a/src/camas/effect/status.py
+++ b/src/camas/effect/status.py
@@ -16,9 +16,7 @@ from __future__ import annotations
 
 import secrets
 import sys
-from collections.abc import Sequence
-from datetime import datetime
-from typing import Final, Literal, NamedTuple, TypeAlias
+from typing import TYPE_CHECKING, Final, Literal, NamedTuple, TypeAlias
 
 if sys.version_info >= (3, 11):
 	from typing import assert_never
@@ -26,7 +24,6 @@ else:  # pragma: no cover
 	from typing_extensions import assert_never
 
 from ..core.completion import Completion, Finished, Skipped
-from ..core.leaf_state import LeafState
 from ..core.render import GREEN, GREY, RED, RESET, VIOLET, strip_ansi
 from ..core.task import Task, TaskNode, task_label
 from ..core.task_event import (
@@ -35,6 +32,12 @@ from ..core.task_event import (
 	StartedEvent,
 	TaskEvent,
 )
+
+if TYPE_CHECKING:
+	from collections.abc import Sequence
+	from datetime import datetime
+
+	from ..core.leaf_state import LeafState
 
 OutputMode: TypeAlias = Literal["quiet", "all", "errors", "stream", "github"]
 
@@ -81,10 +84,10 @@ class Idle(NamedTuple):
 
 
 class Active(NamedTuple):
-	"""Per-leaf ctx: leaf is running.
+	r"""Per-leaf ctx: leaf is running.
 
-	>>> Active(b"hello\\n").output
-	b'hello\\n'
+	>>> Active(b"hello\n").output
+	b'hello\n'
 	"""
 
 	output: bytes
@@ -113,11 +116,12 @@ def cmd_str(task: Task) -> str:
 
 
 def fmt_started(opts: StatusOptions, task: Task, ts: datetime) -> str | None:
-	"""Render the started-line, or ``None`` when ``started_fmt`` is empty.
+	r"""Render the started-line, or ``None`` when ``started_fmt`` is empty.
 
+	>>> from datetime import datetime
 	>>> t0 = datetime(2026, 5, 21, 14, 30, 0, 123000)
 	>>> fmt_started(StatusOptions(), Task("echo hi", name="greet"), t0)
-	'\\x1b[90m[2026-05-21 14:30:00.123]\\x1b[0m \\x1b[95m▶ [greet] started\\x1b[0m'
+	'\x1b[90m[2026-05-21 14:30:00.123]\x1b[0m \x1b[95m▶ [greet] started\x1b[0m'
 	>>> fmt_started(StatusOptions(started_fmt=""), Task("echo hi"), t0) is None
 	True
 	>>> fmt_started(
@@ -134,15 +138,16 @@ def fmt_started(opts: StatusOptions, task: Task, ts: datetime) -> str | None:
 
 
 def fmt_completed(opts: StatusOptions, task: Task, c: Completion, ts: datetime) -> str | None:
-	"""Render the completion line, or ``None`` when the matching template is empty.
+	r"""Render the completion line, or ``None`` when the matching template is empty.
 
+	>>> from datetime import datetime
 	>>> t0 = datetime(2026, 5, 21, 14, 30, 0, 123000)
 	>>> fmt_completed(StatusOptions(), Task("a", name="lint"), Finished(0, 1.5, ()), t0)
-	'\\x1b[90m[2026-05-21 14:30:00.123]\\x1b[0m \\x1b[32m✓ [lint] success\\x1b[0m (1.500s)'
+	'\x1b[90m[2026-05-21 14:30:00.123]\x1b[0m \x1b[32m✓ [lint] success\x1b[0m (1.500s)'
 	>>> fmt_completed(StatusOptions(), Task("a", name="lint"), Finished(2, 0.5, ()), t0)
-	'\\x1b[90m[2026-05-21 14:30:00.123]\\x1b[0m \\x1b[31m✗ [lint] error\\x1b[0m exit=2 (0.500s)'
+	'\x1b[90m[2026-05-21 14:30:00.123]\x1b[0m \x1b[31m✗ [lint] error\x1b[0m exit=2 (0.500s)'
 	>>> fmt_completed(StatusOptions(), Task("a", name="follow"), Skipped(2), t0)
-	'\\x1b[90m[2026-05-21 14:30:00.123]\\x1b[0m \\x1b[90m⏭ [follow] skipped\\x1b[0m (prior rc=2)'
+	'\x1b[90m[2026-05-21 14:30:00.123]\x1b[0m \x1b[90m⏭ [follow] skipped\x1b[0m (prior rc=2)'
 	>>> fmt_completed(
 	...     StatusOptions(finished_fmt=""), Task("a"), Finished(0, 1.0, ()), t0,
 	... ) is None
@@ -171,14 +176,15 @@ def fmt_completed(opts: StatusOptions, task: Task, c: Completion, ts: datetime) 
 
 
 def fmt_output(opts: StatusOptions, task: Task, line: bytes, ts: datetime) -> str | None:
-	"""Render a stream-mode output line (ANSI-stripped, trailing newline removed).
+	r"""Render a stream-mode output line (ANSI-stripped, trailing newline removed).
 
+	>>> from datetime import datetime
 	>>> t0 = datetime(2026, 5, 21, 14, 30, 0, 123000)
-	>>> fmt_output(StatusOptions(), Task("a", name="lint"), b"hello\\n", t0)
-	'\\x1b[90m[2026-05-21 14:30:00.123] · [lint]\\x1b[0m hello'
-	>>> fmt_output(StatusOptions(), Task("a", name="lint"), b"\\x1b[31mred\\x1b[0m\\n", t0)
-	'\\x1b[90m[2026-05-21 14:30:00.123] · [lint]\\x1b[0m red'
-	>>> fmt_output(StatusOptions(output_fmt=""), Task("a"), b"x\\n", t0) is None
+	>>> fmt_output(StatusOptions(), Task("a", name="lint"), b"hello\n", t0)
+	'\x1b[90m[2026-05-21 14:30:00.123] · [lint]\x1b[0m hello'
+	>>> fmt_output(StatusOptions(), Task("a", name="lint"), b"\x1b[31mred\x1b[0m\n", t0)
+	'\x1b[90m[2026-05-21 14:30:00.123] · [lint]\x1b[0m red'
+	>>> fmt_output(StatusOptions(output_fmt=""), Task("a"), b"x\n", t0) is None
 	True
 	"""
 	if not opts.output_fmt:
@@ -193,20 +199,23 @@ def fmt_output(opts: StatusOptions, task: Task, line: bytes, ts: datetime) -> st
 
 
 def _github_safe_title(label: str) -> str:
-	"""Strip newlines/CRs so a ``::group::`` title stays on one line.
+	r"""Strip newlines/CRs so a ``::group::`` title stays on one line.
 
 	>>> _github_safe_title("normal")
 	'normal'
-	>>> _github_safe_title("a\\nb\\rc")
+	>>> _github_safe_title("a\nb\rc")
 	'a b c'
 	"""
 	return label.replace("\r", " ").replace("\n", " ")
 
 
 def _github_stop_token(body: str) -> str:
-	"""Pick a stop-commands token that does not appear as ``::{token}::`` in ``body``.
+	r"""Pick a stop-commands token that does not appear as ``::{token}::`` in ``body``.
 
-	>>> tok = _github_stop_token("plain body\\n")
+	Raises:
+		RuntimeError: if 32 random tokens all collide (practically unreachable).
+
+	>>> tok = _github_stop_token("plain body\n")
 	>>> len(tok) >= 8 and tok.isalnum()
 	True
 	"""
@@ -218,22 +227,22 @@ def _github_stop_token(body: str) -> str:
 
 
 def _format_github_group(title: str, body: str, token: str) -> str:
-	"""Wrap ``body`` in a GitHub ``::group::`` with ``::stop-commands::`` neutralization.
+	r"""Wrap ``body`` in a GitHub ``::group::`` with ``::stop-commands::`` neutralization.
 
 	The stop-commands bracket disables workflow-command parsing for the body
 	so output lines like ``::endgroup::`` or ``::add-mask::`` are emitted
 	verbatim instead of being interpreted by Actions.
 
-	>>> _format_github_group("x", "ok\\n", "T")
-	'::group::x\\n::stop-commands::T\\nok\\n::T::\\n::endgroup::\\n'
-	>>> _format_github_group("x", "::endgroup::\\n", "T")
-	'::group::x\\n::stop-commands::T\\n::endgroup::\\n::T::\\n::endgroup::\\n'
+	>>> _format_github_group("x", "ok\n", "T")
+	'::group::x\n::stop-commands::T\nok\n::T::\n::endgroup::\n'
+	>>> _format_github_group("x", "::endgroup::\n", "T")
+	'::group::x\n::stop-commands::T\n::endgroup::\n::T::\n::endgroup::\n'
 	"""
 	return f"::group::{title}\n::stop-commands::{token}\n{body}::{token}::\n::endgroup::\n"
 
 
 def block_for(mode: OutputMode, task: Task, c: Completion, output: bytes) -> str:
-	"""Return the completion-block text for ``mode`` (empty when nothing to dump).
+	r"""Return the completion-block text for ``mode`` (empty when nothing to dump).
 
 	Output bytes are passed through verbatim — ANSI escapes are preserved so
 	downstream viewers (terminals, Actions logs) render the original colors.
@@ -242,22 +251,22 @@ def block_for(mode: OutputMode, task: Task, c: Completion, output: bytes) -> str
 	``::endgroup::`` or ``::warning::``) cannot prematurely close the group
 	or inject workflow commands.
 
-	>>> block_for("all", Task("a", name="x"), Finished(0, 1.0, ()), b"ok\\n")
-	'ok\\n'
-	>>> block_for("all", Task("a"), Finished(0, 1.0, ()), b"\\x1b[32mgreen\\x1b[0m\\n")
-	'\\x1b[32mgreen\\x1b[0m\\n'
-	>>> block_for("errors", Task("a", name="x"), Finished(0, 1.0, ()), b"ok\\n")
+	>>> block_for("all", Task("a", name="x"), Finished(0, 1.0, ()), b"ok\n")
+	'ok\n'
+	>>> block_for("all", Task("a"), Finished(0, 1.0, ()), b"\x1b[32mgreen\x1b[0m\n")
+	'\x1b[32mgreen\x1b[0m\n'
+	>>> block_for("errors", Task("a", name="x"), Finished(0, 1.0, ()), b"ok\n")
 	''
-	>>> block_for("errors", Task("a", name="x"), Finished(2, 1.0, ()), b"boom\\n")
-	'boom\\n'
-	>>> out = block_for("github", Task("a", name="x"), Finished(0, 1.0, ()), b"ok\\n")
-	>>> out.startswith("::group::x\\n::stop-commands::") and out.endswith("::\\n::endgroup::\\n")
+	>>> block_for("errors", Task("a", name="x"), Finished(2, 1.0, ()), b"boom\n")
+	'boom\n'
+	>>> out = block_for("github", Task("a", name="x"), Finished(0, 1.0, ()), b"ok\n")
+	>>> out.startswith("::group::x\n::stop-commands::") and out.endswith("::\n::endgroup::\n")
 	True
-	>>> "ok\\n" in out
+	>>> "ok\n" in out
 	True
-	>>> block_for("quiet", Task("a"), Finished(0, 1.0, ()), b"ok\\n")
+	>>> block_for("quiet", Task("a"), Finished(0, 1.0, ()), b"ok\n")
 	''
-	>>> block_for("stream", Task("a"), Finished(0, 1.0, ()), b"ok\\n")
+	>>> block_for("stream", Task("a"), Finished(0, 1.0, ()), b"ok\n")
 	''
 	>>> block_for("all", Task("a"), Finished(0, 1.0, ()), b"")
 	''
@@ -294,7 +303,7 @@ def emit(text: str) -> None:
 
 
 def emit_line(text: str | None) -> None:
-	"""Write ``text`` + ``\\n`` when non-empty; no-op for ``None``/empty string."""
+	r"""Write ``text`` + ``\n`` when non-empty; no-op for ``None``/empty string."""
 	if not text:
 		return
 	emit(text + "\n")
@@ -320,6 +329,11 @@ def next_ctx_on_output(mode: OutputMode, ctx: Active, line: bytes) -> Active:
 
 
 class Status:
+	"""Line-oriented status Effect; behavior is selected by ``StatusOptions.output_mode``.
+
+	See the module docstring for how it relates to ``Termtree`` and ``Summary``.
+	"""
+
 	def __init__(self, options: StatusOptions = StatusOptions()) -> None:
 		self.options: Final = options
 

--- a/src/camas/effect/summary.py
+++ b/src/camas/effect/summary.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: 2026 JP Hutchins
 
+"""Effect: silent during the run, then one final tree render at teardown."""
+
 import shutil
 import sys
 import time

--- a/src/camas/effect/termtree.py
+++ b/src/camas/effect/termtree.py
@@ -1,7 +1,10 @@
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: 2026 JP Hutchins
 
+"""Effect: live terminal tree that repaints leaf states in place each frame."""
+
 import asyncio
+import contextlib
 import shutil
 import sys
 import time
@@ -204,9 +207,9 @@ def render_progress_bar(states: Sequence[LeafState], width: int) -> str:
 
 
 def decode_line(line: bytes) -> str:
-	"""Decode a captured output line (stripped of trailing whitespace).
+	r"""Decode a captured output line (stripped of trailing whitespace).
 
-	>>> decode_line(b"hello\\n")
+	>>> decode_line(b"hello\n")
 	'hello'
 	>>> decode_line(b"")
 	''
@@ -215,13 +218,13 @@ def decode_line(line: bytes) -> str:
 
 
 def last_line_display(output: Sequence[bytes]) -> str:
-	"""Decode the final non-empty output line for inline display.
+	r"""Decode the final non-empty output line for inline display.
 
-	>>> last_line_display([b"first\\n", b"last\\n"])
+	>>> last_line_display([b"first\n", b"last\n"])
 	'last'
 	>>> last_line_display([])
 	''
-	>>> last_line_display([b"\\n", b"  \\n"])
+	>>> last_line_display([b"\n", b"  \n"])
 	''
 	"""
 	for line in reversed(output):
@@ -327,11 +330,11 @@ def render_frame(
 	now: datetime,
 	wall_elapsed: float,
 ) -> str:
-	"""Render one positioned frame as an ANSI string, for live animation.
+	r"""Render one positioned frame as an ANSI string, for live animation.
 
-	Starts with CPL (`\\033[NF`) to move the cursor up N lines to column 1,
+	Starts with CPL (`\033[NF`) to move the cursor up N lines to column 1,
 	then writes the frame. Callers must first reserve N+1 rows of vertical
-	space (via `"\\n" * N`) so the frame has room to render inline without
+	space (via `"\n" * N`) so the frame has room to render inline without
 	scrolling the viewport.
 	"""
 	lines: Final = render_lines(rows, states, term_width, display_width, now, wall_elapsed)
@@ -465,10 +468,8 @@ class Termtree:
 		ctx: Final = ctxs[0]  # zuban: ignore[misc] # zuban defies PEP591
 		if ctx.state.tick_task is not None:  # pragma: no branch
 			ctx.state.tick_task.cancel()
-			try:
+			with contextlib.suppress(asyncio.CancelledError):
 				await ctx.state.tick_task
-			except asyncio.CancelledError:
-				pass
 		draw(ctx)
 		sys.stdout.write("\n")
 		sys.stdout.flush()

--- a/src/camas/main/__init__.py
+++ b/src/camas/main/__init__.py
@@ -1,4 +1,6 @@
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: 2026 JP Hutchins
 
+"""CLI package: re-exports ``main`` for the console script and ``python -m camas``."""
+
 from .entrypoint import main as main

--- a/src/camas/main/argv.py
+++ b/src/camas/main/argv.py
@@ -1,12 +1,13 @@
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: 2026 JP Hutchins
 
+"""argv pre-processing: ``--`` passthrough splitting and matrix axis overrides."""
+
 from __future__ import annotations
 
 import shlex
 import sys
-from collections.abc import Sequence
-from typing import Final, NamedTuple
+from typing import TYPE_CHECKING, Final, NamedTuple
 
 if sys.version_info >= (3, 11):
 	from typing import assert_never
@@ -14,6 +15,9 @@ else:  # pragma: no cover
 	from typing_extensions import assert_never
 
 from ..core.task import Parallel, Sequential, Task, TaskNode
+
+if TYPE_CHECKING:
+	from collections.abc import Sequence
 
 
 class SplitArgv(NamedTuple):
@@ -54,6 +58,9 @@ def apply_passthrough(task: TaskNode, args: tuple[str, ...]) -> Task:
 	string commands stay strings (args shell-joined and appended) so dry-run/tree
 	output keeps the user's original quoting.
 
+	Raises:
+		ValueError: if ``task`` is a ``Sequential`` or ``Parallel``.
+
 	>>> apply_passthrough(Task("pytest"), ("-v",))
 	Task(cmd='pytest -v', name=None, env={}, cwd=None)
 	>>> apply_passthrough(Task("git commit -m 'big msg'"), ("--no-verify",))
@@ -82,6 +89,9 @@ def apply_passthrough(task: TaskNode, args: tuple[str, ...]) -> Task:
 
 def parse_matrix_kv(raw: str) -> tuple[str, tuple[str, ...]]:
 	"""Parse ``KEY=VAL[,VAL...]`` into ``(key, values)``.
+
+	Raises:
+		ValueError: on a missing or empty key, or an empty value list.
 
 	>>> parse_matrix_kv("PY=3.13")
 	('PY', ('3.13',))

--- a/src/camas/main/check.py
+++ b/src/camas/main/check.py
@@ -116,16 +116,16 @@ def find_typechecker() -> FoundChecker | None:
 
 
 def run_eval(tasks_py: Path) -> EvalResult:
-	"""Execute ``tasks_py`` via :mod:`runpy`; capture any :class:`Exception`.
+	r"""Execute ``tasks_py`` via :mod:`runpy`; capture any :class:`Exception`.
 
 	>>> import tempfile
 	>>> with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False) as f:
-	...     _ = f.write("x = 1\\n")
+	...     _ = f.write("x = 1\n")
 	...     ok = Path(f.name)
 	>>> isinstance(run_eval(ok), EvalOk)
 	True
 	>>> with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False) as f:
-	...     _ = f.write("raise ValueError('boom')\\n")
+	...     _ = f.write("raise ValueError('boom')\n")
 	...     bad = Path(f.name)
 	>>> r = run_eval(bad)
 	>>> isinstance(r, EvalErr) and isinstance(r.exception, ValueError)
@@ -166,6 +166,7 @@ def run_typecheck(tasks_py: Path) -> TypeCheckResult:
 		text=True,
 		encoding="utf-8",
 		errors="replace",
+		check=False,
 	)
 	if proc.returncode == 0:
 		return CheckerOk(name=found.name)
@@ -236,7 +237,7 @@ def format_minimal_trace(exc: Exception, tasks_py: Path) -> str:
 
 
 def format_checker_output(result: TypeCheckResult, *, after_trace: bool) -> str:
-	"""Format ``result`` for stderr.
+	r"""Format ``result`` for stderr.
 
 	``after_trace`` flips two behaviours used to merge typechecker output with
 	a preceding eval trace: it prepends a blank-line separator before a
@@ -246,7 +247,7 @@ def format_checker_output(result: TypeCheckResult, *, after_trace: bool) -> str:
 	>>> format_checker_output(CheckerOk(name="ty"), after_trace=False)
 	''
 	>>> format_checker_output(CheckerErr("ty", "msg"), after_trace=True)
-	'\\nty:\\nmsg'
+	'\nty:\nmsg'
 	"""
 	match result:
 		case CheckerErr(name=name, output=out):

--- a/src/camas/main/color.py
+++ b/src/camas/main/color.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: 2026 JP Hutchins
 
+"""ANSI codes and helpers for CLI output (listings and help, not Effects)."""
+
 from typing import Final
 
 from ..core.render import RESET
@@ -13,7 +15,8 @@ BOLD_YELLOW: Final = "\033[1;33m"
 
 def wrap_ansi(text: str, code: str) -> str:
 	"""Unconditionally wrap ``text`` in ``code``...``RESET``. Callers gate via
-	``maybe_color`` (or by checking ``color_on()`` themselves)."""
+	``maybe_color`` (or by checking ``color_on()`` themselves).
+	"""
 	return f"{code}{text}{RESET}" if text else text
 
 

--- a/src/camas/main/dispatch.py
+++ b/src/camas/main/dispatch.py
@@ -1,14 +1,15 @@
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: 2026 JP Hutchins
 
+"""CLI dispatch: resolve the tasks source, parse argv, then run or print."""
+
 from __future__ import annotations
 
 import ast
 import asyncio
 import sys
-from collections.abc import Mapping
 from pathlib import Path
-from typing import Final
+from typing import TYPE_CHECKING, Final
 
 if sys.version_info >= (3, 11):
 	from typing import assert_never
@@ -18,7 +19,6 @@ else:  # pragma: no cover
 from ..core.execution import run
 from ..core.matrix import matrix_axes, override_matrix
 from ..core.render import color_on
-from ..core.task import TaskNode
 from .argv import apply_passthrough, parse_axis_values, parse_matrix_kv, split_passthrough
 from .effects import parse_effects
 from .expression import parse_expression
@@ -35,6 +35,11 @@ from .format import (
 from .parser import RESERVED_FLAGS, build_parser
 from .state import EMPTY_STATE, LoadErr, LoadOk, TasksState
 from .tasks import load_tasks, load_tasks_from_py, name_scope_bindings, name_scope_effects
+
+if TYPE_CHECKING:
+	from collections.abc import Mapping
+
+	from ..core.task import TaskNode
 
 
 def dispatch_arg(arg: str, tasks: Mapping[str, TaskNode]) -> TaskNode:

--- a/src/camas/main/effects.py
+++ b/src/camas/main/effects.py
@@ -1,16 +1,20 @@
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: 2026 JP Hutchins
 
+"""Discover Effect classes and evaluate the ``--effects`` mini-language."""
+
 from __future__ import annotations
 
 import ast
 import functools
-from collections.abc import Mapping
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from ..core.effect import Effect
 from .expression import format_syntax_error
 from .mypyc import MISSING, signature_fields_from_source
+
+if TYPE_CHECKING:
+	from collections.abc import Mapping
 
 
 @functools.cache
@@ -183,6 +187,10 @@ def parse_effects(
 	``scope_effects`` is a mapping of user-defined Effect classes
 	(typically from a ``tasks.py`` scope) merged with the built-in registry.
 
+	Raises:
+		ValueError: on syntax errors, non-tuple expressions, unknown names,
+			or elements that are not Effect instances.
+
 	>>> [type(e).__name__ for e in parse_effects("(Summary(),)")]
 	['Summary']
 	>>> [type(e).__name__ for e in parse_effects("(Termtree(), Summary())")]
@@ -205,7 +213,11 @@ def parse_effects(
 def eval_value(node: ast.expr, constructors: Mapping[str, Any]) -> Any:
 	"""Evaluate a node in the --effects mini-language. Returns Any since the
 	concrete type depends on the AST shape; ``expect_effect`` validates at the
-	tuple level."""
+	tuple level.
+
+	Raises:
+		ValueError: on syntax outside the mini-language.
+	"""
 	match node:
 		case ast.Constant(value=val):
 			return val

--- a/src/camas/main/entrypoint.py
+++ b/src/camas/main/entrypoint.py
@@ -1,13 +1,17 @@
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: 2026 JP Hutchins
 
+"""The ``camas`` console-script entry point."""
+
 from __future__ import annotations
 
-import io
 import sys
-from typing import cast
+from typing import TYPE_CHECKING, cast
 
 from .dispatch import dispatch, resolve_tasks_source
+
+if TYPE_CHECKING:
+	import io
 
 
 def main() -> None:
@@ -17,7 +21,7 @@ def main() -> None:
 	render the box-drawing characters used in the tree output.
 	"""
 	for stream in (sys.stdout, sys.stderr):
-		cast(io.TextIOWrapper, stream).reconfigure(encoding="utf-8", errors="replace")
+		cast("io.TextIOWrapper", stream).reconfigure(encoding="utf-8", errors="replace")
 	dispatch(*resolve_tasks_source(sys.argv[1:]))
 
 

--- a/src/camas/main/expression.py
+++ b/src/camas/main/expression.py
@@ -1,13 +1,14 @@
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: 2026 JP Hutchins
 
+"""AST-evaluate the CLI task-expression mini-language into a task tree."""
+
 from __future__ import annotations
 
 import ast
 import re
 import sys
-from collections.abc import Mapping
-from typing import Final, NamedTuple, cast
+from typing import TYPE_CHECKING, Final, NamedTuple, cast
 
 if sys.version_info >= (3, 11):
 	from typing import assert_never
@@ -15,6 +16,9 @@ else:  # pragma: no cover
 	from typing_extensions import assert_never
 
 from ..core.task import Parallel, Sequential, Task, TaskNode
+
+if TYPE_CHECKING:
+	from collections.abc import Mapping
 
 
 class Ref(NamedTuple):
@@ -136,8 +140,9 @@ def eval_matrix(node: ast.expr | None) -> dict[str, tuple[str, ...]] | None:
 
 def children(elts: list[ast.expr], allow_refs: bool) -> tuple[TaskNode, ...]:
 	"""Evaluate task-position children. ``Ref``s pass through here at the type level
-	via ``cast`` — they're resolved later by ``resolve_refs``."""
-	return cast(tuple[TaskNode, ...], tuple(eval_task_pos(e, allow_refs) for e in elts))
+	via ``cast`` — they're resolved later by ``resolve_refs``.
+	"""
+	return cast("tuple[TaskNode, ...]", tuple(eval_task_pos(e, allow_refs) for e in elts))
 
 
 def eval_task_pos(node: ast.expr, allow_refs: bool) -> TaskNode | Ref:
@@ -171,6 +176,9 @@ def eval_node(
 	allow_refs: bool = False,
 ) -> TaskNode | Ref:
 	"""Walk an AST node and construct the corresponding TaskNode or Ref safely (no eval).
+
+	Raises:
+		ValueError: on names or call shapes outside the expression language.
 
 	>>> import ast
 	>>> eval_node(ast.parse('Task("echo hi")', mode="eval").body)
@@ -265,17 +273,20 @@ def parse_expression(expr: str, tasks: Mapping[str, TaskNode] | None = None) -> 
 
 
 def parse_task_value(raw: str) -> TaskNode | Ref:
-	"""Parse a single pyproject.toml task value. Bare strings become Task(cmd).
+	r"""Parse a single pyproject.toml task value. Bare strings become Task(cmd).
 
 	A leading ``Task``/``Sequential``/``Parallel``/``Ref`` call, ``(``, or ``{`` triggers
 	AST-based parsing — letting users use the fluent ``(a, b)`` (Sequential) and
 	``{a, b}`` (Parallel) literals as well as explicit constructor calls.
 
+	Raises:
+		ValueError: when an expression-like value fails to parse.
+
 	>>> parse_task_value("ruff check .")
 	Task(cmd='ruff check .', name=None, env={}, cwd=None)
 	>>> parse_task_value('Task("pytest")')
 	Task(cmd='pytest', name=None, env={}, cwd=None)
-	>>> parse_task_value("Ref(\\"lint\\")")
+	>>> parse_task_value("Ref(\"lint\")")
 	Ref(name='lint')
 	>>> parse_task_value("(a, b)")
 	Sequential(tasks=(Ref(name='a'), Ref(name='b')), name=None, matrix=None, env={}, cwd=None)
@@ -297,6 +308,9 @@ def resolve_refs(
 	visiting: frozenset[str],
 ) -> TaskNode:
 	"""Recursively substitute Ref(name) with its defined TaskNode. Detects cycles.
+
+	Raises:
+		ValueError: on an unknown ref or a reference cycle.
 
 	>>> resolve_refs(Task("x"), {}, frozenset())
 	Task(cmd='x', name=None, env={}, cwd=None)

--- a/src/camas/main/format.py
+++ b/src/camas/main/format.py
@@ -1,26 +1,31 @@
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: 2026 JP Hutchins
 
+"""Plain-text formatting for task listings, summaries, and load-error hints."""
+
 from __future__ import annotations
 
 import re
 import sys
-from collections.abc import Mapping
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 if sys.version_info >= (3, 11):
 	from typing import assert_never
 else:  # pragma: no cover
 	from typing_extensions import assert_never
 
-from ..core.effect import Effect
 from ..core.matrix import matrix_axes
 from ..core.render import GREY, RESET, color_on, render_tree_lines
 from ..core.task import Parallel, Sequential, Task, TaskNode
 from .color import BLUE, BOLD_BLUE, BOLD_CYAN, BOLD_YELLOW, maybe_color, wrap_ansi
 from .effects import available_effects, flatten_annotation, signature_fields
 from .mypyc import MISSING
+
+if TYPE_CHECKING:
+	from collections.abc import Mapping
+
+	from ..core.effect import Effect
 
 
 def is_named_ref(node: TaskNode, names: frozenset[str]) -> bool:
@@ -29,7 +34,8 @@ def is_named_ref(node: TaskNode, names: frozenset[str]) -> bool:
 
 def par_child_summary(node: TaskNode, names: frozenset[str]) -> str:
 	"""Render a Parallel child, parenthesising an anonymous Sequential because
-	``,`` binds looser than ``|``."""
+	``,`` binds looser than ``|``.
+	"""
 	rendered = task_summary(node, names, is_root=False)
 	if isinstance(node, Sequential) and not is_named_ref(node, names) and len(node.tasks) > 1:
 		return f"({rendered})"
@@ -209,7 +215,8 @@ def format_matrix_axes_help(axes: Mapping[str, tuple[str, ...]], color: bool) ->
 
 def print_task_help(name: str, task: TaskNode) -> None:
 	"""Print subcommand help for a single task: its expanded tree and any
-	matrix axes the user can override from the CLI."""
+	matrix axes the user can override from the CLI.
+	"""
 	axes = matrix_axes(task)
 	axis_flags = "".join(f" [--{k} VAL[,VAL...]]" for k in axes)
 	print(f"usage: camas {name} [-h] [--dry-run] [--effects EFFECTS]{axis_flags}")
@@ -245,7 +252,8 @@ def format_default(default: Any, color: bool) -> str:
 
 def format_signature(cls: Any, indent: str, color: bool) -> list[str]:
 	"""Render ``cls(field: Type = default, …)`` plus nested signatures of any
-	camas.effect classes appearing in the field annotations."""
+	camas.effect classes appearing in the field annotations.
+	"""
 	import inspect
 
 	fields = signature_fields(cls)
@@ -353,8 +361,4 @@ def print_available_effects(
 
 def first_line_doc(obj: Any) -> str:
 	doc = getattr(obj, "__doc__", None) or ""
-	for line in doc.splitlines():
-		line = line.strip()
-		if line:
-			return line
-	return ""
+	return next((stripped for line in doc.splitlines() if (stripped := line.strip())), "")

--- a/src/camas/main/mypyc.py
+++ b/src/camas/main/mypyc.py
@@ -12,9 +12,11 @@ signatures the help formatter needs.
 from __future__ import annotations
 
 import ast
-from collections.abc import Mapping
 from pathlib import Path
-from typing import Any, Final
+from typing import TYPE_CHECKING, Any, Final
+
+if TYPE_CHECKING:
+	from collections.abc import Mapping
 
 MISSING: Final = object()
 
@@ -85,9 +87,10 @@ def signature_fields_from_source(cls: Any) -> list[tuple[str, Any, Any, Any]] | 
 def resolve_in_namespace(node: ast.expr, ns: Mapping[str, Any]) -> Any:
 	"""Evaluate an AST expression in ``ns`` (the source module's globals).
 	Falls back to the unparsed string when evaluation fails — typically a
-	forward reference to a name not yet bound when the source is read."""
+	forward reference to a name not yet bound when the source is read.
+	"""
 	src = ast.unparse(node)
 	try:
-		return eval(src, dict(ns))  # noqa: S307 — evaluating our own annotations
-	except Exception:  # noqa: BLE001
+		return eval(src, dict(ns))  # evaluating our own annotations
+	except Exception:
 		return src

--- a/src/camas/main/parser.py
+++ b/src/camas/main/parser.py
@@ -1,23 +1,22 @@
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: 2026 JP Hutchins
 
+"""argparse construction: help is generated from the loaded tasks and effects."""
+
 from __future__ import annotations
 
 import argparse
 import importlib.metadata
 import os
 import sys
-from collections.abc import Mapping
-from typing import Any, Final
+from typing import TYPE_CHECKING, Any, Final
 
 if sys.version_info >= (3, 11):
 	from typing import assert_never
 else:  # pragma: no cover
 	from typing_extensions import assert_never
 
-from ..core.effect import Effect
 from ..core.render import color_on
-from ..core.task import TaskNode
 from .check import describe_check_help
 from .format import (
 	format_available_effects,
@@ -27,6 +26,12 @@ from .format import (
 	format_try_hint,
 )
 from .state import EMPTY_STATE, LoadErr, LoadOk, TasksState
+
+if TYPE_CHECKING:
+	from collections.abc import Mapping
+
+	from ..core.effect import Effect
+	from ..core.task import TaskNode
 
 
 def default_effects_expr() -> str:

--- a/src/camas/main/state.py
+++ b/src/camas/main/state.py
@@ -14,13 +14,15 @@ the types without a cycle.
 
 from __future__ import annotations
 
-from collections.abc import Mapping
-from pathlib import Path
 from types import MappingProxyType
-from typing import Any, Final, NamedTuple, TypeAlias
+from typing import TYPE_CHECKING, Any, Final, NamedTuple, TypeAlias
 
-from ..core.effect import Effect
-from ..core.task import TaskNode
+if TYPE_CHECKING:
+	from collections.abc import Mapping
+	from pathlib import Path
+
+	from ..core.effect import Effect
+	from ..core.task import TaskNode
 
 
 class LoadOk(NamedTuple):

--- a/src/camas/main/tasks.py
+++ b/src/camas/main/tasks.py
@@ -1,13 +1,13 @@
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: 2026 JP Hutchins
 
+"""Load task definitions from ``[tool.camas.tasks]`` or a ``tasks.py`` scope."""
+
 from __future__ import annotations
 
 import runpy
 import sys
-from collections.abc import Mapping
-from pathlib import Path
-from typing import Any, Final, TypeGuard, cast
+from typing import TYPE_CHECKING, Any, Final, TypeGuard, cast
 
 if sys.version_info >= (3, 11):
 	from typing import assert_never
@@ -20,6 +20,10 @@ else:  # pragma: no cover
 from ..core.effect import Effect
 from ..core.task import Parallel, Sequential, Task, TaskNode
 from .expression import Ref, parse_task_value, resolve_refs
+
+if TYPE_CHECKING:
+	from collections.abc import Mapping
+	from pathlib import Path
 
 
 def find_pyproject(start: Path) -> Path | None:
@@ -65,6 +69,10 @@ def load_tasks(path: Path) -> tuple[dict[str, TaskNode], dict[str, type[Effect[A
 	Returns ``(tasks, scope_effects)``; ``scope_effects`` is always empty for
 	pyproject sources (TOML can't host Python classes) — the pair shape is
 	for symmetry with :func:`load_tasks_from_py`.
+
+	Raises:
+		ValueError: when the table or a task value has the wrong type, or a
+			task fails to parse or resolve.
 	"""
 	parsed: dict[str, Any] = tomllib.loads(path.read_text())
 	raw: Any = dig(dig(dig(parsed, "tool"), "camas"), "tasks")

--- a/tests/core/test_effect.py
+++ b/tests/core/test_effect.py
@@ -5,8 +5,7 @@ from __future__ import annotations
 
 import asyncio
 import sys
-from collections.abc import Sequence
-from typing import NamedTuple
+from typing import TYPE_CHECKING, NamedTuple
 
 import pytest
 
@@ -19,8 +18,12 @@ from camas import Parallel, Sequential, Task
 from camas.core.completion import Skipped
 from camas.core.execution import run
 from camas.core.leaf_state import Completed, LeafState
-from camas.core.task import TaskNode
 from camas.core.task_event import CompletedEvent, StartedEvent, TaskEvent
+
+if TYPE_CHECKING:
+	from collections.abc import Sequence
+
+	from camas.core.task import TaskNode
 
 
 class RecorderCtx(NamedTuple):
@@ -95,7 +98,8 @@ def test_multi_effect_receives_identical_streams() -> None:
 		)
 	)
 
-	assert a.final is not None and b.final is not None
+	assert a.final is not None
+	assert b.final is not None
 	assert a.final == b.final
 	all_events = [e for ctx in a.final for e in ctx.events]
 	assert any(isinstance(e, StartedEvent) for e in all_events)
@@ -145,7 +149,7 @@ def test_sequential_skip_emits_skipped_completed_event() -> None:
 
 
 def test_on_event_exception_surfaces_and_teardown_still_runs() -> None:
-	class Boom(Exception):
+	class BoomError(Exception):
 		pass
 
 	class FailCtx(NamedTuple):
@@ -161,13 +165,13 @@ def test_on_event_exception_surfaces_and_teardown_still_runs() -> None:
 		async def on_event(
 			self, event: TaskEvent, states: Sequence[LeafState], ctx: FailCtx
 		) -> FailCtx:
-			raise Boom("effect crashed")
+			raise BoomError("effect crashed")
 
 		async def teardown(self, ctxs: tuple[FailCtx, ...]) -> None:
 			self.torn_down = True
 
 	failing = FailingOnEvent()
-	with pytest.raises(Boom):
+	with pytest.raises(BoomError):
 		asyncio.run(run(Task(("python", "-c", "pass")), effects=(failing,)))
 	assert failing.torn_down is True
 

--- a/tests/effect/test_github_checks.py
+++ b/tests/effect/test_github_checks.py
@@ -6,8 +6,7 @@ from __future__ import annotations
 import asyncio
 import json
 import sys
-from collections.abc import Callable
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 if sys.version_info >= (3, 11):
 	from builtins import BaseExceptionGroup
@@ -40,6 +39,9 @@ from camas.effect.github_checks import (
 	render_body,
 	resolve_config,
 )
+
+if TYPE_CHECKING:
+	from collections.abc import Callable
 
 TS = datetime(2026, 5, 21, 14, 30, 0)
 
@@ -525,7 +527,8 @@ async def test_teardown_fail_on_api_error_raises_exceptiongroup(
 	with pytest.raises(BaseExceptionGroup) as ei:
 		await effect.teardown((Closed(task=bad),))
 	(inner,) = ei.value.exceptions
-	assert isinstance(inner, RuntimeError) and "boom" in str(inner)
+	assert isinstance(inner, RuntimeError)
+	assert "boom" in str(inner)
 
 
 async def test_teardown_logs_errors_without_raising_by_default(

--- a/tests/effect/test_status.py
+++ b/tests/effect/test_status.py
@@ -5,13 +5,12 @@ from __future__ import annotations
 
 import asyncio
 from datetime import datetime
-from typing import TypeVar
+from typing import TYPE_CHECKING, TypeVar
 
 import pytest
 
 from camas import Parallel, Sequential, Task
 from camas.core.completion import Finished, Skipped
-from camas.core.effect import Effect
 from camas.core.leaf_state import LeafState, Waiting, next_state
 from camas.core.task_event import CompletedEvent, OutputEvent, StartedEvent, TaskEvent
 from camas.core.traversal import flatten_leaves
@@ -22,6 +21,9 @@ from camas.effect.status import (
 	Status,
 	StatusOptions,
 )
+
+if TYPE_CHECKING:
+	from camas.core.effect import Effect
 
 TS = datetime(2026, 5, 21, 14, 30, 0, 750_000)
 

--- a/tests/effect/test_summary.py
+++ b/tests/effect/test_summary.py
@@ -4,18 +4,21 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Callable
 from datetime import datetime
-from typing import TypeVar
-
-import pytest
+from typing import TYPE_CHECKING, TypeVar
 
 from camas import Parallel, Sequential, Task
 from camas.core.completion import Finished, Skipped
-from camas.core.effect import Effect
 from camas.core.leaf_state import LeafState, Waiting
 from camas.core.task_event import CompletedEvent, StartedEvent, TaskEvent
 from camas.effect.summary import Fixed, Summary, SummaryOptions
+
+if TYPE_CHECKING:
+	from collections.abc import Callable
+
+	import pytest
+
+	from camas.core.effect import Effect
 
 TS = datetime(2026, 5, 21, 14, 30, 0)
 

--- a/tests/effect/test_termtree.py
+++ b/tests/effect/test_termtree.py
@@ -7,13 +7,12 @@ import asyncio
 import re
 from collections.abc import Callable
 from datetime import datetime
-from typing import TypeVar
+from typing import TYPE_CHECKING, TypeVar
 
 import pytest
 
 from camas import Parallel, Sequential, Task
 from camas.core.completion import Finished, Skipped
-from camas.core.effect import Effect
 from camas.core.leaf_state import Completed, LeafState, Running, Waiting
 from camas.core.render import flatten_rows, strip_ansi
 from camas.core.task_event import CompletedEvent, OutputEvent, StartedEvent, TaskEvent
@@ -26,6 +25,9 @@ from camas.effect.termtree import (
 	render_frame,
 	render_lines,
 )
+
+if TYPE_CHECKING:
+	from camas.core.effect import Effect
 
 TS = datetime(2026, 5, 21, 14, 30, 0)
 

--- a/tests/main/test_check.py
+++ b/tests/main/test_check.py
@@ -402,6 +402,7 @@ def _camas(*args: str, cwd: Path) -> subprocess.CompletedProcess[str]:
 		text=True,
 		encoding="utf-8",
 		env={**os.environ, "NO_COLOR": "1"},
+		check=False,
 	)
 
 
@@ -486,9 +487,8 @@ def test_camas_check_via_dispatch_run_cli_path(
 	(tmp_path / "tasks.py").write_text("from camas import Task\nhi = Task('echo hi')\n")
 	scope: dict[str, object] = {"__file__": str(tmp_path / "tasks.py"), "hi": object()}
 	monkeypatch.setattr(check_mod, "run_typecheck", _stub_ok)
-	with pytest.raises(SystemExit, match="0"):
-		with patch("sys.argv", ["tasks.py", "--check"]):
-			run_cli(scope)
+	with pytest.raises(SystemExit, match="0"), patch("sys.argv", ["tasks.py", "--check"]):
+		run_cli(scope)
 
 
 def test_dispatch_check_with_load_error_runs_report_eval_error(
@@ -574,9 +574,8 @@ def test_run_cli_accepts_path_for_file(tmp_path: Path, monkeypatch: pytest.Monke
 	(tmp_path / "tasks.py").write_text("from camas import Task\nhi = Task('echo hi')\n")
 	scope: dict[str, object] = {"__file__": tmp_path / "tasks.py", "hi": object()}
 	monkeypatch.setattr(check_mod, "run_typecheck", _stub_ok)
-	with pytest.raises(SystemExit, match="0"):
-		with patch("sys.argv", ["tasks.py", "--check"]):
-			run_cli(scope)
+	with pytest.raises(SystemExit, match="0"), patch("sys.argv", ["tasks.py", "--check"]):
+		run_cli(scope)
 
 
 def test_empty_state_is_immutable() -> None:

--- a/tests/main/test_dispatch.py
+++ b/tests/main/test_dispatch.py
@@ -3,16 +3,19 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import pytest
 
 from camas import Parallel, Task
-from camas.core.effect import Effect
-from camas.core.task import TaskNode
 from camas.main.dispatch import dispatch
 from camas.main.state import LoadOk
+
+if TYPE_CHECKING:
+	from collections.abc import Mapping
+
+	from camas.core.effect import Effect
+	from camas.core.task import TaskNode
 
 
 def _state(tasks: Mapping[str, TaskNode]) -> LoadOk:

--- a/tests/main/test_effects.py
+++ b/tests/main/test_effects.py
@@ -8,9 +8,9 @@ import inspect
 import pkgutil
 import sys
 import types
-from collections.abc import Iterator
 from dataclasses import dataclass, field
 from pkgutil import ModuleInfo
+from typing import TYPE_CHECKING
 
 import pytest
 
@@ -23,6 +23,9 @@ from camas.main.effects import (
 	signature_fields,
 )
 from camas.main.mypyc import MISSING
+
+if TYPE_CHECKING:
+	from collections.abc import Iterator
 
 
 def test_parse_effects_rejects_invalid_syntax() -> None:
@@ -113,7 +116,7 @@ def test_isinstance_effect_branch_in_discovery(monkeypatch: pytest.MonkeyPatch) 
 	from camas.effect.summary import Summary
 
 	plugin = types.ModuleType("camas.effect._test_plugin")
-	setattr(plugin, "my_effect", Summary())
+	setattr(plugin, "my_effect", Summary())  # noqa: B010
 	monkeypatch.setitem(sys.modules, "camas.effect._test_plugin", plugin)
 
 	real_iter = pkgutil.iter_modules

--- a/tests/main/test_format.py
+++ b/tests/main/test_format.py
@@ -3,13 +3,9 @@
 
 from __future__ import annotations
 
-from pathlib import Path
-from typing import Any
-
-import pytest
+from typing import TYPE_CHECKING, Any
 
 from camas import Parallel, Sequential, Task
-from camas.core.task import TaskNode
 from camas.main.format import (
 	first_line_doc,
 	format_annotation,
@@ -24,6 +20,14 @@ from camas.main.format import (
 	task_summary,
 )
 from camas.main.mypyc import MISSING
+
+if TYPE_CHECKING:
+	from collections.abc import Mapping
+	from pathlib import Path
+
+	import pytest
+
+	from camas.core.task import TaskNode
 
 
 def test_task_summary_leaf_str_cmd() -> None:
@@ -215,7 +219,6 @@ def test_format_available_effects_no_color() -> None:
 
 
 def test_format_available_effects_empty(monkeypatch: pytest.MonkeyPatch) -> None:
-	from collections.abc import Mapping
 
 	from camas.main import effects as effects_mod
 

--- a/tests/main/test_mypyc.py
+++ b/tests/main/test_mypyc.py
@@ -6,13 +6,15 @@ from __future__ import annotations
 import ast
 import sys
 import types
-from pathlib import Path
-from typing import NamedTuple
-
-import pytest
+from typing import TYPE_CHECKING, NamedTuple
 
 from camas.main.effects import signature_fields
 from camas.main.mypyc import MISSING, resolve_in_namespace, signature_fields_from_source
+
+if TYPE_CHECKING:
+	from pathlib import Path
+
+	import pytest
 
 
 def test_signature_fields_from_source_namedtuple() -> None:
@@ -134,8 +136,10 @@ def test_signature_fields_from_source_with_required_arg(
 	out = signature_fields_from_source(C)
 	assert out is not None
 	(must_have, optional) = out
-	assert must_have[0] == "must_have" and must_have[3] is MISSING
-	assert optional[0] == "optional" and optional[3] == "x"
+	assert must_have[0] == "must_have"
+	assert must_have[3] is MISSING
+	assert optional[0] == "optional"
+	assert optional[3] == "x"
 
 
 def test_signature_fields_falls_back_for_compiled_namedtuple(

--- a/tests/main/test_parser.py
+++ b/tests/main/test_parser.py
@@ -3,9 +3,14 @@
 
 from __future__ import annotations
 
-import pytest
+from typing import TYPE_CHECKING
 
 from camas.main.parser import build_parser
+
+if TYPE_CHECKING:
+	from collections.abc import Mapping
+
+	import pytest
 
 
 def test_parser_has_expression_arg() -> None:
@@ -22,7 +27,6 @@ def test_parser_dry_run_flag() -> None:
 
 
 def test_build_parser_format_help_no_tasks_no_effects(monkeypatch: pytest.MonkeyPatch) -> None:
-	from collections.abc import Mapping
 	from typing import Any
 
 	from camas.main import effects as effects_mod

--- a/tests/main/test_tasks.py
+++ b/tests/main/test_tasks.py
@@ -6,13 +6,12 @@ from __future__ import annotations
 import subprocess
 import sys
 from pathlib import Path
-from typing import cast
+from typing import TYPE_CHECKING, cast
 from unittest.mock import patch
 
 import pytest
 
 from camas import Parallel, Sequential, Task
-from camas.core.task import TaskNode
 from camas.main import main
 from camas.main.dispatch import dispatch_arg, run_cli
 from camas.main.expression import (
@@ -31,6 +30,13 @@ from camas.main.tasks import (
 	name_scope_effects,
 )
 
+if TYPE_CHECKING:
+	from collections.abc import Sequence
+
+	from camas.core.leaf_state import LeafState
+	from camas.core.task import TaskNode
+	from camas.core.task_event import TaskEvent
+
 
 def _par(
 	tasks: tuple[TaskNode | Ref, ...],
@@ -38,7 +44,7 @@ def _par(
 	matrix: dict[str, tuple[str, ...]] | None = None,
 	cwd: Path | None = None,
 ) -> Parallel:
-	return Parallel(*cast(tuple[TaskNode, ...], tasks), name=name, matrix=matrix, cwd=cwd)
+	return Parallel(*cast("tuple[TaskNode, ...]", tasks), name=name, matrix=matrix, cwd=cwd)
 
 
 def _seq(
@@ -47,7 +53,7 @@ def _seq(
 	matrix: dict[str, tuple[str, ...]] | None = None,
 	cwd: Path | None = None,
 ) -> Sequential:
-	return Sequential(*cast(tuple[TaskNode, ...], tasks), name=name, matrix=matrix, cwd=cwd)
+	return Sequential(*cast("tuple[TaskNode, ...]", tasks), name=name, matrix=matrix, cwd=cwd)
 
 
 def test_parse_task_value_bare_string() -> None:
@@ -189,9 +195,8 @@ def test_run_cli_collects_tasks_from_scope(capsys: pytest.CaptureFixture[str]) -
 		"_private": Task("secret"),
 		"other": 42,
 	}
-	with pytest.raises(SystemExit, match="0"):
-		with patch("sys.argv", ["tasks.py", "--list"]):
-			run_cli(scope)
+	with pytest.raises(SystemExit, match="0"), patch("sys.argv", ["tasks.py", "--list"]):
+		run_cli(scope)
 	out = capsys.readouterr().out
 	assert "lint" in out
 	assert "ruff ." in out
@@ -272,10 +277,9 @@ def test_load_tasks_surfaces_syntax_error_with_task_name(tmp_path: Path) -> None
 		")\n"
 		"'''\n"
 	)
-	with pytest.raises(ValueError) as exc:
+	with pytest.raises(ValueError, match="task 'matrix'") as exc:
 		load_tasks(pyproject)
 	msg = str(exc.value)
-	assert "task 'matrix'" in msg
 	assert "invalid syntax (line 3" in msg
 	assert '"PY"=["3.12"]' in msg
 	assert "^" in msg
@@ -373,9 +377,8 @@ def test_list_flag_no_tasks(
 ) -> None:
 	monkeypatch.chdir(tmp_path)
 	(tmp_path / "pyproject.toml").write_text('[project]\nname = "x"\nversion = "0"\n')
-	with pytest.raises(SystemExit, match="0"):
-		with patch("sys.argv", ["camas", "--list"]):
-			main()
+	with pytest.raises(SystemExit, match="0"), patch("sys.argv", ["camas", "--list"]):
+		main()
 	assert "No tasks file found" in capsys.readouterr().out
 
 
@@ -386,9 +389,8 @@ def test_list_flag_with_tasks(
 	(tmp_path / "pyproject.toml").write_text(
 		'[tool.camas.tasks]\nlint = "ruff ."\ntest = "pytest"\n'
 	)
-	with pytest.raises(SystemExit, match="0"):
-		with patch("sys.argv", ["camas", "--list"]):
-			main()
+	with pytest.raises(SystemExit, match="0"), patch("sys.argv", ["camas", "--list"]):
+		main()
 	out = capsys.readouterr().out
 	assert "lint" in out
 	assert "ruff ." in out
@@ -403,9 +405,8 @@ def test_named_task_dry_run(
 	(tmp_path / "pyproject.toml").write_text(
 		'[tool.camas.tasks]\nci = \'Parallel(Task("echo a"), Task("echo b"))\'\n'
 	)
-	with pytest.raises(SystemExit, match="0"):
-		with patch("sys.argv", ["camas", "--dry-run", "ci"]):
-			main()
+	with pytest.raises(SystemExit, match="0"), patch("sys.argv", ["camas", "--dry-run", "ci"]):
+		main()
 	out = capsys.readouterr().out
 	assert "echo a" in out
 	assert "echo b" in out
@@ -418,9 +419,8 @@ def test_named_task_from_subdirectory(tmp_path: Path, monkeypatch: pytest.Monkey
 	sub = tmp_path / "a" / "b"
 	sub.mkdir(parents=True)
 	monkeypatch.chdir(sub)
-	with pytest.raises(SystemExit, match="0"):
-		with patch("sys.argv", ["camas", "hi"]):
-			main()
+	with pytest.raises(SystemExit, match="0"), patch("sys.argv", ["camas", "hi"]):
+		main()
 
 
 def test_broken_pyproject_exits(
@@ -428,17 +428,15 @@ def test_broken_pyproject_exits(
 ) -> None:
 	monkeypatch.chdir(tmp_path)
 	(tmp_path / "pyproject.toml").write_text("[tool.camas.tasks]\nbad = 42\n")
-	with pytest.raises(SystemExit, match="2"):
-		with patch("sys.argv", ["camas", 'Task("x")']):
-			main()
+	with pytest.raises(SystemExit, match="2"), patch("sys.argv", ["camas", 'Task("x")']):
+		main()
 	assert "must be a string" in capsys.readouterr().err
 
 
 def test_missing_expression_and_no_list(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
 	monkeypatch.chdir(tmp_path)
-	with pytest.raises(SystemExit, match="2"):
-		with patch("sys.argv", ["camas"]):
-			main()
+	with pytest.raises(SystemExit, match="2"), patch("sys.argv", ["camas"]):
+		main()
 
 
 def test_named_task_end_to_end(tmp_path: Path) -> None:
@@ -449,6 +447,7 @@ def test_named_task_end_to_end(tmp_path: Path) -> None:
 		[sys.executable, "-m", "camas", "ok"],
 		cwd=tmp_path,
 		capture_output=True,
+		check=False,
 	)
 	assert result.returncode == 0
 
@@ -495,9 +494,8 @@ def test_tasks_py_preferred_over_pyproject(
 		"from camas import Task\nhi = Task(('python', '-c', 'pass'))\n"
 	)
 	(tmp_path / "pyproject.toml").write_text('[tool.camas.tasks]\nhi = "python -c \\"fail\\""\n')
-	with pytest.raises(SystemExit, match="0"):
-		with patch("sys.argv", ["camas", "--dry-run", "hi"]):
-			main()
+	with pytest.raises(SystemExit, match="0"), patch("sys.argv", ["camas", "--dry-run", "hi"]):
+		main()
 	captured = capsys.readouterr()
 	assert "python -c pass" in captured.out
 	assert 'python -c "fail"' not in captured.out
@@ -509,9 +507,11 @@ def test_explicit_py_file_arg(
 	monkeypatch.chdir(tmp_path)
 	other = tmp_path / "other_tasks.py"
 	other.write_text("from camas import Task\ngreet = Task('echo other')\n")
-	with pytest.raises(SystemExit, match="0"):
-		with patch("sys.argv", ["camas", str(other), "--dry-run", "greet"]):
-			main()
+	with (
+		pytest.raises(SystemExit, match="0"),
+		patch("sys.argv", ["camas", str(other), "--dry-run", "greet"]),
+	):
+		main()
 	assert "echo other" in capsys.readouterr().out
 
 
@@ -519,9 +519,8 @@ def test_explicit_py_file_missing(
 	tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
 	monkeypatch.chdir(tmp_path)
-	with pytest.raises(SystemExit, match="2"):
-		with patch("sys.argv", ["camas", "nope.py", "x"]):
-			main()
+	with pytest.raises(SystemExit, match="2"), patch("sys.argv", ["camas", "nope.py", "x"]):
+		main()
 	assert "no such file" in capsys.readouterr().err
 
 
@@ -568,9 +567,8 @@ def test_subcommand_help_shows_tree(
 		"b = Task('do-b')\n"
 		"both = Parallel(a, b)\n"
 	)
-	with pytest.raises(SystemExit, match="0"):
-		with patch("sys.argv", ["camas", "both", "--help"]):
-			main()
+	with pytest.raises(SystemExit, match="0"), patch("sys.argv", ["camas", "both", "--help"]):
+		main()
 	out = capsys.readouterr().out
 	assert "runs the 'both' task" in out
 	assert "do-a" in out
@@ -585,9 +583,11 @@ def test_explicit_py_file_load_error_listed_with_hint(
 	monkeypatch.chdir(tmp_path)
 	broken = tmp_path / "broken.py"
 	broken.write_text("raise RuntimeError('boom from tasks file')\n")
-	with pytest.raises(SystemExit, match="0"):
-		with patch("sys.argv", ["camas", str(broken), "--list"]):
-			main()
+	with (
+		pytest.raises(SystemExit, match="0"),
+		patch("sys.argv", ["camas", str(broken), "--list"]),
+	):
+		main()
 	out = capsys.readouterr().out
 	assert str(broken) in out
 	assert "boom from tasks file" in out
@@ -599,9 +599,8 @@ def test_autodiscover_tasks_py_load_error_listed_with_hint(
 ) -> None:
 	monkeypatch.chdir(tmp_path)
 	(tmp_path / "tasks.py").write_text("raise RuntimeError('boom autodiscover')\n")
-	with pytest.raises(SystemExit, match="0"):
-		with patch("sys.argv", ["camas", "--list"]):
-			main()
+	with pytest.raises(SystemExit, match="0"), patch("sys.argv", ["camas", "--list"]):
+		main()
 	out = capsys.readouterr().out
 	assert "tasks.py" in out
 	assert "boom autodiscover" in out
@@ -616,9 +615,8 @@ def test_nearer_pyproject_wins_over_farther_tasks_py(
 	sub.mkdir()
 	(sub / "pyproject.toml").write_text('[tool.camas.tasks]\nhi = "from-near-pyproject"\n')
 	monkeypatch.chdir(sub)
-	with pytest.raises(SystemExit, match="0"):
-		with patch("sys.argv", ["camas", "--dry-run", "hi"]):
-			main()
+	with pytest.raises(SystemExit, match="0"), patch("sys.argv", ["camas", "--dry-run", "hi"]):
+		main()
 	out = capsys.readouterr().out
 	assert "from-near-pyproject" in out
 	assert "from-far-tasks-py" not in out
@@ -634,9 +632,8 @@ def test_walk_skips_pyproject_without_camas_tasks(
 	sub.mkdir()
 	(sub / "pyproject.toml").write_text('[project]\nname = "x"\nversion = "0"\n')
 	monkeypatch.chdir(sub)
-	with pytest.raises(SystemExit, match="0"):
-		with patch("sys.argv", ["camas", "--dry-run", "hi"]):
-			main()
+	with pytest.raises(SystemExit, match="0"), patch("sys.argv", ["camas", "--dry-run", "hi"]):
+		main()
 	assert "from-ancestor-tasks-py" in capsys.readouterr().out
 
 
@@ -646,9 +643,8 @@ def test_autodiscover_skips_warning_when_pyproject_tasks_invalid(
 	monkeypatch.chdir(tmp_path)
 	(tmp_path / "tasks.py").write_text("from camas import Task\nhi = Task('echo hi')\n")
 	(tmp_path / "pyproject.toml").write_text("[tool.camas]\ntasks = 'oops'\n")
-	with pytest.raises(SystemExit, match="0"):
-		with patch("sys.argv", ["camas", "--list"]):
-			main()
+	with pytest.raises(SystemExit, match="0"), patch("sys.argv", ["camas", "--list"]):
+		main()
 	captured = capsys.readouterr()
 	assert "both define tasks" not in captured.err
 	assert "hi" in captured.out
@@ -674,10 +670,6 @@ def test_is_str_dict_rejects_non_dict() -> None:
 def test_name_scope_effects_finds_class() -> None:
 	"""A class satisfying the Effect protocol structurally is exposed; bare
 	instances are ignored — ``--effects`` invokes effects with ``()``."""
-	from collections.abc import Sequence
-
-	from camas.core.leaf_state import LeafState
-	from camas.core.task_event import TaskEvent
 
 	class MyEffect:
 		async def setup(self, task: TaskNode) -> int:

--- a/tests/test_effect_plugin_fixture.py
+++ b/tests/test_effect_plugin_fixture.py
@@ -23,6 +23,7 @@ def _camas(*args: str) -> subprocess.CompletedProcess[str]:
 		text=True,
 		encoding="utf-8",
 		env={**os.environ, "NO_COLOR": "1"},
+		check=False,
 	)
 
 
@@ -34,6 +35,7 @@ def _camas_in(cwd: Path, *args: str) -> subprocess.CompletedProcess[str]:
 		text=True,
 		encoding="utf-8",
 		env={**os.environ, "NO_COLOR": "1"},
+		check=False,
 	)
 
 
@@ -111,5 +113,6 @@ def test_fixture_typechecks_under_strict_mypy() -> None:
 		cwd=FIXTURE,
 		capture_output=True,
 		text=True,
+		check=False,
 	)
 	assert r.returncode == 0, f"stdout:\n{r.stdout}\nstderr:\n{r.stderr}"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -20,6 +20,7 @@ def test_help(tmp_path: Path) -> None:
 		capture_output=True,
 		text=True,
 		encoding="utf-8",
+		check=False,
 	)
 	assert result.returncode == 0
 	assert "expression" in result.stdout
@@ -32,6 +33,7 @@ def test_version(tmp_path: Path) -> None:
 		capture_output=True,
 		text=True,
 		encoding="utf-8",
+		check=False,
 	)
 	assert result.returncode == 0
 	assert "camas" in result.stdout
@@ -49,6 +51,7 @@ def test_top_level_help_source_is_local_filesystem_path(tmp_path: Path) -> None:
 		capture_output=True,
 		text=True,
 		encoding="utf-8",
+		check=False,
 	)
 	assert result.returncode == 0
 	assert "Reference:" in result.stdout
@@ -62,9 +65,8 @@ def test_no_args_with_no_tasks_errors(
 	tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
 	monkeypatch.chdir(tmp_path)
-	with pytest.raises(SystemExit, match="2"):
-		with patch("sys.argv", ["camas"]):
-			main()
+	with pytest.raises(SystemExit, match="2"), patch("sys.argv", ["camas"]):
+		main()
 	assert "expression is required" in capsys.readouterr().err
 
 
@@ -79,9 +81,8 @@ def test_no_args_with_tasks_lists_them(
 		"ci = Sequential(lint, test)\n"
 	)
 	monkeypatch.chdir(tmp_path)
-	with pytest.raises(SystemExit, match="2"):
-		with patch("sys.argv", ["camas"]):
-			main()
+	with pytest.raises(SystemExit, match="2"), patch("sys.argv", ["camas"]):
+		main()
 	captured = capsys.readouterr()
 	assert "Available tasks from" in captured.out
 	assert "tasks.py" in captured.out
@@ -100,9 +101,8 @@ def test_no_args_with_tasks_includes_reference_block(
 	tasks_py = tmp_path / "tasks.py"
 	tasks_py.write_text("from camas import Task\nlint = Task('ruff check .')\n")
 	monkeypatch.chdir(tmp_path)
-	with pytest.raises(SystemExit, match="2"):
-		with patch("sys.argv", ["camas"]):
-			main()
+	with pytest.raises(SystemExit, match="2"), patch("sys.argv", ["camas"]):
+		main()
 	out = capsys.readouterr().out
 	assert "Reference:" in out
 	assert str(Path(camas_pkg.__file__).parent) in out, out
@@ -119,9 +119,8 @@ def test_list_flag_with_tasks(
 		"both = Parallel(a, b)\n"
 	)
 	monkeypatch.chdir(tmp_path)
-	with pytest.raises(SystemExit, match="0"):
-		with patch("sys.argv", ["camas", "--list"]):
-			main()
+	with pytest.raises(SystemExit, match="0"), patch("sys.argv", ["camas", "--list"]):
+		main()
 	out = capsys.readouterr().out
 	assert "both" in out
 	assert "a | b" in out
@@ -138,9 +137,8 @@ def test_tree_flag_prints_expanded_trees(
 		"both = Parallel(a, b)\n"
 	)
 	monkeypatch.chdir(tmp_path)
-	with pytest.raises(SystemExit, match="0"):
-		with patch("sys.argv", ["camas", "--tree"]):
-			main()
+	with pytest.raises(SystemExit, match="0"), patch("sys.argv", ["camas", "--tree"]):
+		main()
 	out = capsys.readouterr().out
 	assert "Available tasks from" in out
 	assert "echo a" in out
@@ -151,35 +149,41 @@ def test_dispatch_rejects_bad_effects(
 	tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
 	monkeypatch.chdir(tmp_path)
-	with pytest.raises(SystemExit, match="2"):
-		with patch("sys.argv", ["camas", "--effects=nope(", 'Task("echo hi")']):
-			main()
+	with (
+		pytest.raises(SystemExit, match="2"),
+		patch("sys.argv", ["camas", "--effects=nope(", 'Task("echo hi")']),
+	):
+		main()
 	assert "--effects" in capsys.readouterr().err
 
 
 def test_dry_run_prints_tree(capsys: pytest.CaptureFixture[str]) -> None:
-	with pytest.raises(SystemExit, match="0"):
-		with patch(
+	with (
+		pytest.raises(SystemExit, match="0"),
+		patch(
 			"sys.argv",
 			["camas", "--dry-run", 'Parallel(Task("echo a"),Task("echo b"))'],
-		):
-			main()
+		),
+	):
+		main()
 	captured = capsys.readouterr()
 	assert "echo a" in captured.out
 	assert "echo b" in captured.out
 
 
 def test_dry_run_matrix(capsys: pytest.CaptureFixture[str]) -> None:
-	with pytest.raises(SystemExit, match="0"):
-		with patch(
+	with (
+		pytest.raises(SystemExit, match="0"),
+		patch(
 			"sys.argv",
 			[
 				"camas",
 				"--dry-run",
 				'Parallel(Task("test {PY}"),matrix={"PY": ("3.12", "3.13")})',
 			],
-		):
-			main()
+		),
+	):
+		main()
 	captured = capsys.readouterr()
 	assert "3.12" in captured.out
 	assert "3.13" in captured.out
@@ -189,9 +193,8 @@ def test_dispatch_effects_no_value_lists(
 	tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
 	monkeypatch.chdir(tmp_path)
-	with pytest.raises(SystemExit, match="0"):
-		with patch("sys.argv", ["camas", "--effects"]):
-			main()
+	with pytest.raises(SystemExit, match="0"), patch("sys.argv", ["camas", "--effects"]):
+		main()
 	assert "Available Effects:" in capsys.readouterr().out
 
 
@@ -200,9 +203,8 @@ def test_help_includes_tasks_and_effects(
 ) -> None:
 	(tmp_path / "tasks.py").write_text('from camas import Task\nlint = Task("ruff check .")\n')
 	monkeypatch.chdir(tmp_path)
-	with pytest.raises(SystemExit, match="0"):
-		with patch("sys.argv", ["camas", "--help"]):
-			main()
+	with pytest.raises(SystemExit, match="0"), patch("sys.argv", ["camas", "--help"]):
+		main()
 	out = capsys.readouterr().out
 	assert "Available tasks from" in out
 	assert "lint" in out
@@ -211,26 +213,30 @@ def test_help_includes_tasks_and_effects(
 
 
 def test_successful_execution() -> None:
-	with pytest.raises(SystemExit, match="0"):
-		with patch("sys.argv", ["camas", 'Task(("python", "-c", "pass"), name="ok")']):
-			main()
+	with (
+		pytest.raises(SystemExit, match="0"),
+		patch("sys.argv", ["camas", 'Task(("python", "-c", "pass"), name="ok")']),
+	):
+		main()
 
 
 def test_failed_execution() -> None:
-	with pytest.raises(SystemExit, match="1"):
-		with patch(
-			"sys.argv", ["camas", 'Task(("python", "-c", "raise SystemExit(1)"), name="fail")']
-		):
-			main()
+	with (
+		pytest.raises(SystemExit, match="1"),
+		patch("sys.argv", ["camas", 'Task(("python", "-c", "raise SystemExit(1)"), name="fail")']),
+	):
+		main()
 
 
 def test_passthrough_appended_to_inline_task(capsys: pytest.CaptureFixture[str]) -> None:
-	with pytest.raises(SystemExit, match="0"):
-		with patch(
+	with (
+		pytest.raises(SystemExit, match="0"),
+		patch(
 			"sys.argv",
 			["camas", "--dry-run", 'Task(("python", "-c", "print(1)"))', "--", "extra"],
-		):
-			main()
+		),
+	):
+		main()
 	assert "extra" in capsys.readouterr().out
 
 
@@ -241,11 +247,16 @@ def test_passthrough_to_named_task(
 		"from camas import Task\ntest = Task('pytest')\n",
 	)
 	monkeypatch.chdir(tmp_path)
-	with pytest.raises(SystemExit, match="0"):
-		with patch("sys.argv", ["camas", "--dry-run", "test", "--", "-v", "-k", "x"]):
-			main()
+	with (
+		pytest.raises(SystemExit, match="0"),
+		patch("sys.argv", ["camas", "--dry-run", "test", "--", "-v", "-k", "x"]),
+	):
+		main()
 	out = capsys.readouterr().out
-	assert "pytest" in out and "-v" in out and "-k" in out and "x" in out
+	assert "pytest" in out
+	assert "-v" in out
+	assert "-k" in out
+	assert "x" in out
 
 
 def test_passthrough_rejects_sequential_task(
@@ -255,9 +266,8 @@ def test_passthrough_rejects_sequential_task(
 		"from camas import Sequential, Task\nci = Sequential(Task('a'), Task('b'))\n",
 	)
 	monkeypatch.chdir(tmp_path)
-	with pytest.raises(SystemExit, match="2"):
-		with patch("sys.argv", ["camas", "ci", "--", "-v"]):
-			main()
+	with pytest.raises(SystemExit, match="2"), patch("sys.argv", ["camas", "ci", "--", "-v"]):
+		main()
 	assert "only apply to Task" in capsys.readouterr().err
 
 
@@ -269,9 +279,11 @@ def test_passthrough_help_after_separator_not_consumed(
 		"from camas import Task\ntest = Task(('python', '-c', 'pass'))\n",
 	)
 	monkeypatch.chdir(tmp_path)
-	with pytest.raises(SystemExit, match="0"):
-		with patch("sys.argv", ["camas", "--dry-run", "test", "--", "--help"]):
-			main()
+	with (
+		pytest.raises(SystemExit, match="0"),
+		patch("sys.argv", ["camas", "--dry-run", "test", "--", "--help"]),
+	):
+		main()
 	out = capsys.readouterr().out
 	assert "--help" in out
 	assert "usage:" not in out

--- a/tests/test_playwright_matrix_override_fixture.py
+++ b/tests/test_playwright_matrix_override_fixture.py
@@ -20,6 +20,7 @@ def _camas(*args: str) -> subprocess.CompletedProcess[str]:
 		text=True,
 		encoding="utf-8",
 		env={**os.environ, "NO_COLOR": "1"},
+		check=False,
 	)
 
 

--- a/tests/test_python_project_fixture.py
+++ b/tests/test_python_project_fixture.py
@@ -20,6 +20,7 @@ def _camas(*args: str) -> subprocess.CompletedProcess[str]:
 		text=True,
 		encoding="utf-8",
 		env={**os.environ, "NO_COLOR": "1"},
+		check=False,
 	)
 
 

--- a/tests/test_python_version_matrix_fixture.py
+++ b/tests/test_python_version_matrix_fixture.py
@@ -20,6 +20,7 @@ def _camas(*args: str) -> subprocess.CompletedProcess[str]:
 		text=True,
 		encoding="utf-8",
 		env={**os.environ, "NO_COLOR": "1"},
+		check=False,
 	)
 
 

--- a/tests/test_tauri_fixture.py
+++ b/tests/test_tauri_fixture.py
@@ -20,6 +20,7 @@ def _camas(*args: str) -> subprocess.CompletedProcess[str]:
 		text=True,
 		encoding="utf-8",
 		env={**os.environ, "NO_COLOR": "1"},
+		check=False,
 	)
 
 


### PR DESCRIPTION
Closes #28

## Selection

`[tool.ruff.lint]` grows from `extend-select = ["I"]` to an explicit, annotated `select` of 34 stable groups plus five pydoclint rules. The selection was driven by a survey of nine mainstream configs (FastAPI, pydantic, polars, home-assistant/core, pandas, airflow, uv, anthropic/openai SDKs): the consensus tier (`E W F I B UP C4`), the strict-library tier (`D PT SIM TRY TC PL RUF PERF PTH FURB N ...`), and the zero-cost guards this codebase already satisfies (`ASYNC SLOT RSE RET SLF PGH PIE ICN LOG G FLY FA YTT PYI INP ISC`).

## doclint

Ruff implements pydoclint as the preview-only `DOC` group, so `preview = true` + `explicit-preview-rules = true` — only exact-code-selected preview rules activate. (Preview also broadens ruff's *default* selection, which is why the config uses `select` rather than `extend-select`: DTZ005, BLE001 et al. would otherwise ride in silently.)

- **`DOC501`/`DOC502`** — raised exceptions must be documented; documented exceptions must be raised. 13 functions gained Google-style `Raises:` sections (`convention = "google"`; ruff's DOC parser recognizes Google/NumPy sections but not Sphinx `:raises:` fields — verified empirically).
- **`DOC102`/`DOC202`/`DOC403`** — drift guards: documented params/returns/yields that don't match the signature.
- **`DOC201`/`DOC402` deliberately not selected** — annotations are the single source of truth for parameter/return/yield types; docstrings document only what the type system cannot express.

## Notable ignores (each annotated in pyproject.toml)

- the formatter-conflict set (`W191 E101 E111 E114 E117 D206 D300 ISC001 ISC002`) — tab indentation — and `E501` (the formatter owns line length)
- `D102`/`D103` — self-documenting code; every flagged `D102` was an Effect-protocol implementation whose contract is documented on the protocol
- `D205`/`D417`/`D105`/`D107` — flowing summary paragraphs; params belong to the type system
- `PLC0415` — imports are scoped as narrowly as possible, by design
- `TRY003`/`TRY004` — messages live in the raise; `ValueError` is the CLI's user-error channel (`dispatch` catches it, so "prefer TypeError" would break error handling)
- `PLR09xx`/`PLR2004` — complexity thresholds; renderer geometry is honest small numbers

## Evaluated and rejected

- **`S` (bandit)** — 0/9 surveyed projects enable it wholesale; a tool whose purpose is spawning shell commands trips `S6xx` at every call site by design
- **`A`** — `Task(help=...)` is public API; task names like `format` and `all` are the product idiom
- **`TID`** (relative imports are house style), **`T20`** (printing is the product), **`DTZ`** (naive local wall-clock timestamps are intentional display behavior), **`EM`** (its fix mandates temporary variables), **`ARG`** (protocol impls and pytest fixtures legitimately ignore params), **`ERA`/`BLE`** (all sites intentional), **`COM`/`Q`** (redundant with the formatter)

## Mechanical changes

- `TC001/2/3`: ~65 typing-only imports moved under `TYPE_CHECKING`; doctests that construct real values now import their own names, matching the existing `>>> from camas.core.completion import Finished, Skipped` precedent
- `D301`: 18 docstrings converted to `r"""` — scripted with a `literal_eval` equality assertion so every docstring value is provably unchanged (one manual case in `render.py` mixes real ESC chars in doctest literals)
- `PLW1510`: explicit `check=False` at 13 `subprocess.run` sites that inspect `returncode`
- `B008` handled precisely via `flake8-bugbear.extend-immutable-calls` for the immutable Options NamedTuple defaults instead of a blanket ignore
- `D100`/`D101`/`D104`: 24 one-line module/package/class docstrings
- `SIM117` (nested `with`s combined), `PT011`/`PT018`, `N818`, `SIM105`, `PLW2901`, `INP001` (`tests/effect/__init__.py` now matches its siblings), `PTH` (`setup.py` on pathlib)

## Verification

- `camas check` green: format, lint, mypy, pyright, ty, zuban, pyrefly, pytest including doctests
- `camas coverage` green at the 100% branch-coverage gate
- pyrefly was verified from a normal path; inside a `.claude/`-nested worktree it matches zero files (parent-repo ignore rules — same class of quirk as the hidden-dir note in `tasks.py`), unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)