### PR TITLE
refactor: LLM-slop cleanup (dead code + over-documentation + single-use inlining)

### DIFF
--- a/src/camas/core/execution.py
+++ b/src/camas/core/execution.py
@@ -33,7 +33,7 @@ from .task import task_label
 from .traversal import flatten_leaves, subtree_leaf_indices
 
 if TYPE_CHECKING:
-	from collections.abc import Iterable, Sequence
+	from collections.abc import Sequence
 
 	from ..v0.effect import Effect
 	from .effect import EventSink
@@ -86,19 +86,6 @@ async def skip_subtree(
 	return results
 
 
-def first_failure_rc(results: Iterable[TaskResult]) -> int | None:
-	"""Return the first non-zero returncode in ``results``, or ``None`` if all are zero.
-
-	>>> first_failure_rc((TaskResult("a", Finished(0, 0.1, ())),))
-	>>> first_failure_rc((TaskResult("a", Finished(0, 0.1, ())), TaskResult("b", Finished(2, 0.1, ()))))
-	2
-	"""
-	return next(
-		(r.completion.returncode for r in results if r.completion.returncode != 0),
-		None,
-	)
-
-
 async def execute(
 	node: TaskNode,
 	dispatch: EventSink,
@@ -127,7 +114,14 @@ async def execute(
 				)
 				seq_results = (*seq_results, *child_results)
 				if failed_rc is None:
-					failed_rc = first_failure_rc(child_results)
+					failed_rc = next(
+						(
+							r.completion.returncode
+							for r in child_results
+							if r.completion.returncode != 0
+						),
+						None,
+					)
 			return seq_results
 		case _:
 			assert_never(node)

--- a/src/camas/core/matrix.py
+++ b/src/camas/core/matrix.py
@@ -46,8 +46,6 @@ def substitute_in_str(text: str, binding: MatrixBinding) -> str:
 
 	>>> substitute_in_str("test --python {PY}", (VarBinding("PY", "3.14"),))
 	'test --python 3.14'
-	>>> substitute_in_str("no placeholders", (VarBinding("X", "1"),))
-	'no placeholders'
 	"""
 	return functools.reduce(
 		lambda acc, vb: acc.replace(f"{{{vb.name}}}", vb.value),
@@ -124,15 +122,11 @@ def specialize_node(task: TaskNode, binding: MatrixBinding, suffix: str) -> Task
 def matrix_axes(task: TaskNode) -> dict[str, tuple[str, ...]]:
 	"""Walk a task tree and collect every matrix axis with its values.
 
-	When the same axis name appears in multiple matrices, the outermost (closest
-	to the root) wins — that's the value the user sees in ``--list`` and the one
-	overrides should target. Inner duplicates with the same key but different
-	values are unusual; users almost never write them.
+	On a name collision the outermost matrix (closest to the root) wins — the value
+	``--list`` shows and the one overrides target.
 
 	>>> matrix_axes(Task("hi"))
 	{}
-	>>> matrix_axes(Parallel(Task("test"), matrix={"PY": ("3.12", "3.13")}))
-	{'PY': ('3.12', '3.13')}
 	>>> matrix_axes(Sequential(Parallel(Task("t"), matrix={"OS": ("a", "b")}), matrix={"PY": ("3.12",)}))
 	{'PY': ('3.12',), 'OS': ('a', 'b')}
 	"""
@@ -150,17 +144,16 @@ def matrix_axes(task: TaskNode) -> dict[str, tuple[str, ...]]:
 
 
 def override_matrix(task: TaskNode, overrides: Mapping[str, tuple[str, ...]]) -> TaskNode:
-	"""Return a tree with each ``matrix[k]`` replaced by ``overrides[k]`` everywhere
-	the key appears. Strict on keys: every override must match an axis present in
-	the tree. Permissive on values: any tuple is accepted.
+	"""Replace each ``matrix[k]`` with ``overrides[k]`` wherever the key appears.
+
+	Strict on keys (every override must match an axis in the tree), permissive on
+	values (any tuple is accepted).
 
 	Raises:
 		ValueError: if an override key matches no matrix axis in the tree.
 
 	>>> override_matrix(Parallel(Task("t"), matrix={"PY": ("3.12", "3.13")}), {"PY": ("3.13",)}).matrix  # type: ignore[union-attr]
 	{'PY': ('3.13',)}
-	>>> override_matrix(Task("hi"), {})
-	Task(cmd='hi', name=None, env={}, cwd=None)
 	>>> override_matrix(Parallel(Task("t"), matrix={"PY": ("3.12",)}), {"XX": ("a",)})
 	Traceback (most recent call last):
 	    ...
@@ -208,12 +201,10 @@ def apply_overrides(task: TaskNode, overrides: Mapping[str, tuple[str, ...]]) ->
 
 
 def matrix_bindings(matrix: dict[str, tuple[str, ...]]) -> tuple[MatrixBinding, ...]:
-	"""Generate all cartesian product bindings from a matrix definition.
+	"""Generate all cartesian-product bindings from a matrix definition.
 
 	>>> matrix_bindings({"PY": ("3.12", "3.13")})
 	((VarBinding(name='PY', value='3.12'),), (VarBinding(name='PY', value='3.13'),))
-	>>> len(matrix_bindings({"A": ("1", "2"), "B": ("x", "y")}))
-	4
 	"""
 	keys: Final = tuple(matrix.keys())
 	return tuple(
@@ -223,13 +214,7 @@ def matrix_bindings(matrix: dict[str, tuple[str, ...]]) -> tuple[MatrixBinding, 
 
 
 def binding_suffix(binding: MatrixBinding) -> str:
-	"""Format a matrix binding as a bracketed suffix.
-
-	>>> binding_suffix((VarBinding("PY", "3.14"),))
-	'[PY=3.14]'
-	>>> binding_suffix((VarBinding("OS", "linux"), VarBinding("PY", "3.14")))
-	'[OS=linux, PY=3.14]'
-	"""
+	"""Format a matrix binding as a bracketed ``[name=value, ...]`` suffix."""
 	return "[" + ", ".join(f"{vb.name}={vb.value}" for vb in binding) + "]"
 
 

--- a/src/camas/core/render.py
+++ b/src/camas/core/render.py
@@ -47,24 +47,10 @@ ANSI_ESCAPE: Final = re.compile(
 
 
 def strip_ansi(text: str) -> str:
-	r"""Remove ANSI escape sequences and ASCII control characters from a string.
+	r"""Strip ANSI escapes and ASCII control chars; tab and newline are kept.
 
-	Tab (``\t``) and newline (``\n``) are preserved — they're load-bearing for
-	formatted log output. Carriage return (``\r``), BEL, BS, and other
-	control chars are stripped.
-
-	>>> strip_ansi("\x1b[32mgreen\x1b[0m text")
-	'green text'
-	>>> strip_ansi("\x1b]8;;https://example.com\x07link\x1b]8;;\x07 text")
-	'link text'
-	>>> strip_ansi("no escapes")
-	'no escapes'
-	>>> strip_ansi("line one\nline two\tcol")
-	'line one\nline two\tcol'
-	>>> strip_ansi("\r\x1b[2Kprogress")
-	'progress'
-	>>> strip_ansi("\x1b[1mbold\x1b(B\x1b[m done")
-	'bold done'
+	>>> strip_ansi("\x1b[32mgreen\x1b[0m\ttext\r")
+	'green\ttext'
 	"""
 	return ANSI_ESCAPE.sub("", text)
 
@@ -124,11 +110,6 @@ def group_display_name(tasks: tuple[TaskNode, ...], separator: str) -> str:
 
 def render_tree_prefix(depth: int, is_last_chain: tuple[ChainLink, ...]) -> str:
 	"""Reconstitute the ASCII tree prefix from structural position data.
-
-	Children of a ``Sequential`` get ``├─`` / ``└─`` branches with ``│`` continuations —
-	the sequence has an ordering and a terminator. Children of a ``Parallel`` get a
-	plain ``┃`` column with no ``├``/``└`` distinction, since parallel siblings have
-	no order.
 
 	>>> render_tree_prefix(0, ())
 	''
@@ -193,14 +174,7 @@ def iter_rows(
 
 
 def flatten_rows(task: TaskNode) -> tuple[DisplayRow, ...]:
-	"""Flatten a task tree into display rows (GroupHeaders + LeafInfos) in DFS order.
-
-	>>> rows = flatten_rows(Parallel(Task("a"), Task("b")))
-	>>> len(rows)
-	3
-	>>> isinstance(rows[0], GroupHeader)
-	True
-	"""
+	"""Flatten a task tree into display rows (GroupHeaders + LeafInfos) in DFS order."""
 	return tuple(iter_rows(task))
 
 

--- a/src/camas/core/render.py
+++ b/src/camas/core/render.py
@@ -248,8 +248,8 @@ def leaf_label(task: Task, show_cmd: bool, color: bool) -> str:
 def render_tree_lines(task: TaskNode, show_cmd: bool = False, color: bool = False) -> list[str]:
 	"""Build the tree-display lines (group headers + leaves) for an expanded task tree.
 
-	Pure: returns a list of strings without printing. ``print_tree`` (in
-	``main.format``) is the printing wrapper.
+	Pure: returns a list of strings without printing. :func:`print_tree` is the
+	printing wrapper.
 
 	>>> render_tree_lines(Task("echo hi"))
 	['echo hi']
@@ -276,3 +276,15 @@ def render_tree_lines(task: TaskNode, show_cmd: bool = False, color: bool = Fals
 			case _:
 				assert_never(row)
 	return lines
+
+
+def print_tree(task: TaskNode, show_cmd: bool = False) -> None:
+	"""Print the task tree structure to stdout without executing.
+
+	>>> print_tree(Task("echo hi"))
+	echo hi
+	>>> print_tree(Task("echo hi", name="greet"), show_cmd=True)
+	greet: echo hi
+	"""
+	for line in render_tree_lines(task, show_cmd=show_cmd, color=color_on()):
+		print(line)

--- a/src/camas/core/task.py
+++ b/src/camas/core/task.py
@@ -26,16 +26,11 @@ MatrixBinding: TypeAlias = tuple[VarBinding, ...]
 
 
 def task_label(task: Task) -> str:
-	"""Return a task's identifying label: the explicit `name` or the full command string.
-
-	This is a data accessor with no concept of display width — callers that render
-	into a column-constrained terminal are responsible for truncation.
+	"""Return a task's label: the explicit ``name``, else the full command string.
 
 	>>> from camas import Task
 	>>> task_label(Task("echo hi", name="greet"))
 	'greet'
-	>>> task_label(Task("echo hi"))
-	'echo hi'
 	>>> task_label(Task(("python", "-c", "pass")))
 	'python -c pass'
 	"""

--- a/src/camas/core/traversal.py
+++ b/src/camas/core/traversal.py
@@ -40,39 +40,12 @@ def iter_leaves(
 
 
 def flatten_leaves(task: TaskNode) -> tuple[LeafInfo, ...]:
-	"""Flatten a task tree into a tuple of LeafInfo in depth-first order.
-
-	>>> [info.task.cmd for info in flatten_leaves(Parallel(Task("a"), Task("b")))]
-	['a', 'b']
-	>>> flatten_leaves(Task("echo hi"))[0].depth
-	0
-	>>> flatten_leaves(Parallel(Task("a"), Task("b")))[0].is_last_chain
-	(ChainLink(is_last=False, parent_is_parallel=True),)
-	>>> flatten_leaves(Parallel(Task("a"), Task("b")))[1].is_last_chain
-	(ChainLink(is_last=True, parent_is_parallel=True),)
-	"""
+	"""Flatten a task tree into a tuple of LeafInfo in depth-first order."""
 	return tuple(iter_leaves(task, depth=0, is_last_chain=()))
 
 
-def build_leaf_index_map(task: TaskNode) -> dict[int, int]:
-	"""Map `id(Task)` to leaf index (depth-first position) for the whole tree.
-
-	>>> t1, t2 = Task("a"), Task("b")
-	>>> m = build_leaf_index_map(Parallel(t1, t2))
-	>>> m[id(t1)], m[id(t2)]
-	(0, 1)
-	"""
-	return {id(info.task): i for i, info in enumerate(flatten_leaves(task))}
-
-
 def subtree_leaf_indices(task: TaskNode, index_map: dict[int, int]) -> tuple[int, ...]:
-	"""Collect all leaf indices within a subtree.
-
-	>>> t1, t2 = Task("a"), Task("b")
-	>>> tree = Parallel(t1, t2)
-	>>> subtree_leaf_indices(tree, build_leaf_index_map(tree))
-	(0, 1)
-	"""
+	"""Collect all leaf indices within a subtree, in depth-first order."""
 	match task:
 		case Task():
 			return (index_map[id(task)],)

--- a/src/camas/effect/github_checks.py
+++ b/src/camas/effect/github_checks.py
@@ -210,12 +210,8 @@ def build_name(prefix: str, task: Task) -> str:
 	"""Compose check-run name; truncate to ``NAME_LIMIT`` with right-side ellipsis.
 
 	>>> from camas import Task
-	>>> build_name("", Task("ruff check .", name="lint"))
-	'lint'
 	>>> build_name("ubuntu/", Task("ruff check .", name="lint"))
 	'ubuntu/lint'
-	>>> build_name("", Task("ruff check ."))
-	'ruff check .'
 	>>> len(build_name("x" * 200, Task("y", name="z")))
 	100
 	"""
@@ -249,11 +245,7 @@ def tail_bytes(buf: bytes, limit: int) -> bytes:
 	b'def'
 	>>> tail_bytes(b"abc", 10)
 	b'abc'
-	>>> tail_bytes(b"", 5)
-	b''
 	>>> tail_bytes(b"abc", 0)
-	b''
-	>>> tail_bytes(b"abc", -1)
 	b''
 	"""
 	if limit <= 0:
@@ -410,15 +402,7 @@ def started_to_active(state: EffectState, task: Task) -> Active:
 
 
 def external_id_for(cfg: ResolvedConfig, task: Task) -> str:
-	"""Stable per-leaf identifier — same leaf on the same prefix yields the same id.
-
-	>>> from camas import Task
-	>>> external_id_for(
-	...     ResolvedConfig("t", "o", "r", "s", "ubuntu/", 8192, False),
-	...     Task("ruff check .", name="lint"),
-	... )
-	'camas:ubuntu/lint'
-	"""
+	"""Stable per-leaf identifier — same leaf on the same prefix yields the same id."""
 	return f"camas:{cfg.name_prefix}{task_label(task)}"
 
 
@@ -452,13 +436,8 @@ def pipelines_from_ctxs(
 ) -> tuple[asyncio.Task[None], ...]:
 	"""Pure: unfold every leaf ctx into its terminal pipeline task.
 
-	- ``Closed(task=t)`` → ``t`` (already a pipeline)
-	- ``Active(post_task=p, ...)`` → newly-spawned cancel pipeline awaiting ``p``
-	- ``Pending()`` / ``Closed(task=None)`` → contributes nothing
-
-	The cancel pipelines for Active leaves are created here, not held on the
-	effect; their refs live in the returned tuple until ``teardown`` awaits
-	them.
+	``Closed`` yields its existing pipeline; ``Active`` spawns a cancel pipeline
+	awaiting its POST; ``Pending`` / ``Closed(task=None)`` contribute nothing.
 	"""
 	return tuple(extracted for ctx in ctxs if (extracted := pipeline_of(state, ctx)) is not None)
 

--- a/src/camas/effect/status.py
+++ b/src/camas/effect/status.py
@@ -101,14 +101,7 @@ LeafCtx: TypeAlias = Idle | Active | Done
 
 
 def cmd_str(task: Task) -> str:
-	"""Return ``task.cmd`` as a single string (joins tuple form with spaces).
-
-	>>> from camas import Task
-	>>> cmd_str(Task("echo hi"))
-	'echo hi'
-	>>> cmd_str(Task(("python", "-c", "pass")))
-	'python -c pass'
-	"""
+	"""Return ``task.cmd`` as a single string (joining tuple form with spaces)."""
 	return task.cmd if isinstance(task.cmd, str) else " ".join(task.cmd)
 
 
@@ -149,10 +142,6 @@ def fmt_completed(opts: StatusOptions, task: Task, c: Completion, ts: datetime) 
 	'\x1b[90m[2026-05-21 14:30:00.123]\x1b[0m \x1b[90m⏭ [follow] skipped\x1b[0m (prior rc=2)'
 	>>> fmt_completed(
 	...     StatusOptions(finished_fmt=""), Task("a"), Finished(0, 1.0, ()), t0,
-	... ) is None
-	True
-	>>> fmt_completed(
-	...     StatusOptions(failed_fmt=""), Task("a"), Finished(2, 1.0, ()), t0,
 	... ) is None
 	True
 	"""
@@ -199,13 +188,7 @@ def fmt_output(opts: StatusOptions, task: Task, line: bytes, ts: datetime) -> st
 
 
 def _github_safe_title(label: str) -> str:
-	r"""Strip newlines/CRs so a ``::group::`` title stays on one line.
-
-	>>> _github_safe_title("normal")
-	'normal'
-	>>> _github_safe_title("a\nb\rc")
-	'a b c'
-	"""
+	"""Strip CRs/newlines so a ``::group::`` title stays on one line."""
 	return label.replace("\r", " ").replace("\n", " ")
 
 
@@ -227,16 +210,10 @@ def _github_stop_token(body: str) -> str:
 
 
 def _format_github_group(title: str, body: str, token: str) -> str:
-	r"""Wrap ``body`` in a GitHub ``::group::`` with ``::stop-commands::`` neutralization.
+	"""Wrap ``body`` in a GitHub ``::group::`` with ``::stop-commands::`` neutralization.
 
-	The stop-commands bracket disables workflow-command parsing for the body
-	so output lines like ``::endgroup::`` or ``::add-mask::`` are emitted
-	verbatim instead of being interpreted by Actions.
-
-	>>> _format_github_group("x", "ok\n", "T")
-	'::group::x\n::stop-commands::T\nok\n::T::\n::endgroup::\n'
-	>>> _format_github_group("x", "::endgroup::\n", "T")
-	'::group::x\n::stop-commands::T\n::endgroup::\n::T::\n::endgroup::\n'
+	The stop-commands bracket disables workflow-command parsing for the body, so
+	output lines like ``::endgroup::`` are emitted verbatim, not interpreted.
 	"""
 	return f"::group::{title}\n::stop-commands::{token}\n{body}::{token}::\n::endgroup::\n"
 
@@ -244,12 +221,9 @@ def _format_github_group(title: str, body: str, token: str) -> str:
 def block_for(mode: OutputMode, task: Task, c: Completion, output: bytes) -> str:
 	r"""Return the completion-block text for ``mode`` (empty when nothing to dump).
 
-	Output bytes are passed through verbatim — ANSI escapes are preserved so
-	downstream viewers (terminals, Actions logs) render the original colors.
-	For ``github`` mode the body is wrapped in ``::stop-commands::`` so task
-	output that happens to start with ``::`` (e.g. another tool's
-	``::endgroup::`` or ``::warning::``) cannot prematurely close the group
-	or inject workflow commands.
+	Output bytes pass through verbatim (ANSI preserved). For ``github`` mode the
+	body is wrapped in ``::stop-commands::`` so task output starting with ``::``
+	cannot prematurely close the group or inject workflow commands.
 
 	>>> from camas import Task
 	>>> block_for("all", Task("a", name="x"), Finished(0, 1.0, ()), b"ok\n")
@@ -316,8 +290,6 @@ def next_ctx_on_output(mode: OutputMode, ctx: Active, line: bytes) -> Active:
 	>>> next_ctx_on_output("all", Active(b"abc"), b"def").output
 	b'abcdef'
 	>>> next_ctx_on_output("stream", Active(b""), b"x").output
-	b''
-	>>> next_ctx_on_output("quiet", Active(b""), b"x").output
 	b''
 	"""
 	match mode:

--- a/src/camas/effect/termtree.py
+++ b/src/camas/effect/termtree.py
@@ -21,9 +21,7 @@ from ..core.render import (
 	RESET,
 	DisplayRow,
 	GroupHeader,
-	color_on,
 	flatten_rows,
-	render_tree_lines,
 	render_tree_prefix,
 	strip_ansi,
 )
@@ -359,18 +357,6 @@ def print_passes(states: Sequence[LeafState], term_width: int) -> None:
 				print_task_output(task, output, "PASSED", GREEN, 0, term_width)
 			case _:
 				pass
-
-
-def print_tree(task: TaskNode, show_cmd: bool = False) -> None:
-	"""Print the task tree structure to stdout without executing.
-
-	>>> print_tree(Task("echo hi"))
-	echo hi
-	>>> print_tree(Task("echo hi", name="greet"), show_cmd=True)
-	greet: echo hi
-	"""
-	for line in render_tree_lines(task, show_cmd=show_cmd, color=color_on()):
-		print(line)
 
 
 @dataclass

--- a/src/camas/effect/termtree.py
+++ b/src/camas/effect/termtree.py
@@ -36,20 +36,12 @@ from ..v0.task_event import TaskEvent
 
 
 def truncate_middle(text: str, max_width: int) -> str:
-	"""Truncate text in the middle with '...' if it exceeds max_width.
+	"""Middle-truncate with '...' to ``max_width`` (result length ``min(len(text), max_width)``).
 
-	Always returns a string of length min(len(text), max(max_width, 0)).
-
-	>>> truncate_middle("hello", 10)
-	'hello'
 	>>> truncate_middle("hello world!", 9)
 	'hel...ld!'
 	>>> truncate_middle("built", 2)
 	'..'
-	>>> truncate_middle("built", 4)
-	'...t'
-	>>> truncate_middle("built", 0)
-	''
 	"""
 	if len(text) <= max_width:
 		return text
@@ -60,13 +52,7 @@ def truncate_middle(text: str, max_width: int) -> str:
 
 
 def fit_label(text: str, max_width: int) -> str:
-	"""Return ``text`` unchanged if it fits; otherwise middle-truncate to ``max_width``.
-
-	>>> fit_label("uv run ruff check .", 40)
-	'uv run ruff check .'
-	>>> fit_label("uv run ruff format --check .", 15)
-	'uv run...heck .'
-	"""
+	"""Return ``text`` unchanged if it fits; otherwise middle-truncate to ``max_width``."""
 	return text if len(text) <= max_width else truncate_middle(text, max(max_width, 3))
 
 
@@ -114,10 +100,9 @@ PROG_MIN_MARGIN: Final = 2
 def bucket_glyph_color(states: Sequence[LeafState]) -> tuple[str, str]:
 	"""Reduce a bucket of leaf states to (glyph, ANSI color) for a progress cell.
 
-	Worst-progress wins so the bar never overstates progress: any waiting →
-	blank; else any running → dashed line; else a solid line. Color
-	distinguishes the active state (cyan running) from the settled outcome
-	(red on any failure, grey if all skipped, otherwise green).
+	Worst-progress wins (any waiting → blank; else any running → dashed; else
+	solid), and color reflects the settled outcome (red on any failure, grey if
+	all skipped, else green).
 
 	>>> t = Task("x")
 	>>> t0 = datetime(2026, 1, 1)
@@ -152,12 +137,10 @@ def bucket_glyph_color(states: Sequence[LeafState]) -> tuple[str, str]:
 
 
 def render_progress_bar(states: Sequence[LeafState], width: int) -> str:
-	"""Render a fragmented progress bar for the result-line summary slot.
+	"""Render a fragmented progress bar of visible width ``width`` for the summary slot.
 
-	Cells are equal width (capped at ``PROG_MAX_CELL_WIDTH``) and centered in
-	``width`` visible columns. When ``len(states)`` exceeds ``width``, leaves
-	are bucketed across exactly ``width`` 1-column cells. Returned string
-	always has visible width ``width``.
+	Cells are equal width (capped at ``PROG_MAX_CELL_WIDTH``) and centered; when
+	``len(states)`` exceeds the usable span, leaves are bucketed into 1-column cells.
 
 	>>> t = Task("x")
 	>>> t0 = datetime(2026, 1, 1)
@@ -209,13 +192,7 @@ def render_progress_bar(states: Sequence[LeafState], width: int) -> str:
 
 
 def decode_line(line: bytes) -> str:
-	r"""Decode a captured output line (stripped of trailing whitespace).
-
-	>>> decode_line(b"hello\n")
-	'hello'
-	>>> decode_line(b"")
-	''
-	"""
+	"""Decode a captured output line, stripped of trailing whitespace."""
 	return line.rstrip().decode(errors="replace")
 
 
@@ -386,11 +363,6 @@ def print_passes(states: Sequence[LeafState], term_width: int) -> None:
 
 def print_tree(task: TaskNode, show_cmd: bool = False) -> None:
 	"""Print the task tree structure to stdout without executing.
-
-	When ``show_cmd`` is True, leaf tasks with a distinct name show ``name: cmd``;
-	env entries are shown only at the deepest ancestor that introduces them,
-	so matrix expansions annotate their group header and leaves stay clean.
-	ANSI colors are emitted when stdout is a TTY and NO_COLOR is unset.
 
 	>>> print_tree(Task("echo hi"))
 	echo hi

--- a/src/camas/main/argv.py
+++ b/src/camas/main/argv.py
@@ -40,8 +40,6 @@ def split_passthrough(argv: Sequence[str]) -> SplitArgv:
 	SplitArgv(head=('mytask',), passthrough=())
 	>>> split_passthrough(["mytask", "--", "-v", "--tb=short"])
 	SplitArgv(head=('mytask',), passthrough=('-v', '--tb=short'))
-	>>> split_passthrough(["mytask", "--", "--", "x"])
-	SplitArgv(head=('mytask',), passthrough=('--', 'x'))
 	"""
 	argv_copy: Final = tuple(argv)
 	try:
@@ -52,19 +50,15 @@ def split_passthrough(argv: Sequence[str]) -> SplitArgv:
 
 
 def apply_passthrough(task: TaskNode, args: tuple[str, ...]) -> Task:
-	"""Append ``args`` to a leaf ``Task``'s command. Errors on Sequential/Parallel.
-
-	The ``cmd`` shape is preserved: tuple commands stay tuples (args appended);
-	string commands stay strings (args shell-joined and appended) so dry-run/tree
-	output keeps the user's original quoting.
+	"""Append ``args`` to a leaf ``Task``'s command, preserving ``cmd`` shape: tuples
+	stay tuples (appended), strings stay strings (args shell-joined) so dry-run/tree
+	output keeps the user's quoting. Errors on Sequential/Parallel.
 
 	Raises:
 		ValueError: if ``task`` is a ``Sequential`` or ``Parallel``.
 
 	>>> apply_passthrough(Task("pytest"), ("-v",))
 	Task(cmd='pytest -v', name=None, env={}, cwd=None)
-	>>> apply_passthrough(Task("git commit -m 'big msg'"), ("--no-verify",))
-	Task(cmd="git commit -m 'big msg' --no-verify", name=None, env={}, cwd=None)
 	>>> apply_passthrough(Task(("pytest",), name="t"), ("-v", "-k", "x"))
 	Task(cmd=('pytest', '-v', '-k', 'x'), name='t', env={}, cwd=None)
 	>>> apply_passthrough(Task("pytest"), ("-k", "a b"))
@@ -112,8 +106,6 @@ def parse_matrix_kv(raw: str) -> tuple[str, tuple[str, ...]]:
 def parse_axis_values(raw: str) -> tuple[str, ...]:
 	"""Comma-separated values into a tuple, trimming whitespace and dropping empties.
 
-	>>> parse_axis_values("3.13")
-	('3.13',)
 	>>> parse_axis_values("3.13, 3.14")
 	('3.13', '3.14')
 	>>> parse_axis_values("")

--- a/src/camas/main/check.py
+++ b/src/camas/main/check.py
@@ -11,7 +11,6 @@ explicitly requests it.
 from __future__ import annotations
 
 import linecache
-import runpy
 import shutil
 import subprocess
 import sys
@@ -26,20 +25,6 @@ else:  # pragma: no cover
 
 
 CheckerName: TypeAlias = Literal["ty", "mypy"]
-
-
-class EvalOk(NamedTuple):
-	"""Eval outcome: the tasks file executed without raising ``Exception``."""
-
-
-class EvalErr(NamedTuple):
-	"""Eval outcome: the tasks file raised an ``Exception`` during execution."""
-
-	exception: Exception
-	"""The captured exception, still attached to its traceback."""
-
-
-EvalResult: TypeAlias = EvalOk | EvalErr
 
 
 class FoundChecker(NamedTuple):
@@ -113,15 +98,6 @@ def find_typechecker() -> FoundChecker | None:
 		if (found := shutil.which(name)) is not None:
 			return FoundChecker(name=name, path=Path(found))
 	return None
-
-
-def run_eval(tasks_py: Path) -> EvalResult:
-	"""Execute ``tasks_py`` via :mod:`runpy`; capture any :class:`Exception` as EvalErr."""
-	try:
-		runpy.run_path(str(tasks_py))
-	except Exception as e:
-		return EvalErr(exception=e)
-	return EvalOk()
 
 
 def checker_argv(found: FoundChecker, tasks_py: Path) -> list[str]:

--- a/src/camas/main/check.py
+++ b/src/camas/main/check.py
@@ -116,21 +116,7 @@ def find_typechecker() -> FoundChecker | None:
 
 
 def run_eval(tasks_py: Path) -> EvalResult:
-	r"""Execute ``tasks_py`` via :mod:`runpy`; capture any :class:`Exception`.
-
-	>>> import tempfile
-	>>> with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False) as f:
-	...     _ = f.write("x = 1\n")
-	...     ok = Path(f.name)
-	>>> isinstance(run_eval(ok), EvalOk)
-	True
-	>>> with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False) as f:
-	...     _ = f.write("raise ValueError('boom')\n")
-	...     bad = Path(f.name)
-	>>> r = run_eval(bad)
-	>>> isinstance(r, EvalErr) and isinstance(r.exception, ValueError)
-	True
-	"""
+	"""Execute ``tasks_py`` via :mod:`runpy`; capture any :class:`Exception` as EvalErr."""
 	try:
 		runpy.run_path(str(tasks_py))
 	except Exception as e:
@@ -186,11 +172,8 @@ def deepest_user_frame(exc: Exception, tasks_py: Path) -> traceback.FrameSummary
 
 
 def caret_line(colno: int, end_colno: int, raw_source: str) -> str | None:
-	"""Build the ``    ^^^^`` line that points at PEP 657 column info.
-
-	Returns ``None`` when the col offset is inside ``raw_source``'s leading
-	whitespace — defensive: shouldn't happen for real Python tracebacks (the
-	column points at the offending token, not indentation).
+	"""Build the ``    ^^^^`` line pointing at PEP 657 column info, or ``None`` when the
+	offset falls inside ``raw_source``'s leading whitespace.
 
 	>>> caret_line(11, 14, "x = foo(bar)")
 	'               ^^^'
@@ -262,11 +245,9 @@ def format_checker_output(result: TypeCheckResult, *, after_trace: bool) -> str:
 
 
 def report_eval_error(tasks_py: Path, exc: Exception) -> int:
-	"""Print a minimal trace for ``exc`` and opportunistically run the typechecker.
+	"""Print a minimal trace for ``exc`` and run the typechecker; return exit code 1.
 
-	Used by both ``resolve_tasks_source`` (normal-task path, on tasks.py eval
-	failure) and ``--check`` (which always runs the typechecker, including on
-	eval failure). Returns exit code ``1``.
+	Shared by the normal-task path (on tasks.py eval failure) and ``--check``.
 	"""
 	sys.stderr.write(format_minimal_trace(exc, tasks_py))
 	sys.stderr.write(format_checker_output(run_typecheck(tasks_py), after_trace=True))

--- a/src/camas/main/dispatch.py
+++ b/src/camas/main/dispatch.py
@@ -59,16 +59,9 @@ def dispatch_arg(arg: str, tasks: Mapping[str, TaskNode]) -> TaskNode:
 
 
 def run_cli(scope: Mapping[str, object]) -> None:
-	"""Collect Task/Sequential/Parallel values from ``scope`` and dispatch CLI args.
-
-	Names starting with ``_`` and non-task values are skipped. Public bindings
-	are named by their binding identifier, and nested references inherit those
-	names (consistent with ``[tool.camas.tasks]`` in pyproject.toml). Public
-	Effect classes in ``scope`` are also picked up so users can pass them to
-	``--effects`` and see them under ``camas --effects``.
-
-	Propagates ``scope['__file__']`` as the :class:`LoadOk` ``source`` so per-task
-	help cites the right path and ``--check`` knows which file to type-check.
+	"""Collect Task/Sequential/Parallel and Effect bindings from ``scope`` (skipping
+	``_``-prefixed names) and dispatch CLI args, citing ``scope['__file__']`` as the
+	:class:`LoadOk` ``source`` for per-task help and ``--check``.
 	"""
 	source_obj = scope.get("__file__")
 	source = Path(source_obj) if isinstance(source_obj, (str, Path)) else None
@@ -223,17 +216,7 @@ def dispatch(state: TasksState, argv: list[str] | None = None) -> None:
 
 
 def looks_like_py_file(arg: str) -> bool:
-	"""A CLI arg refers to a tasks file when it ends in ``.py`` — expressions always end in ``)``.
-
-	>>> looks_like_py_file("tasks.py")
-	True
-	>>> looks_like_py_file("./sub/my_tasks.py")
-	True
-	>>> looks_like_py_file('Task("pytest x.py")')
-	False
-	>>> looks_like_py_file("lint")
-	False
-	"""
+	"""A CLI arg is a tasks file when it ends in ``.py`` (expressions end in ``)``)."""
 	return arg.endswith(".py")
 
 

--- a/src/camas/main/dispatch.py
+++ b/src/camas/main/dispatch.py
@@ -18,7 +18,7 @@ else:  # pragma: no cover
 
 from ..core.execution import run
 from ..core.matrix import matrix_axes, override_matrix
-from ..core.render import color_on
+from ..core.render import color_on, print_tree
 from .argv import apply_passthrough, parse_axis_values, parse_matrix_kv, split_passthrough
 from .effects import parse_effects
 from .expression import parse_expression
@@ -30,7 +30,6 @@ from .format import (
 	print_task_help,
 	print_task_summary_listing,
 	print_task_trees,
-	print_tree,
 )
 from .parser import RESERVED_FLAGS, build_parser
 from .state import EMPTY_STATE, LoadErr, LoadOk, TasksState
@@ -215,11 +214,6 @@ def dispatch(state: TasksState, argv: list[str] | None = None) -> None:
 			assert_never(state)
 
 
-def looks_like_py_file(arg: str) -> bool:
-	"""A CLI arg is a tasks file when it ends in ``.py`` (expressions end in ``)``)."""
-	return arg.endswith(".py")
-
-
 def _load_py(path: Path) -> TasksState:
 	"""Evaluate ``path`` and return a :class:`LoadOk` / :class:`LoadErr`."""
 	try:
@@ -238,7 +232,7 @@ def resolve_tasks_source(argv: list[str]) -> tuple[TasksState, list[str]]:
 	the walk going. A ``tasks.py`` whose evaluation raises returns
 	:class:`LoadErr` so meta operations (``--help``, ``--list``) still work.
 	"""
-	if argv and looks_like_py_file(argv[0]):
+	if argv and argv[0].endswith(".py"):
 		path = Path(argv[0])
 		if not path.is_file():
 			print(f"error: {path}: no such file", file=sys.stderr)

--- a/src/camas/main/effects.py
+++ b/src/camas/main/effects.py
@@ -184,8 +184,8 @@ def parse_effects(
 ) -> tuple[Effect[Any], ...]:
 	"""Parse a ``--effects`` expression into a tuple of Effect instances.
 
-	``scope_effects`` is a mapping of user-defined Effect classes
-	(typically from a ``tasks.py`` scope) merged with the built-in registry.
+	``scope_effects`` (user-defined Effect classes, e.g. from a ``tasks.py`` scope)
+	is merged with the built-in registry.
 
 	Raises:
 		ValueError: on syntax errors, non-tuple expressions, unknown names,
@@ -193,8 +193,6 @@ def parse_effects(
 
 	>>> [type(e).__name__ for e in parse_effects("(Summary(),)")]
 	['Summary']
-	>>> [type(e).__name__ for e in parse_effects("(Termtree(), Summary())")]
-	['Termtree', 'Summary']
 	>>> parse_effects("(Summary(options=SummaryOptions(term_width=Fixed(80))),)")[0].options.term_width
 	Fixed(columns=80)
 	>>> parse_effects("()")

--- a/src/camas/main/expression.py
+++ b/src/camas/main/expression.py
@@ -146,11 +146,8 @@ def children(elts: list[ast.expr], allow_refs: bool) -> tuple[TaskNode, ...]:
 
 
 def eval_task_pos(node: ast.expr, allow_refs: bool) -> TaskNode | Ref:
-	"""Evaluate an AST node at a *task position* — inside ``Sequential``/``Parallel`` args
-	or as a top-level expression — coercing literals to nodes.
-
-	Coercion: ``str`` → ``Task(cmd=str)``; tuple literal → ``Sequential``;
-	set literal → ``Parallel``. Other forms delegate to ``eval_node``.
+	"""Evaluate an AST node at a *task position*, coercing literals to nodes; other
+	forms delegate to ``eval_node``.
 
 	>>> import ast
 	>>> eval_task_pos(ast.parse('"echo hi"', mode="eval").body, allow_refs=False)
@@ -273,21 +270,15 @@ def parse_expression(expr: str, tasks: Mapping[str, TaskNode] | None = None) -> 
 
 
 def parse_task_value(raw: str) -> TaskNode | Ref:
-	r"""Parse a single pyproject.toml task value. Bare strings become Task(cmd).
-
-	A leading ``Task``/``Sequential``/``Parallel``/``Ref`` call, ``(``, or ``{`` triggers
-	AST-based parsing — letting users use the fluent ``(a, b)`` (Sequential) and
-	``{a, b}`` (Parallel) literals as well as explicit constructor calls.
+	r"""Parse a single pyproject.toml task value. Bare strings become ``Task(cmd)``;
+	a leading ``Task``/``Sequential``/``Parallel``/``Ref`` call, ``(``, or ``{`` triggers
+	AST parsing (so ``(a, b)`` is a Sequential and ``{a, b}`` a Parallel).
 
 	Raises:
 		ValueError: when an expression-like value fails to parse.
 
 	>>> parse_task_value("ruff check .")
 	Task(cmd='ruff check .', name=None, env={}, cwd=None)
-	>>> parse_task_value('Task("pytest")')
-	Task(cmd='pytest', name=None, env={}, cwd=None)
-	>>> parse_task_value("Ref(\"lint\")")
-	Ref(name='lint')
 	>>> parse_task_value("(a, b)")
 	Sequential(tasks=(Ref(name='a'), Ref(name='b')), name=None, matrix=None, env={}, cwd=None)
 	>>> isinstance(parse_task_value("{a, b}"), Parallel)

--- a/src/camas/main/format.py
+++ b/src/camas/main/format.py
@@ -16,7 +16,7 @@ else:  # pragma: no cover
 	from typing_extensions import assert_never
 
 from ..core.matrix import matrix_axes
-from ..core.render import GREY, RESET, color_on, render_tree_lines
+from ..core.render import GREY, RESET, color_on, print_tree
 from ..v0.task import Parallel, Sequential, Task, TaskNode
 from .color import BLUE, BOLD_BLUE, BOLD_CYAN, BOLD_YELLOW, maybe_color, wrap_ansi
 from .effects import available_effects, flatten_annotation, signature_fields
@@ -85,20 +85,6 @@ def format_axis(name: str, values: tuple[str, ...]) -> str:
 	return f"{name}×{len(values)} ({values[0]}..{values[-1]})"
 
 
-def summary_annotation(node: TaskNode) -> str:
-	"""Annotate a top-level entry with its matrix axes (empty for non-matrix nodes).
-
-	>>> summary_annotation(Task("hi"))
-	''
-	>>> summary_annotation(Parallel(Task("t"), matrix={"DB": ("sqlite", "postgres"), "OPT": ("debug",)}))
-	'  [matrix: DB×2 (sqlite..postgres) OPT=debug]'
-	"""
-	if isinstance(node, Task) or node.matrix is None:
-		return ""
-	axes = " ".join(format_axis(k, v) for k, v in node.matrix.items())
-	return f"  [matrix: {axes}]"
-
-
 def colorize_summary(body: str, color: bool) -> str:
 	"""Grey out the structural ``,`` and ``|`` operators in a task summary."""
 	if not color:
@@ -145,7 +131,11 @@ def format_task_summary_listing(
 			if node.help is not None
 			else colorize_summary(task_summary(node, names), color)
 		)
-		annotation = summary_annotation(node)
+		annotation = (
+			""
+			if isinstance(node, Task) or node.matrix is None
+			else f"  [matrix: {' '.join(format_axis(k, v) for k, v in node.matrix.items())}]"
+		)
 		lines.append(
 			f"  {maybe_color(name.ljust(width + 1), BOLD_CYAN, color)} {body}"
 			f"{maybe_color(annotation, GREY, color) if annotation else ''}"
@@ -155,18 +145,6 @@ def format_task_summary_listing(
 
 def print_task_summary_listing(tasks: Mapping[str, TaskNode], source: Path | None) -> None:
 	print(format_task_summary_listing(tasks, source, color=color_on()))
-
-
-def print_tree(task: TaskNode, show_cmd: bool = False) -> None:
-	"""Print the task tree structure to stdout without executing.
-
-	>>> print_tree(Task("echo hi"))
-	echo hi
-	>>> print_tree(Task("echo hi", name="greet"), show_cmd=True)
-	greet: echo hi
-	"""
-	for line in render_tree_lines(task, show_cmd=show_cmd, color=color_on()):
-		print(line)
 
 
 def print_task_trees(tasks: Mapping[str, TaskNode], source: Path | None) -> None:
@@ -314,23 +292,15 @@ def format_try_hint(color: bool) -> str:
 	return f"{header}\n{body}"
 
 
-def reference_entries() -> tuple[tuple[str, str], ...]:
-	"""Reference rows for the ``Reference:`` block.
-
-	Source resolves to the install path of this package — a local filesystem
-	directory agents and humans can open without a network round-trip.
-	Examples are not shipped with the wheel, so they remain at the GitHub URL.
-	"""
-	return (
+def format_reference(color: bool) -> str:
+	"""``Reference:`` block — local source path, remote examples, PyPI."""
+	# Source is the package's install path — a local directory openable without a
+	# network round-trip; examples ship only on GitHub, not in the wheel.
+	entries = (
 		("Source", str(Path(__file__).parent.parent)),
 		("Examples", "https://github.com/JPHutchins/camas/tree/main/examples"),
 		("PyPI", "https://pypi.org/project/camas/"),
 	)
-
-
-def format_reference(color: bool) -> str:
-	"""``Reference:`` block — local source path, remote examples, PyPI."""
-	entries = reference_entries()
 	width = max(len(label) for label, _ in entries) + 1
 	header = maybe_color("Reference:", BOLD_BLUE, color)
 	body = "\n".join(

--- a/src/camas/main/format.py
+++ b/src/camas/main/format.py
@@ -55,8 +55,6 @@ def task_summary(node: TaskNode, names: frozenset[str], is_root: bool = True) ->
 	'a, b'
 	>>> task_summary(Parallel(Task("a"), Task("b")), frozenset())
 	'a | b'
-	>>> task_summary(Sequential(Task("a"), Parallel(Task("b"), Task("c"))), frozenset())
-	'a, b | c'
 	>>> task_summary(Parallel(Sequential(Task("a"), Task("b")), Task("c")), frozenset())
 	'(a, b) | c'
 	>>> task_summary(Sequential(Task("a", name="lint"), Task("b")), frozenset({"lint"}))
@@ -77,10 +75,8 @@ def task_summary(node: TaskNode, names: frozenset[str], is_root: bool = True) ->
 
 
 def format_axis(name: str, values: tuple[str, ...]) -> str:
-	"""Render a matrix axis for the listing annotation.
+	"""Render a matrix axis for the listing annotation (``PY=3.13`` or ``PY×6 (lo..hi)``).
 
-	>>> format_axis("PY", ("3.13",))
-	'PY=3.13'
 	>>> format_axis("PY", ("3.10", "3.11", "3.12", "3.13", "3.14", "3.15"))
 	'PY×6 (3.10..3.15)'
 	"""
@@ -90,13 +86,10 @@ def format_axis(name: str, values: tuple[str, ...]) -> str:
 
 
 def summary_annotation(node: TaskNode) -> str:
-	"""Annotate a top-level entry with its matrix axes — important context that
-	doesn't appear in the body otherwise.
+	"""Annotate a top-level entry with its matrix axes (empty for non-matrix nodes).
 
 	>>> summary_annotation(Task("hi"))
 	''
-	>>> summary_annotation(Parallel(Task("t"), matrix={"PY": ("3.12", "3.13")}))
-	'  [matrix: PY×2 (3.12..3.13)]'
 	>>> summary_annotation(Parallel(Task("t"), matrix={"DB": ("sqlite", "postgres"), "OPT": ("debug",)}))
 	'  [matrix: DB×2 (sqlite..postgres) OPT=debug]'
 	"""
@@ -166,11 +159,6 @@ def print_task_summary_listing(tasks: Mapping[str, TaskNode], source: Path | Non
 
 def print_tree(task: TaskNode, show_cmd: bool = False) -> None:
 	"""Print the task tree structure to stdout without executing.
-
-	When ``show_cmd`` is True, leaf tasks with a distinct name show ``name: cmd``;
-	env entries are shown only at the deepest ancestor that introduces them,
-	so matrix expansions annotate their group header and leaves stay clean.
-	ANSI colors are emitted when stdout is a TTY and NO_COLOR is unset.
 
 	>>> print_tree(Task("echo hi"))
 	echo hi

--- a/src/camas/main/parser.py
+++ b/src/camas/main/parser.py
@@ -35,11 +35,8 @@ if TYPE_CHECKING:
 
 
 def default_effects_expr() -> str:
-	"""Pick the default ``--effects`` expression based on the runtime environment.
-
-	GitHub Actions sets ``GITHUB_ACTIONS=true`` reliably; in that case prefer
-	``Status`` with the ``github`` mode (collapsed workflow groups) over the
-	live ``Termtree`` (which renders garbage in non-interactive log capture).
+	"""Default ``--effects`` for the environment: ``Status('github')`` under GitHub
+	Actions (``GITHUB_ACTIONS=true``, collapsed workflow groups), else live ``Termtree``.
 
 	>>> import os
 	>>> _saved = os.environ.pop("GITHUB_ACTIONS", None)
@@ -168,12 +165,5 @@ RESERVED_FLAGS: Final = frozenset(
 
 
 def expression_metavar(tasks: Mapping[str, TaskNode] | None) -> str:
-	"""Build the positional metavar.
-
-	>>> from camas import Task
-	>>> expression_metavar(None)
-	'expression'
-	>>> expression_metavar({"all": Task("x")})
-	'task | expression'
-	"""
+	"""Positional metavar: ``task | expression`` when tasks exist, else ``expression``."""
 	return "task | expression" if tasks else "expression"

--- a/src/camas/main/tasks.py
+++ b/src/camas/main/tasks.py
@@ -26,14 +26,6 @@ if TYPE_CHECKING:
 	from pathlib import Path
 
 
-def find_pyproject(start: Path) -> Path | None:
-	"""Walk upward from ``start`` looking for a pyproject.toml."""
-	for candidate in (start, *start.parents):
-		if (pyproject := candidate / "pyproject.toml").is_file():
-			return pyproject
-	return None
-
-
 def is_str_dict(value: Any) -> TypeGuard[dict[str, Any]]:
 	return isinstance(value, dict) and all(isinstance(k, str) for k in value)  # pyright: ignore[reportUnknownVariableType]
 
@@ -87,14 +79,6 @@ def load_tasks(path: Path) -> tuple[dict[str, TaskNode], dict[str, type[Effect[A
 		except ValueError as e:
 			raise ValueError(f"task {name!r}: {e}") from e
 	return {name: resolve_refs(tree, pre, frozenset({name})) for name, tree in pre.items()}, {}
-
-
-def find_tasks_py(start: Path) -> Path | None:
-	"""Walk upward from ``start`` looking for a ``tasks.py``."""
-	for candidate in (start, *start.parents):
-		if (tasks_py := candidate / "tasks.py").is_file():
-			return tasks_py
-	return None
 
 
 def name_scope_bindings(scope: Mapping[str, object]) -> dict[str, TaskNode]:

--- a/tests/core/test_traversal.py
+++ b/tests/core/test_traversal.py
@@ -7,8 +7,8 @@ import pytest
 
 from camas import Parallel, Sequential, Task
 from camas.core.leaf_state import ChainLink
+from camas.core.render import print_tree
 from camas.core.traversal import flatten_leaves
-from camas.effect.termtree import print_tree
 
 
 def test_single_cmd() -> None:

--- a/tests/main/test_check.py
+++ b/tests/main/test_check.py
@@ -19,8 +19,6 @@ from camas.main.check import (
 	CheckerErr,
 	CheckerNotFound,
 	CheckerOk,
-	EvalErr,
-	EvalOk,
 	FoundChecker,
 	checker_argv,
 	deepest_user_frame,
@@ -28,10 +26,10 @@ from camas.main.check import (
 	find_typechecker,
 	format_minimal_trace,
 	report_eval_error,
-	run_eval,
 	run_typecheck,
 	run_typecheck_only,
 )
+from camas.main.tasks import load_tasks_from_py
 
 FIXTURES: Final = Path(__file__).parents[1] / "fixtures" / "check"
 
@@ -168,21 +166,6 @@ def test_find_typechecker_win32_uses_exe_suffix(
 	assert find_typechecker() == FoundChecker(name="ty", path=tmp_path / "ty.exe")
 
 
-def test_run_eval_pass(tmp_path: Path) -> None:
-	p = tmp_path / "ok.py"
-	p.write_text("x = 1\n")
-	assert isinstance(run_eval(p), EvalOk)
-
-
-def test_run_eval_captures_exception(tmp_path: Path) -> None:
-	p = tmp_path / "bad.py"
-	p.write_text("raise ValueError('boom')\n")
-	result = run_eval(p)
-	assert isinstance(result, EvalErr)
-	assert isinstance(result.exception, ValueError)
-	assert str(result.exception) == "boom"
-
-
 @requires_checker
 def test_run_typecheck_passes(tmp_path: Path) -> None:
 	p = tmp_path / "clean.py"
@@ -211,9 +194,9 @@ def test_run_typecheck_no_checker(tmp_path: Path, monkeypatch: pytest.MonkeyPatc
 def test_deepest_user_frame_finds_tasks_py(tmp_path: Path) -> None:
 	p = tmp_path / "tasks.py"
 	p.write_text("raise RuntimeError('boom')\n")
-	r = run_eval(p)
-	assert isinstance(r, EvalErr)
-	frame = deepest_user_frame(r.exception, p)
+	with pytest.raises(RuntimeError) as caught:
+		load_tasks_from_py(p)
+	frame = deepest_user_frame(caught.value, p)
 	assert frame is not None
 	assert Path(frame.filename).resolve() == p.resolve()
 	assert frame.lineno == 1
@@ -228,9 +211,9 @@ def test_deepest_user_frame_none_when_no_match(tmp_path: Path) -> None:
 def test_format_minimal_trace_simple_error(tmp_path: Path) -> None:
 	p = tmp_path / "tasks.py"
 	p.write_text("raise RuntimeError('boom')\n")
-	r = run_eval(p)
-	assert isinstance(r, EvalErr)
-	out = format_minimal_trace(r.exception, p)
+	with pytest.raises(RuntimeError) as caught:
+		load_tasks_from_py(p)
+	out = format_minimal_trace(caught.value, p)
 	assert f"error: {p}:1" in out
 	assert "raise RuntimeError('boom')" in out
 	assert "RuntimeError: boom" in out
@@ -242,9 +225,9 @@ def test_format_minimal_trace_simple_error(tmp_path: Path) -> None:
 def test_format_minimal_trace_includes_caret(tmp_path: Path) -> None:
 	p = tmp_path / "tasks.py"
 	p.write_text("x = undefined_thing\n")
-	r = run_eval(p)
-	assert isinstance(r, EvalErr)
-	out = format_minimal_trace(r.exception, p)
+	with pytest.raises(NameError) as caught:
+		load_tasks_from_py(p)
+	out = format_minimal_trace(caught.value, p)
 	assert "^^^^^^^^^^^^^^^" in out
 	assert "NameError" in out
 	assert "undefined_thing" in out
@@ -309,9 +292,9 @@ def test_report_eval_error_prints_trace_and_silent_checker_ok(
 	monkeypatch.setattr(check_mod, "run_typecheck", _stub_ok)
 	p = tmp_path / "tasks.py"
 	p.write_text("raise RuntimeError('boom')\n")
-	r = run_eval(p)
-	assert isinstance(r, EvalErr)
-	assert report_eval_error(p, r.exception) == 1
+	with pytest.raises(RuntimeError) as caught:
+		load_tasks_from_py(p)
+	assert report_eval_error(p, caught.value) == 1
 	err = capsys.readouterr().err
 	assert "RuntimeError: boom" in err
 	assert "ty:" not in err
@@ -323,9 +306,9 @@ def test_report_eval_error_appends_checker_output_with_header(
 	monkeypatch.setattr(check_mod, "run_typecheck", _stub_err)
 	p = tmp_path / "tasks.py"
 	p.write_text("raise RuntimeError('boom')\n")
-	r = run_eval(p)
-	assert isinstance(r, EvalErr)
-	assert report_eval_error(p, r.exception) == 1
+	with pytest.raises(RuntimeError) as caught:
+		load_tasks_from_py(p)
+	assert report_eval_error(p, caught.value) == 1
 	err = capsys.readouterr().err
 	assert "RuntimeError: boom" in err
 	assert "\nty:\nTYPE_FAIL_MARKER" in err
@@ -338,9 +321,9 @@ def test_report_eval_error_silent_on_no_checker(
 	monkeypatch.setattr(check_mod, "run_typecheck", _stub_not_found)
 	p = tmp_path / "tasks.py"
 	p.write_text("raise RuntimeError('boom')\n")
-	r = run_eval(p)
-	assert isinstance(r, EvalErr)
-	assert report_eval_error(p, r.exception) == 1
+	with pytest.raises(RuntimeError) as caught:
+		load_tasks_from_py(p)
+	assert report_eval_error(p, caught.value) == 1
 	err = capsys.readouterr().err
 	assert "RuntimeError: boom" in err
 	assert INSTALL_HINT not in err

--- a/tests/main/test_tasks.py
+++ b/tests/main/test_tasks.py
@@ -22,8 +22,6 @@ from camas.main.expression import (
 )
 from camas.main.tasks import (
 	assign_key_name,
-	find_pyproject,
-	find_tasks_py,
 	is_str_dict,
 	load_tasks,
 	load_tasks_from_py,
@@ -169,24 +167,6 @@ def test_resolve_refs_transitive_cycle() -> None:
 	}
 	with pytest.raises(ValueError, match="cycle"):
 		resolve_refs(Ref("a"), pre, frozenset())
-
-
-def test_find_pyproject_in_cwd(tmp_path: Path) -> None:
-	(tmp_path / "pyproject.toml").write_text("")
-	assert find_pyproject(tmp_path) == tmp_path / "pyproject.toml"
-
-
-def test_find_pyproject_walks_up(tmp_path: Path) -> None:
-	(tmp_path / "pyproject.toml").write_text("")
-	sub = tmp_path / "a" / "b" / "c"
-	sub.mkdir(parents=True)
-	assert find_pyproject(sub) == tmp_path / "pyproject.toml"
-
-
-def test_find_pyproject_none(tmp_path: Path) -> None:
-	sub = tmp_path / "nested"
-	sub.mkdir()
-	assert find_pyproject(sub) is None
 
 
 def test_run_cli_collects_tasks_from_scope(capsys: pytest.CaptureFixture[str]) -> None:
@@ -450,22 +430,6 @@ def test_named_task_end_to_end(tmp_path: Path) -> None:
 		check=False,
 	)
 	assert result.returncode == 0
-
-
-def test_find_tasks_py_in_cwd(tmp_path: Path) -> None:
-	(tmp_path / "tasks.py").write_text("")
-	assert find_tasks_py(tmp_path) == tmp_path / "tasks.py"
-
-
-def test_find_tasks_py_walks_up(tmp_path: Path) -> None:
-	(tmp_path / "tasks.py").write_text("")
-	sub = tmp_path / "a" / "b"
-	sub.mkdir(parents=True)
-	assert find_tasks_py(sub) == tmp_path / "tasks.py"
-
-
-def test_find_tasks_py_none(tmp_path: Path) -> None:
-	assert find_tasks_py(tmp_path) is None
 
 
 def test_load_tasks_from_py_propagates_names(tmp_path: Path) -> None:


### PR DESCRIPTION
## LLM-slop cleanup

Reduce total LOC across the repo without losing anything — behavior, public API docs, or test coverage. The codebase had accumulated over-abstraction (single-use helpers extracted purely for testability/composition) and over-documentation (obvious functions with prose + granular doctests) from prior overzealous LLM choices.

**Net: src 5569 → 5258 (−311 LOC)**; overall +113/−477. 100% branch coverage maintained throughout; ruff, mypy, pyright, pyrefly, ty, and zuban all green. Public `camas.v0` docstrings untouched.

### Phase 1 — dead code + docstring/doctest diet (`afe43ef`)
- Removed the unused `build_leaf_index_map` (production builds the same leaf-index dict inline in `run`).
- Trimmed over-documentation across `core`/`effect`/`main`: prose that restated self-evident one-line bodies, and doctests too granular to earn their lines.
- Kept doctests that serve as the behavioral spec (`block_for` — README-cited, `render_tree_prefix`, and the renderers whose doctests are their only direct coverage).
- Internal docstring lines 1119 → 896.

### Phase 2 — dead test-only code + single-use inlining (`b226dc2`)
**Test-only triage** — delete abstractions production never uses:
- `run_eval` + `EvalOk`/`EvalErr`/`EvalResult` — a parallel eval path; production captures load errors via `_load_py` → `LoadErr`. The error-formatter tests that used `run_eval` only to *produce* an exception now drive the live `load_tasks_from_py` path via `pytest.raises`, so that coverage exercises real code.
- `find_pyproject` / `find_tasks_py` — superseded by `resolve_tasks_source`'s inline upward walk.
- `looks_like_py_file` → inlined to `arg.endswith(".py")`.

**Inline single-use helpers** whose sole caller stays small: `first_failure_rc` → `execute`, `reference_entries` → `format_reference`, `summary_annotation` → `format_task_summary_listing`. Consolidated the byte-identical `print_tree` (duplicated in `main/format.py` and `effect/termtree.py`) into `core/render.py` beside `render_tree_lines`.

**Deliberately kept** — genuine decomposition that aids readability or compile-time safety, not slop: match-helpers with `assert_never` (exhaustiveness), genexpr/f-string composition, pure/impure splits, recursive walkers, and the `fmt_*` formatter family.

### Related
`run_cli` was kept and investigated against the PEP 723 work — findings on how to wire it as the standalone `if __name__ == "__main__"` entry point are in #32.
