### PR TITLE
fix(toml): thread cwd/help through the expression evaluator

### DIFF
--- a/src/camas/main/expression.py
+++ b/src/camas/main/expression.py
@@ -202,6 +202,8 @@ def eval_node(
 						cmd=eval_cmd(cmd_node),
 						name=eval_opt_str(kw.get("name")),
 						env=eval_env(kw.get("env")),
+						cwd=eval_opt_str(kw.get("cwd")),
+						help=eval_opt_str(kw.get("help")),
 					)
 				case "Sequential" | "Parallel":
 					ctor = Sequential if name == "Sequential" else Parallel
@@ -210,6 +212,8 @@ def eval_node(
 						name=eval_opt_str(kw.get("name")),
 						matrix=eval_matrix(kw.get("matrix")),
 						env=eval_env(kw.get("env")),
+						cwd=eval_opt_str(kw.get("cwd")),
+						help=eval_opt_str(kw.get("help")),
 					)
 				case "Ref":
 					ref_name_node = args[0] if args else kw.get("name")

--- a/tests/main/test_expression.py
+++ b/tests/main/test_expression.py
@@ -3,10 +3,14 @@
 
 from __future__ import annotations
 
+import inspect
+from pathlib import Path
+
 import pytest
 
 from camas import Parallel, Sequential, Task
 from camas.main.expression import parse_expression
+from camas.v0.task import Group
 
 
 @pytest.mark.parametrize(
@@ -135,6 +139,28 @@ def test_parse_expression_threads_cwd_and_help() -> None:
 	assert parse_expression('Parallel(Task("a"), cwd="work", help="grp")') == Parallel(
 		Task("a"), cwd="work", help="grp"
 	)
+
+
+def test_eval_node_threads_every_public_constructor_kwarg() -> None:
+	"""Drift guard: a new public kwarg on Task/Sequential/Parallel fails here until
+	it's both wired through ``eval_node`` and given a sentinel below — so a silently
+	dropped kwarg (the #25 bug) can't reappear unnoticed."""
+	# fragment + (attribute, expected value) for each constructor kwarg.
+	samples = {
+		"name": ("name='n'", "name", "n"),
+		"env": ("env={'K': 'v'}", "env", {"K": "v"}),
+		"cwd": ("cwd='d'", "cwd", Path("d")),
+		"help": ("help='h'", "help", "h"),
+		"matrix": ("matrix={'X': ('1',)}", "matrix", {"X": ("1",)}),
+	}
+	for cls, prefix, variadic in (
+		(Task, "Task('c', ", "cmd"),
+		(Group, "Parallel(Task('a'), ", "tasks"),
+	):
+		for kw in set(inspect.signature(cls).parameters) - {variadic}:
+			frag, attr, expected = samples[kw]  # KeyError flags an unsampled new kwarg
+			node = parse_expression(prefix + frag + ")")
+			assert getattr(node, attr) == expected, (cls.__name__, kw)
 
 
 # Parser-side fluent syntax: strings inside literals and the README one-liner.

--- a/tests/main/test_expression.py
+++ b/tests/main/test_expression.py
@@ -126,6 +126,17 @@ def test_parse_explicit_none_name() -> None:
 	assert parse_expression('Task("hi", name=None)') == Task("hi", name=None)
 
 
+def test_parse_expression_threads_cwd_and_help() -> None:
+	"""``cwd`` / ``help`` reach the constructors from the expression mini-language,
+	at parity with ``tasks.py`` — not silently dropped (#25)."""
+	assert parse_expression('Task("cargo build", cwd="src-tauri", help="Build")') == Task(
+		"cargo build", cwd="src-tauri", help="Build"
+	)
+	assert parse_expression('Parallel(Task("a"), cwd="work", help="grp")') == Parallel(
+		Task("a"), cwd="work", help="grp"
+	)
+
+
 # Parser-side fluent syntax: strings inside literals and the README one-liner.
 
 

--- a/tests/main/test_tasks.py
+++ b/tests/main/test_tasks.py
@@ -84,6 +84,15 @@ def test_parse_task_value_explicit_ref() -> None:
 	)
 
 
+def test_parse_task_value_threads_cwd_and_help() -> None:
+	assert parse_task_value('Task("cargo build", cwd="src-tauri", help="Build")') == Task(
+		"cargo build", cwd="src-tauri", help="Build"
+	)
+	assert parse_task_value('Parallel(Task("a"), cwd="work", help="grp")') == Parallel(
+		Task("a"), cwd="work", help="grp"
+	)
+
+
 def test_parse_task_value_matrix_preserved() -> None:
 	assert parse_task_value('Parallel(Task("t {PY}"),matrix={"PY": ("3.12", "3.13")})') == Parallel(
 		Task("t {PY}"), matrix={"PY": ("3.12", "3.13")}
@@ -209,6 +218,24 @@ ci = 'Sequential(Ref("lint"), Ref("typecheck"), Ref("test"))'
 		Parallel(Task("mypy .", name="mypy"), Task("pyright .", name="pyright"), name="typecheck"),
 		Task("pytest", name="test"),
 		name="ci",
+	)
+
+
+def test_load_tasks_threads_cwd_and_help(tmp_path: Path) -> None:
+	"""The [tool.camas.tasks] path applies ``cwd`` / ``help`` instead of silently
+	dropping them (#25) — full parity with the Python ``tasks.py`` constructors."""
+	pyproject = tmp_path / "pyproject.toml"
+	pyproject.write_text(
+		"[tool.camas.tasks]\n"
+		'build = \'Task("cargo build", cwd="src-tauri", help="Build the app")\'\n'
+		'checks = \'Parallel(Task("a"), Task("b"), cwd="work", help="Run checks")\'\n'
+	)
+	tasks, _ = load_tasks(pyproject)
+	assert tasks["build"] == Task(
+		"cargo build", name="build", cwd="src-tauri", help="Build the app"
+	)
+	assert tasks["checks"] == Parallel(
+		Task("a"), Task("b"), name="checks", cwd="work", help="Run checks"
 	)
 
 


### PR DESCRIPTION
## Problem

Tasks defined in `[tool.camas.tasks]` (and the inline expression mini-language) silently ignored `cwd=` and `help=`. `eval_node` (`src/camas/main/expression.py`) built `kw = {...}` collecting *all* kwargs but only read a subset:

- `Task`: read `cmd`, `name`, `env` — dropped `cwd`, `help`
- `Sequential` / `Parallel`: read `name`, `matrix`, `env` — dropped `cwd`, `help`

So this ran in the wrong directory, silently:

```toml
[tool.camas.tasks]
build = 'Task("cargo build", cwd="src-tauri")'   # cwd ignored → ran in project root
```

and `help=` never reached `--list` / `<task> --help` — even though the Python `Task`/`Group` constructors accept both. The TOML path was strictly less capable, invisibly. (#25)

## Fix

`eval_node` now threads `cwd` and `help` into `Task` / `Sequential` / `Parallel`, giving the TOML path **full parity** with `tasks.py` (the issue's preferred option). `assign_key_name` and `resolve_refs` already preserve both, so they survive TOML-key naming and ref resolution.

Per the issue discussion, this is the parity fix; a future project-wide defaults layer (#21) can build on it rather than re-plumbing `eval_node`.

## Tests

- `test_load_tasks_threads_cwd_and_help` — the exact issue scenario end-to-end (`Task("cargo build", cwd="src-tauri", help=...)` and a `Parallel(..., cwd=, help=)`) through `load_tasks`.
- `test_parse_task_value_threads_cwd_and_help` — `parse_task_value` unit.
- `test_parse_expression_threads_cwd_and_help` — inline expression mini-language.

(Comparisons use `Path` equality, not repr, so they hold on Windows too.) Full suite: 532 passed. ruff/mypy/ty clean.

Fixes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)