### PR TITLE
fix(dispatch): accept hyphenated aliases for underscore task names

### DIFF
--- a/src/camas/main/dispatch.py
+++ b/src/camas/main/dispatch.py
@@ -5,8 +5,8 @@
 
 from __future__ import annotations
 
-import ast
 import asyncio
+import re
 import sys
 from pathlib import Path
 from typing import TYPE_CHECKING, Final
@@ -41,18 +41,26 @@ if TYPE_CHECKING:
 	from ..v0.task import TaskNode
 
 
+_NAME_LIKE: Final = re.compile(r"^[A-Za-z_][A-Za-z0-9_-]*$")
+"""A bare task name — possibly hyphenated — as opposed to a camas expression
+(which carries parens, quotes, braces, or operators)."""
+
+
 def dispatch_arg(arg: str, tasks: Mapping[str, TaskNode]) -> TaskNode:
-	"""Interpret a CLI arg: task name (possibly hyphenated) ⇒ lookup, else inline expression."""
-	if arg in tasks:
-		return tasks[arg]
-	try:
-		parsed = ast.parse(arg, mode="eval")
-	except SyntaxError:
-		return parse_expression(arg, tasks=tasks)
-	if isinstance(parsed.body, ast.Name):
-		name = parsed.body.id
+	"""Interpret a CLI arg: task name ⇒ lookup, else inline expression.
+
+	The name is matched verbatim first (so a hyphenated ``[tool.camas.tasks]``
+	key resolves directly), then with hyphens folded to underscores — so a
+	``tasks.py`` binding ``test_all`` is reachable as the conventional
+	``camas test-all`` even though ``test-all`` is a subtraction, not a name.
+	Underscore is canonical; the hyphen spelling is the convention-driven alias.
+	"""
+	for candidate in (arg, arg.replace("-", "_")):
+		if candidate in tasks:
+			return tasks[candidate]
+	if _NAME_LIKE.match(arg):
 		known = ", ".join(sorted(tasks)) or "none"
-		print(f"error: no task named {name!r} (known: {known})", file=sys.stderr)
+		print(f"error: no task named {arg!r} (known: {known})", file=sys.stderr)
 		sys.exit(2)
 	return parse_expression(arg, tasks=tasks)
 

--- a/src/camas/main/dispatch.py
+++ b/src/camas/main/dispatch.py
@@ -42,18 +42,18 @@ if TYPE_CHECKING:
 
 
 _NAME_LIKE: Final = re.compile(r"^[A-Za-z_][A-Za-z0-9_-]*$")
-"""A bare task name — possibly hyphenated — as opposed to a camas expression
-(which carries parens, quotes, braces, or operators)."""
+"""A bare task name, hyphens allowed — distinct from a camas expression, which
+carries parens, quotes, or braces. A ``-`` is taken as part of the name (the
+convention alias), never as subtraction."""
 
 
 def dispatch_arg(arg: str, tasks: Mapping[str, TaskNode]) -> TaskNode:
 	"""Interpret a CLI arg: task name ⇒ lookup, else inline expression.
 
 	The name is matched verbatim first (so a hyphenated ``[tool.camas.tasks]``
-	key resolves directly), then with hyphens folded to underscores — so a
+	key resolves directly), then with hyphens folded to underscores — so the
 	``tasks.py`` binding ``test_all`` is reachable as the conventional
-	``camas test-all`` even though ``test-all`` is a subtraction, not a name.
-	Underscore is canonical; the hyphen spelling is the convention-driven alias.
+	``camas test-all``, which would otherwise parse as a subtraction.
 	"""
 	for candidate in (arg, arg.replace("-", "_")):
 		if candidate in tasks:

--- a/tests/main/test_tasks.py
+++ b/tests/main/test_tasks.py
@@ -289,6 +289,20 @@ def test_dispatch_arg_hyphenated_name() -> None:
 	assert dispatch_arg("matrix-ci", tasks) == Task("uv run camas ci")
 
 
+def test_dispatch_arg_hyphen_folds_to_underscore_binding() -> None:
+	# `camas test-all` reaches the underscore-named tasks.py binding `test_all`.
+	tasks = {"test_all": Task("pytest")}
+	assert dispatch_arg("test-all", tasks) == Task("pytest")
+
+
+def test_dispatch_arg_hyphenated_unknown_errors(capsys: pytest.CaptureFixture[str]) -> None:
+	# A hyphenated name with no verbatim or underscore-folded match is a friendly
+	# "no task named" error, not the cryptic ``unsupported syntax: BinOp(...)``.
+	with pytest.raises(SystemExit, match="2"):
+		dispatch_arg("test-all", {"lint": Task("ruff .")})
+	assert "no task named 'test-all'" in capsys.readouterr().err
+
+
 def test_dispatch_arg_unknown_name() -> None:
 	with pytest.raises(SystemExit, match="2"):
 		dispatch_arg("nope", {"a": Task("x")})
@@ -390,6 +404,19 @@ def test_named_task_dry_run(
 	out = capsys.readouterr().out
 	assert "echo a" in out
 	assert "echo b" in out
+
+
+def test_hyphenated_invocation_of_underscore_binding(
+	tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+	monkeypatch.chdir(tmp_path)
+	(tmp_path / "tasks.py").write_text("from camas import Task\ntest_all = Task('echo ran')\n")
+	with (
+		pytest.raises(SystemExit, match="0"),
+		patch("sys.argv", ["camas", "--dry-run", "test-all"]),
+	):
+		main()
+	assert "echo ran" in capsys.readouterr().out
 
 
 def test_named_task_from_subdirectory(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Problem

`camas test-all` for a `tasks.py` binding named `test_all` failed with a cryptic error:

```
$ camas test-all
error: unsupported syntax: BinOp(left=Name(id='test', ctx=Load()), op=Sub(), right=Name(id='all', ctx=Load()))
```

The arg was parsed as a Python expression (`test - all`, a subtraction) and fell through to the `unsupported syntax` branch. Every peer runner (just, Task, poe, npm scripts) uses hyphens, so `test-all` is the natural thing to type. (#24)

## Fix

Per the issue discussion (underscore is canonical, but allow the `-` fallback users assume by convention), `dispatch_arg`:

1. matches the name **verbatim** first — so a hyphenated `[tool.camas.tasks]` key (`matrix-ci`) still resolves directly;
2. then matches with **hyphens folded to underscores** — so `camas test-all` reaches the `test_all` binding;
3. otherwise, if the arg is identifier-shaped (a `_NAME_LIKE` bare name, possibly hyphenated, with no parens/quotes/braces/operators), emits the friendly `no task named 'test-all' (known: ...)` error instead of the `BinOp` dump — extending the existing bare-`Name` handling to the hyphen case;
4. only genuine expressions (carrying parens/quotes/braces/operators) take the inline-expression path, unchanged.

This also lets the implementation drop the `ast.parse` round-trip in `dispatch_arg` in favor of a single regex.

## Tests

- `test_dispatch_arg_hyphen_folds_to_underscore_binding` — `dispatch_arg("test-all", {"test_all": ...})` resolves.
- `test_dispatch_arg_hyphenated_unknown_errors` — friendly error, not a `BinOp` dump.
- `test_hyphenated_invocation_of_underscore_binding` — end-to-end `camas test-all` against a `tasks.py` defining `test_all`.
- Existing `test_dispatch_arg_hyphenated_name` (literal hyphenated TOML key) still passes.

Full suite: 532 passed. ruff/mypy/pyright/ty clean.

Fixes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)