### PR TITLE
refactor(demo): single source for typed and executed command

### DIFF
--- a/.github/scripts/demo-payload.sh
+++ b/.github/scripts/demo-payload.sh
@@ -6,13 +6,16 @@
 set -euo pipefail
 
 PROMPT='\033[1;32m❯\033[0m '
-CMD='camas all'
+CMD=(camas all)
 TYPE_DELAY="${TYPE_DELAY:-0.08}"
 
+# Type then run the same argv, so the keystrokes shown can never drift from
+# what's executed.
+typed="${CMD[*]}"
 printf "%b" "$PROMPT"
 sleep 0.4
-for ((i = 0; i < ${#CMD}; i++)); do
-	printf "%s" "${CMD:$i:1}"
+for ((i = 0; i < ${#typed}; i++)); do
+	printf "%s" "${typed:$i:1}"
 	sleep "$TYPE_DELAY"
 done
 sleep 0.4
@@ -24,4 +27,4 @@ sleep 0.2
 # default effect, which renders collapsed workflow groups instead of the
 # animation — so scrub it for this one process to get the local experience a user
 # typing `camas all` would actually see.
-exec env -u GITHUB_ACTIONS camas all
+exec env -u GITHUB_ACTIONS "${CMD[@]}"


### PR DESCRIPTION
Address review: make CMD a bash array so the keystrokes typed in the cast and the argv exec'd can't drift apart (previously CMD was typed but 'camas all' was hard-coded in the exec).