### PR TITLE
fix(demo): record Termtree, not the CI github effect

### DIFF
--- a/.github/scripts/demo-payload.sh
+++ b/.github/scripts/demo-payload.sh
@@ -19,4 +19,9 @@ sleep 0.4
 printf '\n'
 sleep 0.2
 
-exec camas all
+# Record the live Termtree TUI the demo exists to showcase. Under CI,
+# GITHUB_ACTIONS=true makes camas auto-select Status(output_mode="github") as the
+# default effect, which renders collapsed workflow groups instead of the
+# animation — so scrub it for this one process to get the local experience a user
+# typing `camas all` would actually see.
+exec env -u GITHUB_ACTIONS camas all


### PR DESCRIPTION
## Problem

The demo GIF is supposed to showcase camas's live `Termtree` TUI, but #22 reported it rendering the GitHub effect instead.

**Root cause:** the demo is recorded in CI, where `GITHUB_ACTIONS=true`. `default_effects_expr()` (`src/camas/main/parser.py`) auto-selects `Status(output_mode="github")` as the default `--effects` in that environment. `demo-payload.sh` runs a bare `camas all` (no `--effects`), so the recording captured collapsed workflow-group output rather than the animation.

## Fix

Scrub `GITHUB_ACTIONS` for the single `camas all` recording process (`exec env -u GITHUB_ACTIONS camas all`) so the cast captures the local Termtree experience a developer typing `camas all` would actually see. The typed/displayed command stays `camas all`; only the inherited CI env is adjusted for the recording.

This is independent of #21 — it fixes the environment the demo records under, not the default-effect resolution itself, so it holds regardless of what #21 settles for default-effect fallback.

## Verification

- `shellcheck .github/scripts/demo-payload.sh` — clean
- `shfmt -d` — no diff
- `default_effects_expr()` doctest already asserts `(Termtree(),)` is returned when `GITHUB_ACTIONS` is unset.

Fixes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)