### PR TITLE
feat(jobs): optional --jobs / CAMAS_JOBS concurrency cap

### DIFF
--- a/src/camas/core/execution.py
+++ b/src/camas/core/execution.py
@@ -151,6 +151,8 @@ async def run(
 	a run more parallel than it already is.
 
 	Raises:
+		ValueError: when ``jobs`` is provided but less than 1 (``0`` would
+			deadlock on an empty semaphore; negatives are meaningless).
 		BaseExceptionGroup: every error raised by Effects during setup,
 			on_event, or teardown, collected per phase.
 
@@ -160,6 +162,8 @@ async def run(
 	>>> asyncio.run(run(Task(("python", "-c", "raise SystemExit(1)")))).returncode
 	1
 	"""
+	if jobs is not None and jobs < 1:
+		raise ValueError(f"jobs must be >= 1, got {jobs}")
 	limiter: Final[Limiter] = asyncio.Semaphore(jobs) if jobs is not None else nullcontext()
 	expanded: Final = expand_matrix(task)
 	leaf_infos: Final = flatten_leaves(expanded)

--- a/src/camas/core/execution.py
+++ b/src/camas/core/execution.py
@@ -41,8 +41,7 @@ if TYPE_CHECKING:
 
 
 Limiter: TypeAlias = "asyncio.Semaphore | nullcontext[None]"
-"""What bounds concurrent leaf subprocesses: an ``asyncio.Semaphore(jobs)`` for a
-``--jobs`` cap, or a no-op ``nullcontext`` when unbounded (the default)."""
+"""Throttles concurrent leaf subprocesses under ``--jobs``; a no-op when unbounded."""
 
 
 def subprocess_env(merged: dict[str, str]) -> dict[str, str]:
@@ -54,13 +53,7 @@ def subprocess_env(merged: dict[str, str]) -> dict[str, str]:
 
 
 async def run_cmd(task: Task, leaf_index: int, dispatch: EventSink, limiter: Limiter) -> TaskResult:
-	"""Run one leaf as a subprocess, dispatching Started/Output/Completed events.
-
-	``limiter`` bounds how many leaves hold a live subprocess at once (the
-	``--jobs`` cap); acquired before the leaf starts so a queued leaf stays
-	``Waiting`` and its measured elapsed excludes the wait. It is a no-op
-	``nullcontext`` when unbounded.
-	"""
+	"""Run one leaf as a subprocess, dispatching Started/Output/Completed events."""
 	async with limiter:
 		start_pc: Final = time.perf_counter()
 		await dispatch(leaf_index, StartedEvent(task, leaf_index, datetime.now()))
@@ -146,13 +139,8 @@ async def run(
 ) -> RunResult:
 	"""Execute a task tree, dispatching events to every effect.
 
-	``jobs`` caps how many leaf subprocesses run at once; ``None`` (the default)
-	is unbounded. It only ever throttles the tree's own fan-out — it cannot make
-	a run more parallel than it already is.
-
 	Raises:
-		ValueError: when ``jobs`` is provided but less than 1 (``0`` would
-			deadlock on an empty semaphore; negatives are meaningless).
+		ValueError: when ``jobs`` is provided and less than 1.
 		BaseExceptionGroup: every error raised by Effects during setup,
 			on_event, or teardown, collected per phase.
 

--- a/src/camas/core/execution.py
+++ b/src/camas/core/execution.py
@@ -9,9 +9,10 @@ import asyncio
 import os
 import sys
 import time
+from contextlib import nullcontext
 from datetime import datetime
 from subprocess import STDOUT
-from typing import TYPE_CHECKING, Any, Final
+from typing import TYPE_CHECKING, Any, Final, TypeAlias
 
 if sys.version_info >= (3, 11):
 	from asyncio import TaskGroup
@@ -39,6 +40,11 @@ if TYPE_CHECKING:
 	from .effect import EventSink
 
 
+Limiter: TypeAlias = "asyncio.Semaphore | nullcontext[None]"
+"""What bounds concurrent leaf subprocesses: an ``asyncio.Semaphore(jobs)`` for a
+``--jobs`` cap, or a no-op ``nullcontext`` when unbounded (the default)."""
+
+
 def subprocess_env(merged: dict[str, str]) -> dict[str, str]:
 	"""Leaf-subprocess env: defaults merged underneath ``merged``; ``NO_COLOR`` strips color forces."""
 	base = {"PYTHONUNBUFFERED": "1"} | merged
@@ -47,28 +53,35 @@ def subprocess_env(merged: dict[str, str]) -> dict[str, str]:
 	return {"FORCE_COLOR": "1", "CLICOLOR_FORCE": "1"} | base
 
 
-async def run_cmd(task: Task, leaf_index: int, dispatch: EventSink) -> TaskResult:
-	"""Run one leaf as a subprocess, dispatching Started/Output/Completed events."""
-	start_pc: Final = time.perf_counter()
-	await dispatch(leaf_index, StartedEvent(task, leaf_index, datetime.now()))
-	proc: Final = await asyncio.create_subprocess_exec(
-		*resolve_cmd(task.cmd),
-		stdout=asyncio.subprocess.PIPE,
-		stderr=STDOUT,
-		env=subprocess_env({**os.environ, **task.env}),
-		cwd=task.cwd,
-	)
-	output: Final[list[bytes]] = []
-	if proc.stdout is not None:  # pragma: no branch
-		async for line in proc.stdout:
-			output.append(line)
-			await dispatch(leaf_index, OutputEvent(task, leaf_index, line, datetime.now()))
-	await proc.wait()
-	elapsed: Final = time.perf_counter() - start_pc
-	rc: Final = proc.returncode or 0
-	completion: Final = Finished(rc, elapsed, output)
-	await dispatch(leaf_index, CompletedEvent(task, leaf_index, completion, datetime.now()))
-	return TaskResult(task_label(task), completion)
+async def run_cmd(task: Task, leaf_index: int, dispatch: EventSink, limiter: Limiter) -> TaskResult:
+	"""Run one leaf as a subprocess, dispatching Started/Output/Completed events.
+
+	``limiter`` bounds how many leaves hold a live subprocess at once (the
+	``--jobs`` cap); acquired before the leaf starts so a queued leaf stays
+	``Waiting`` and its measured elapsed excludes the wait. It is a no-op
+	``nullcontext`` when unbounded.
+	"""
+	async with limiter:
+		start_pc: Final = time.perf_counter()
+		await dispatch(leaf_index, StartedEvent(task, leaf_index, datetime.now()))
+		proc: Final = await asyncio.create_subprocess_exec(
+			*resolve_cmd(task.cmd),
+			stdout=asyncio.subprocess.PIPE,
+			stderr=STDOUT,
+			env=subprocess_env({**os.environ, **task.env}),
+			cwd=task.cwd,
+		)
+		output: Final[list[bytes]] = []
+		if proc.stdout is not None:  # pragma: no branch
+			async for line in proc.stdout:
+				output.append(line)
+				await dispatch(leaf_index, OutputEvent(task, leaf_index, line, datetime.now()))
+		await proc.wait()
+		elapsed: Final = time.perf_counter() - start_pc
+		rc: Final = proc.returncode or 0
+		completion: Final = Finished(rc, elapsed, output)
+		await dispatch(leaf_index, CompletedEvent(task, leaf_index, completion, datetime.now()))
+		return TaskResult(task_label(task), completion)
 
 
 async def skip_subtree(
@@ -91,15 +104,16 @@ async def execute(
 	dispatch: EventSink,
 	leaves: tuple[Task, ...],
 	index_map: dict[int, int],
+	limiter: Limiter,
 ) -> tuple[TaskResult, ...]:
 	"""Walk a task subtree, returning one TaskResult per leaf in DFS order."""
 	match node:
 		case Task():
-			return (await run_cmd(node, index_map[id(node)], dispatch),)
+			return (await run_cmd(node, index_map[id(node)], dispatch, limiter),)
 		case Parallel(tasks=children):
 			async with TaskGroup() as tg:
 				futures: Final = tuple(
-					tg.create_task(execute(child, dispatch, leaves, index_map))
+					tg.create_task(execute(child, dispatch, leaves, index_map, limiter))
 					for child in children
 				)
 			return tuple(r for f in futures for r in f.result())
@@ -110,7 +124,7 @@ async def execute(
 				child_results = (
 					await skip_subtree(child, Skipped(failed_rc), dispatch, leaves, index_map)
 					if failed_rc is not None
-					else await execute(child, dispatch, leaves, index_map)
+					else await execute(child, dispatch, leaves, index_map, limiter)
 				)
 				seq_results = (*seq_results, *child_results)
 				if failed_rc is None:
@@ -127,19 +141,26 @@ async def execute(
 			assert_never(node)
 
 
-async def run(task: TaskNode, effects: Sequence[Effect[Any]] = ()) -> RunResult:
+async def run(
+	task: TaskNode, effects: Sequence[Effect[Any]] = (), jobs: int | None = None
+) -> RunResult:
 	"""Execute a task tree, dispatching events to every effect.
+
+	``jobs`` caps how many leaf subprocesses run at once; ``None`` (the default)
+	is unbounded. It only ever throttles the tree's own fan-out — it cannot make
+	a run more parallel than it already is.
 
 	Raises:
 		BaseExceptionGroup: every error raised by Effects during setup,
 			on_event, or teardown, collected per phase.
 
 	>>> import asyncio
-	>>> asyncio.run(run(Task(("python", "-c", "pass")))).returncode
+	>>> asyncio.run(run(Task(("python", "-c", "pass")), jobs=1)).returncode
 	0
 	>>> asyncio.run(run(Task(("python", "-c", "raise SystemExit(1)")))).returncode
 	1
 	"""
+	limiter: Final[Limiter] = asyncio.Semaphore(jobs) if jobs is not None else nullcontext()
 	expanded: Final = expand_matrix(task)
 	leaf_infos: Final = flatten_leaves(expanded)
 	leaves: Final = tuple(info.task for info in leaf_infos)
@@ -176,7 +197,7 @@ async def run(task: TaskNode, effects: Sequence[Effect[Any]] = ()) -> RunResult:
 	try:
 		if setup_errors:
 			raise BaseExceptionGroup("setup errors", setup_errors)
-		results = await execute(expanded, dispatch, leaves, index_map)
+		results = await execute(expanded, dispatch, leaves, index_map, limiter)
 	finally:
 		teardown_errors: Final = tuple(
 			r

--- a/src/camas/main/dispatch.py
+++ b/src/camas/main/dispatch.py
@@ -31,7 +31,7 @@ from .format import (
 	print_task_summary_listing,
 	print_task_trees,
 )
-from .parser import RESERVED_FLAGS, build_parser
+from .parser import RESERVED_FLAGS, build_parser, resolve_jobs
 from .state import EMPTY_STATE, LoadErr, LoadOk, TasksState
 from .tasks import load_tasks, load_tasks_from_py, name_scope_bindings, name_scope_effects
 
@@ -208,7 +208,12 @@ def dispatch(state: TasksState, argv: list[str] | None = None) -> None:
 			if args.dry_run:
 				print_tree(task, show_cmd=True)
 				sys.exit(0)
-			sys.exit(asyncio.run(run(task, effects=effects)).returncode)
+			try:
+				jobs: Final = resolve_jobs(args.jobs)
+			except ValueError as e:
+				print(f"error: {e}", file=sys.stderr)
+				sys.exit(2)
+			sys.exit(asyncio.run(run(task, effects=effects, jobs=jobs)).returncode)
 
 		case _:
 			assert_never(state)

--- a/src/camas/main/parser.py
+++ b/src/camas/main/parser.py
@@ -54,6 +54,63 @@ def default_effects_expr() -> str:
 	return "(Termtree(),)"
 
 
+def positive_jobs(raw: str) -> int:
+	"""Validate ``--jobs`` as an argparse ``type``: a positive integer.
+
+	Raises:
+		ArgumentTypeError: when ``raw`` is not an integer ``>= 1``.
+
+	>>> positive_jobs("4")
+	4
+	>>> positive_jobs("0")
+	Traceback (most recent call last):
+	argparse.ArgumentTypeError: --jobs must be >= 1, got 0
+	"""
+	try:
+		n = int(raw)
+	except ValueError:
+		raise argparse.ArgumentTypeError(f"--jobs expects an integer, got {raw!r}") from None
+	if n < 1:
+		raise argparse.ArgumentTypeError(f"--jobs must be >= 1, got {n}")
+	return n
+
+
+def resolve_jobs(cli_jobs: int | None) -> int | None:
+	"""Effective ``--jobs`` cap: the CLI flag wins, else ``CAMAS_JOBS``, else
+	``None`` (unbounded).
+
+	Raises:
+		ValueError: when ``CAMAS_JOBS`` is set but not a positive integer.
+
+	>>> resolve_jobs(8)
+	8
+	>>> import os
+	>>> _saved = os.environ.pop("CAMAS_JOBS", None)
+	>>> resolve_jobs(None) is None
+	True
+	>>> os.environ["CAMAS_JOBS"] = "2"
+	>>> resolve_jobs(None)
+	2
+	>>> resolve_jobs(8)
+	8
+	>>> os.environ.pop("CAMAS_JOBS", None)
+	'2'
+	>>> _ = os.environ.update({"CAMAS_JOBS": _saved}) if _saved is not None else None
+	"""
+	if cli_jobs is not None:
+		return cli_jobs
+	raw = os.environ.get("CAMAS_JOBS")
+	if not raw:
+		return None
+	try:
+		n = int(raw)
+	except ValueError:
+		raise ValueError(f"CAMAS_JOBS expects a positive integer, got {raw!r}") from None
+	if n < 1:
+		raise ValueError(f"CAMAS_JOBS must be >= 1, got {n}")
+	return n
+
+
 class CamasArgumentParser(argparse.ArgumentParser):
 	"""``ArgumentParser`` whose ``--help`` appends the discovered tasks listing
 	(or load-error hint), the Effects listing, and the Try hint after argparse's
@@ -156,11 +213,21 @@ def build_parser(state: TasksState = EMPTY_STATE) -> argparse.ArgumentParser:
 		metavar="KEY=VAL[,VAL...]",
 		help="override a matrix axis (repeatable; e.g. --matrix PY=3.13)",
 	)
+	parser.add_argument(
+		"--jobs",
+		type=positive_jobs,
+		default=None,
+		metavar="N",
+		help="cap concurrently running leaf subprocesses at N (also: CAMAS_JOBS). "
+		"A throttle, not a speedup — the tree never runs wider than its own "
+		"fan-out, so --jobs can only slow a run down; reach for it only when a "
+		"wide matrix oversubscribes the machine (CPU/RAM/disk)",
+	)
 	return parser
 
 
 RESERVED_FLAGS: Final = frozenset(
-	{"help", "version", "dry-run", "list", "tree", "check", "effects", "matrix"}
+	{"help", "version", "dry-run", "list", "tree", "check", "effects", "matrix", "jobs"}
 )
 
 

--- a/src/camas/main/parser.py
+++ b/src/camas/main/parser.py
@@ -59,12 +59,6 @@ def positive_jobs(raw: str) -> int:
 
 	Raises:
 		ArgumentTypeError: when ``raw`` is not an integer ``>= 1``.
-
-	>>> positive_jobs("4")
-	4
-	>>> positive_jobs("0")
-	Traceback (most recent call last):
-	argparse.ArgumentTypeError: --jobs must be >= 1, got 0
 	"""
 	try:
 		n = int(raw)
@@ -81,21 +75,6 @@ def resolve_jobs(cli_jobs: int | None) -> int | None:
 
 	Raises:
 		ValueError: when ``CAMAS_JOBS`` is set but not a positive integer.
-
-	>>> resolve_jobs(8)
-	8
-	>>> import os
-	>>> _saved = os.environ.pop("CAMAS_JOBS", None)
-	>>> resolve_jobs(None) is None
-	True
-	>>> os.environ["CAMAS_JOBS"] = "2"
-	>>> resolve_jobs(None)
-	2
-	>>> resolve_jobs(8)
-	8
-	>>> os.environ.pop("CAMAS_JOBS", None)
-	'2'
-	>>> _ = os.environ.update({"CAMAS_JOBS": _saved}) if _saved is not None else None
 	"""
 	if cli_jobs is not None:
 		return cli_jobs

--- a/tests/core/test_execution.py
+++ b/tests/core/test_execution.py
@@ -165,6 +165,28 @@ def test_parallel_concurrency() -> None:
 	assert elapsed < 2.5
 
 
+def test_jobs_cap_serializes_parallel() -> None:
+	task = Parallel(
+		*(Task(("python", "-c", "import time; time.sleep(0.3)"), name=f"t{i}") for i in range(3))
+	)
+	start = time.perf_counter()
+	asyncio.run(run(task, jobs=1))
+	elapsed = time.perf_counter() - start
+	# jobs=1 serializes the three 0.3s sleeps (~0.9s+); unbounded would be ~0.3s.
+	assert elapsed >= 0.8
+
+
+def test_jobs_cap_preserves_results() -> None:
+	task = Parallel(
+		Task(("python", "-c", "pass"), name="a"),
+		Task(("python", "-c", "raise SystemExit(1)"), name="b"),
+		Task(("python", "-c", "pass"), name="c"),
+	)
+	result = asyncio.run(run(task, jobs=2))
+	assert result.returncode == 1
+	assert len(result.results) == 3
+
+
 def test_sequential_ordering() -> None:
 	task = Sequential(
 		Task(("python", "-c", "import time; time.sleep(0.1)"), name="a"),

--- a/tests/core/test_execution.py
+++ b/tests/core/test_execution.py
@@ -187,6 +187,13 @@ def test_jobs_cap_preserves_results() -> None:
 	assert len(result.results) == 3
 
 
+@pytest.mark.parametrize("bad", [0, -1])
+def test_jobs_below_one_rejected(bad: int) -> None:
+	# jobs=0 would block forever on an empty Semaphore; reject it up front.
+	with pytest.raises(ValueError, match="jobs must be >= 1"):
+		asyncio.run(run(Task(("python", "-c", "pass")), jobs=bad))
+
+
 def test_sequential_ordering() -> None:
 	task = Sequential(
 		Task(("python", "-c", "import time; time.sleep(0.1)"), name="a"),

--- a/tests/core/test_execution.py
+++ b/tests/core/test_execution.py
@@ -189,7 +189,6 @@ def test_jobs_cap_preserves_results() -> None:
 
 @pytest.mark.parametrize("bad", [0, -1])
 def test_jobs_below_one_rejected(bad: int) -> None:
-	# jobs=0 would block forever on an empty Semaphore; reject it up front.
 	with pytest.raises(ValueError, match="jobs must be >= 1"):
 		asyncio.run(run(Task(("python", "-c", "pass")), jobs=bad))
 

--- a/tests/main/test_dispatch.py
+++ b/tests/main/test_dispatch.py
@@ -92,3 +92,18 @@ def test_dispatch_skips_reserved_axis_name_for_auto_flag(
 	out = capsys.readouterr().out
 	assert "[matrix=b]" in out
 	assert "[matrix=a]" not in out
+
+
+def test_dispatch_jobs_runs_to_completion() -> None:
+	task = Task(("python", "-c", "print('hi')"))
+	with pytest.raises(SystemExit, match="0"):
+		dispatch(_state({"go": task}), ["go", "--jobs", "1", "--effects", "()"])
+
+
+def test_dispatch_bad_camas_jobs_errors(
+	monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+	monkeypatch.setenv("CAMAS_JOBS", "nope")
+	with pytest.raises(SystemExit, match="2"):
+		dispatch(_state({"go": Task(("python", "-c", "pass"))}), ["go", "--effects", "()"])
+	assert "CAMAS_JOBS" in capsys.readouterr().err

--- a/tests/main/test_parser.py
+++ b/tests/main/test_parser.py
@@ -5,12 +5,12 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from camas.main.parser import build_parser
+import pytest
+
+from camas.main.parser import build_parser, resolve_jobs
 
 if TYPE_CHECKING:
 	from collections.abc import Mapping
-
-	import pytest
 
 
 def test_parser_has_expression_arg() -> None:
@@ -24,6 +24,47 @@ def test_parser_dry_run_flag() -> None:
 	parser = build_parser()
 	args = parser.parse_args(["--dry-run", 'Task("echo hi")'])
 	assert args.dry_run is True
+
+
+def test_parser_jobs_flag() -> None:
+	assert build_parser().parse_args(["--jobs", "4", "x"]).jobs == 4
+
+
+def test_parser_jobs_defaults_none() -> None:
+	assert build_parser().parse_args(["x"]).jobs is None
+
+
+@pytest.mark.parametrize("bad", ["0", "-2", "abc"])
+def test_parser_jobs_rejects_invalid(bad: str) -> None:
+	with pytest.raises(SystemExit):
+		build_parser().parse_args(["--jobs", bad, "x"])
+
+
+def test_resolve_jobs_cli_wins(monkeypatch: pytest.MonkeyPatch) -> None:
+	monkeypatch.setenv("CAMAS_JOBS", "2")
+	assert resolve_jobs(8) == 8
+
+
+def test_resolve_jobs_env_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
+	monkeypatch.setenv("CAMAS_JOBS", "3")
+	assert resolve_jobs(None) == 3
+
+
+def test_resolve_jobs_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+	monkeypatch.delenv("CAMAS_JOBS", raising=False)
+	assert resolve_jobs(None) is None
+
+
+def test_resolve_jobs_bad_env_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+	monkeypatch.setenv("CAMAS_JOBS", "nope")
+	with pytest.raises(ValueError, match="CAMAS_JOBS expects"):
+		resolve_jobs(None)
+
+
+def test_resolve_jobs_nonpositive_env_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+	monkeypatch.setenv("CAMAS_JOBS", "0")
+	with pytest.raises(ValueError, match=">= 1"):
+		resolve_jobs(None)
 
 
 def test_build_parser_format_help_no_tasks_no_effects(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Motivation

`Parallel` — and therefore every expanded matrix, since `expand_*_matrix` returns a `Parallel` — launches all leaves at once via an unbounded `asyncio.TaskGroup`. A modest matrix multiplies fast: a 5-version × 2-leaf test matrix spawns 10 `uv run pytest` processes simultaneously, each potentially syncing a venv and running a full suite. On a laptop or small runner that oversubscribes CPU/RAM/disk. (#27)

## What this adds

An **opt-in** global cap:

- `--jobs N` (CLI flag) and `CAMAS_JOBS` (env var), CLI winning over env. Both validate as positive integers — `--jobs 0` / `--jobs abc` are argparse errors; a malformed `CAMAS_JOBS` exits 2 with a clear message.
- Implemented as a single `asyncio.Semaphore(N)` acquired around each leaf's subprocess in `run_cmd`. The tree shape is unchanged — still logically parallel, just throttled at the subprocess boundary. Default stays **unbounded** (`contextlib.nullcontext`, a no-op).
- The semaphore is acquired *before* the leaf starts, so a queued leaf stays `Waiting` in the live view and its measured `elapsed` excludes the queue wait.

## On the framing (per the issue thread)

This is a **machine-specific throttle, not project config** — it never touches what `#21` would own, and it can only *reduce* concurrency, never widen it past the tree's own fan-out. The `--help` text says so plainly so nobody mistakes `--jobs` for a speedup:

> A throttle, not a speedup — the tree never runs wider than its own fan-out, so --jobs can only slow a run down; reach for it only when a wide matrix oversubscribes the machine (CPU/RAM/disk)

It's intentionally not promoted in the README for the same reason.

## Tests

- `test_jobs_cap_serializes_parallel` — `jobs=1` serializes three parallel sleeps (~0.9s vs ~0.3s unbounded).
- `test_jobs_cap_preserves_results` — cap doesn't change returncode/result count.
- parser: `--jobs` parses, defaults `None`, rejects `0`/`-2`/`abc`.
- `resolve_jobs`: CLI wins, `CAMAS_JOBS` fallback, unset → `None`, bad/non-positive env raises.
- dispatch: end-to-end `--jobs 1` run, and bad `CAMAS_JOBS` exits 2.

Full `pytest --doctest-modules`: 634 passed. ruff/mypy/pyright/ty clean.

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)