### PR TITLE
feat(api): support standalone PEP 723 tasks.py via run_cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,37 @@ The top-level `camas` namespace is the unversioned alias for the latest generati
 
 To pin a minimum camas *feature* level, use your dependency declaration (`camas>=0.x` in `pyproject.toml`, or PEP 723 inline metadata) — the import path covers API shape; the package pin covers feature availability.
 
+## Standalone `tasks.py` (PEP 723)
+
+For a non-Python project that wants a single-file task runner — no `pyproject.toml`, no venv to manage — give `tasks.py` a [PEP 723](https://peps.python.org/pep-0723/) header and a `run_cli(globals())` entry point, then run it with any PEP 723-aware tool:
+
+```python
+# /// script
+# requires-python = ">=3.11"
+# dependencies = ["camas>=0.1.8"]
+# ///
+"""Build tasks for my project."""
+
+from camas import Parallel, Task, run_cli
+
+lint = Task("ruff check .")
+test = Task("pytest")
+check = Parallel(lint, test)
+
+if __name__ == "__main__":
+    run_cli(globals())
+```
+
+```bash
+uv run tasks.py check     # uv reads the header, builds an ephemeral env, runs
+uv run tasks.py --list    # every camas flag still works
+pipx run tasks.py test
+```
+
+`run_cli(globals())` introspects the module for `Task` / `Sequential` / `Parallel` and `Effect` bindings — exactly what camas does when it auto-discovers a `tasks.py` — so the standalone file behaves identically to a discovered one: `camas <task> --help`, `--dry-run`, matrix overrides, and `--check` all work and cite the file. `run_cli` is part of the stable surface (`from camas import run_cli`, or `from camas.v0 import run_cli` to pin the generation); it's imported lazily, so a plain `from camas import Task` doesn't pull it in.
+
+The header owns version pinning (`dependencies = ["camas>=0.1.8"]`) and the interpreter floor (`requires-python`); it's inert to `camas --check` and to auto-discovery, which read the module the same way with or without it.
+
 ## Reference
 
 - **[examples/](https://github.com/JPHutchins/camas/tree/main/tests/fixtures)** — full project layouts under test coverage. The canonical reference for how to structure `tasks.py`, use `[tool.camas.tasks]` in `pyproject.toml`, drive a matrix from `.python-version`, or scope a 2-axis matrix from the CLI.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -233,7 +233,7 @@ exclude_lines = [
 "case _:",
 "pragma: no cover",
 "if __name__ == .__main__.:",
-"if TYPE_CHECKING",
+"if (typing\\.)?TYPE_CHECKING",
 ':\s*\.\.\.\s*$',
 '^\s*\.\.\.\s*$',
 "raise AssertionError",

--- a/src/camas/__init__.py
+++ b/src/camas/__init__.py
@@ -293,7 +293,27 @@ Effect protocol: subclass ``Effect`` (see ``examples/effect-plugin/``). Per-task
 help: ``camas <task> --help``.
 """
 
+import typing
+
 from .v0 import Effect as Effect
 from .v0 import Parallel as Parallel
 from .v0 import Sequential as Sequential
 from .v0 import Task as Task
+
+if typing.TYPE_CHECKING:
+	from .main.dispatch import run_cli as run_cli
+
+
+def __getattr__(name: str) -> object:
+	"""Lazily expose ``run_cli`` — the standalone ``run_cli(globals())`` entry point
+	— without importing the engine at package load, so ``from camas import Task``
+	stays light and the type layer keeps not depending on ``camas.main``.
+
+	Raises:
+		AttributeError: for any name other than ``run_cli``.
+	"""
+	if name == "run_cli":
+		from .main.dispatch import run_cli
+
+		return run_cli
+	raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/camas/__init__.py
+++ b/src/camas/__init__.py
@@ -304,10 +304,15 @@ if typing.TYPE_CHECKING:
 	from .main.dispatch import run_cli as run_cli
 
 
-def __getattr__(name: str) -> object:
+def __getattr__(name: str) -> typing.Any:
 	"""Lazily expose ``run_cli`` — the standalone ``run_cli(globals())`` entry point
 	— without importing the engine at package load, so ``from camas import Task``
 	stays light and the type layer keeps not depending on ``camas.main``.
+
+	Returns ``Any`` (the PEP 562 convention): ``run_cli`` is typed precisely via the
+	``TYPE_CHECKING`` import above, while typing the fallback as ``object`` would
+	mistype real module attributes like ``__file__`` for checkers that route them
+	through ``__getattr__``.
 
 	Raises:
 		AttributeError: for any name other than ``run_cli``.

--- a/src/camas/main/dispatch.py
+++ b/src/camas/main/dispatch.py
@@ -61,6 +61,14 @@ def run_cli(scope: Mapping[str, object]) -> None:
 	"""Collect Task/Sequential/Parallel and Effect bindings from ``scope`` (skipping
 	``_``-prefixed names) and dispatch CLI args, citing ``scope['__file__']`` as the
 	:class:`LoadOk` ``source`` for per-task help and ``--check``.
+
+	The standalone entry point for a PEP 723 ``tasks.py`` run via ``python tasks.py``
+	or ``uv run --script tasks.py`` — hand it the module globals::
+
+	    if __name__ == "__main__":
+	        from camas import run_cli
+
+	        run_cli(globals())
 	"""
 	source_obj = scope.get("__file__")
 	source = Path(source_obj) if isinstance(source_obj, (str, Path)) else None

--- a/src/camas/v0/__init__.py
+++ b/src/camas/v0/__init__.py
@@ -2,7 +2,26 @@
 # SPDX-FileCopyrightText: 2026 JP Hutchins
 """The v0 generation of the public API — import from ``camas.v0`` and its submodules to pin it."""
 
+import typing
+
 from .effect import Effect as Effect
 from .task import Parallel as Parallel
 from .task import Sequential as Sequential
 from .task import Task as Task
+
+if typing.TYPE_CHECKING:
+	from ..main.dispatch import run_cli as run_cli
+
+
+def __getattr__(name: str) -> object:
+	"""Lazily expose ``run_cli`` without importing ``camas.main`` / ``camas.core`` at
+	import time, keeping the version namespace free of the engine it is consumed by.
+
+	Raises:
+		AttributeError: for any name other than ``run_cli``.
+	"""
+	if name == "run_cli":
+		from ..main.dispatch import run_cli
+
+		return run_cli
+	raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/camas/v0/__init__.py
+++ b/src/camas/v0/__init__.py
@@ -13,9 +13,13 @@ if typing.TYPE_CHECKING:
 	from ..main.dispatch import run_cli as run_cli
 
 
-def __getattr__(name: str) -> object:
+def __getattr__(name: str) -> typing.Any:
 	"""Lazily expose ``run_cli`` without importing ``camas.main`` / ``camas.core`` at
 	import time, keeping the version namespace free of the engine it is consumed by.
+
+	Returns ``Any`` (the PEP 562 convention): ``run_cli`` is typed precisely via the
+	``TYPE_CHECKING`` import above, while ``object`` would mistype real module
+	attributes (e.g. ``__file__``) for checkers that route them through ``__getattr__``.
 
 	Raises:
 		AttributeError: for any name other than ``run_cli``.

--- a/tests/fixtures/pep723/tasks.py
+++ b/tests/fixtures/pep723/tasks.py
@@ -1,0 +1,17 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = ["camas"]
+# ///
+"""Standalone PEP 723 tasks.py fixture.
+
+The inline-metadata header sits above the imports and the ``__main__`` block wraps
+the bindings; camas's loader must read this module identically to a header-less
+``tasks.py``, and ``run_cli(globals())`` must dispatch when run as a script.
+"""
+
+from camas import Task, run_cli
+
+hello = Task(("python", "-c", "print('hello from pep723')"))
+
+if __name__ == "__main__":
+	run_cli(globals())

--- a/tests/test_pep723_fixture.py
+++ b/tests/test_pep723_fixture.py
@@ -1,0 +1,41 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2026 JP Hutchins
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+from camas import Task
+from camas.main.tasks import load_tasks_from_py
+
+FIXTURE = Path(__file__).parent / "fixtures" / "pep723" / "tasks.py"
+
+
+def test_pep723_header_is_inert_to_loader() -> None:
+	"""The PEP 723 header (and the ``__main__`` block) leave the loader's view of
+	the module unchanged — it reads identically to a header-less ``tasks.py``."""
+	tasks, effects = load_tasks_from_py(FIXTURE)
+	assert effects == {}
+	assert tasks["hello"] == Task(("python", "-c", "print('hello from pep723')"), name="hello")
+
+
+def test_pep723_runs_standalone() -> None:
+	"""``python tasks.py hello`` dispatches through the ``run_cli(globals())`` entry
+	point using the camas in the current environment. (PEP 723 dependency
+	resolution is uv's concern, not camas's, so it is not exercised here.)"""
+	result = subprocess.run(
+		[
+			sys.executable,
+			str(FIXTURE),
+			"hello",
+			"--effects",
+			"(Summary(SummaryOptions(show_passing=True)),)",
+		],
+		capture_output=True,
+		text=True,
+		check=False,
+	)
+	assert result.returncode == 0, result.stderr
+	assert "hello from pep723" in result.stdout

--- a/tests/test_v0.py
+++ b/tests/test_v0.py
@@ -8,6 +8,8 @@ import sys
 from types import ModuleType
 from typing import Final
 
+import pytest
+
 import camas
 import camas.v0
 from camas.v0.completion import Completion, Finished, Skipped
@@ -65,6 +67,24 @@ def test_public_types_are_defined_in_the_version_package() -> None:
 	for obj in PUBLIC_API:
 		if isinstance(obj, type):
 			assert obj.__module__.startswith("camas.v0."), obj
+
+
+def test_run_cli_lazy_export_is_engine_function() -> None:
+	"""``run_cli`` is reachable from both namespaces and is the engine's function —
+	a lazy ``__getattr__`` export, so it stays out of ``vars()`` and off the
+	eager-import path that :func:`test_importing_v0_does_not_load_the_engine` pins."""
+	from camas.main.dispatch import run_cli as canonical
+
+	assert camas.run_cli is canonical
+	assert camas.v0.run_cli is canonical
+	assert "run_cli" not in public_names(camas)
+
+
+@pytest.mark.parametrize("module", [camas, camas.v0])
+def test_unknown_attribute_raises(module: object) -> None:
+	missing = "does_not_exist"
+	with pytest.raises(AttributeError):
+		getattr(module, missing)
 
 
 def test_importing_v0_does_not_load_the_engine() -> None:


### PR DESCRIPTION
## What

Lets a `tasks.py` run standalone under PEP 723-aware tooling (`uv run tasks.py`, `pipx run`) by carrying an inline-metadata header and an `if __name__ == "__main__": run_cli(globals())` entry point — a single-file task runner for non-Python projects, with version pinning living in the header's `dependencies`. (#32)

```python
# /// script
# requires-python = ">=3.11"
# dependencies = ["camas>=0.1.8"]
# ///
from camas import Parallel, Task, run_cli

check = Parallel(Task("ruff check ."), Task("pytest"))

if __name__ == "__main__":
    run_cli(globals())
```

## How

`run_cli` already did the right thing (introspects the scope for `Task`/`Sequential`/`Parallel`/`Effect` bindings, cites `scope['__file__']` for per-task `--help` / `--check`) — it just wasn't on the stable surface. This re-exports it from both `camas` and `camas.v0`.

**Re-export is lazy, via module `__getattr__` (PEP 562)** — chosen so:
- `from camas import run_cli` and `from camas.v0 import run_cli` both resolve (precise type via a `TYPE_CHECKING` import; the runtime `__getattr__` does the lazy import on access).
- `from camas import Task` stays light — the engine loads only when `run_cli` is actually accessed.
- The one-directional layering holds: `test_importing_v0_does_not_load_the_engine` stays green (importing `camas.v0` still doesn't pull in `camas.main`/`camas.core`). An eager re-export would have broken it.
- The `__init__` files aren't mypyc-compiled (`setup.py` only compiles `camas/main` + `camas/effect`), so PEP 562 is safe there.

The `__init__` files `import typing` (module form) rather than `from typing import TYPE_CHECKING`, so `TYPE_CHECKING` doesn't leak onto the public surface that `test_top_level_and_v0_expose_the_same_headline` guards. The coverage `exclude_lines` pattern is generalized from `if TYPE_CHECKING` to `if (typing\.)?TYPE_CHECKING` to cover that form.

## Tests / docs

- `tests/fixtures/pep723/tasks.py` + `test_pep723_header_is_inert_to_loader` (the header leaves the loader's view unchanged) and `test_pep723_runs_standalone` (`python tasks.py hello` dispatches through `run_cli(globals())`). PEP 723 *dependency resolution* is uv's concern, so it isn't exercised — the standalone **entry-point contract** is.
- `test_run_cli_lazy_export_is_engine_function` + `test_unknown_attribute_raises` cover both `__getattr__` branches and assert `run_cli` stays out of `vars()`.
- README: a "Standalone `tasks.py` (PEP 723)" section with the full shape.

100% coverage, 623 passed. ruff/mypy/pyright/ty clean.

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)