### PR TITLE
refactor(demo): single source for typed and executed command

### DIFF
--- a/.github/scripts/demo-payload.sh
+++ b/.github/scripts/demo-payload.sh
@@ -6,13 +6,16 @@
 set -euo pipefail
 
 PROMPT='\033[1;32m❯\033[0m '
-CMD='camas all'
+CMD=(camas all)
 TYPE_DELAY="${TYPE_DELAY:-0.08}"
 
+# Type then run the same argv, so the keystrokes shown can never drift from
+# what's executed.
+typed="${CMD[*]}"
 printf "%b" "$PROMPT"
 sleep 0.4
-for ((i = 0; i < ${#CMD}; i++)); do
-	printf "%s" "${CMD:$i:1}"
+for ((i = 0; i < ${#typed}; i++)); do
+	printf "%s" "${typed:$i:1}"
 	sleep "$TYPE_DELAY"
 done
 sleep 0.4
@@ -24,4 +27,4 @@ sleep 0.2
 # default effect, which renders collapsed workflow groups instead of the
 # animation — so scrub it for this one process to get the local experience a user
 # typing `camas all` would actually see.
-exec env -u GITHUB_ACTIONS camas all
+exec env -u GITHUB_ACTIONS "${CMD[@]}"


### PR DESCRIPTION
Follow-up to #36 (already merged), addressing the review comment on `.github/scripts/demo-payload.sh`: the keystrokes were typed from `CMD` but the executed command was hard-coded (`exec ... camas all`), so the two could drift if the demo command ever changed.

Make `CMD` a bash array (`CMD=(camas all)`): the keystrokes are typed from `"${CMD[*]}"` and the command is run as `exec env -u GITHUB_ACTIONS "${CMD[@]}"`, so the displayed and executed argv share one source.

(This commit was made on the #36 branch just after it merged, so it missed the merge — re-landing it here.)

- `shellcheck` clean
- `shfmt -d` no diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)