### PR TITLE
feat: Config for default task + GitHub task (#21)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -60,7 +60,8 @@ jobs:
 
       - uses: astral-sh/setup-uv@v6
 
-      - run: uv run camas coverage --effects='(Status(StatusOptions(output_mode="all")),)'
+      # Bare `camas` runs the github_task declared by Config in tasks.py.
+      - run: uv run camas --effects='(Status(StatusOptions(output_mode="all")),)'
 
       - uses: codecov/codecov-action@v5
         if: always()

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,7 +47,7 @@ jobs:
 
       - uses: astral-sh/setup-uv@v6
 
-      - run: uv run camas check
+      - run: uv run camas
         env:
           UV_PYTHON: ${{ matrix.python }}
 
@@ -60,8 +60,7 @@ jobs:
 
       - uses: astral-sh/setup-uv@v6
 
-      # Bare `camas` runs the github_task declared by Config in tasks.py.
-      - run: uv run camas --effects='(Status(StatusOptions(output_mode="all")),)'
+      - run: uv run camas coverage --effects='(Status(StatusOptions(output_mode="all")),)'
 
       - uses: codecov/codecov-action@v5
         if: always()

--- a/README.md
+++ b/README.md
@@ -133,6 +133,33 @@ The downside is that fork PRs get a read-only `GITHUB_TOKEN` from GitHub and can
 
 **When not to bother.** OSS gets free runners — just GHA-matrix them in parallel for faster wall-clock time. The cost is small: you give up either SSOT (matrix definition moves into YAML) or per-leaf-UI granularity (one PR check entry per runner instead of per leaf) — pick one. What *is* a deal-breaker for OSS is fork PRs: external-contributor PRs return 403 from the Checks API, so per-leaf entries silently don't appear. The `github-checks-demo` job is marked `continue-on-error` so it doesn't block CI when that happens, but `GitHubChecks` isn't a workable OSS solution.
 
+## Default task
+
+Bind a `Config` in `tasks.py` and bare `camas` (no arguments) runs its `default_task`:
+
+```python
+from camas import Config, Sequential, Task
+
+lint = Task("ruff check .")
+test = Task("pytest")
+ci = Sequential(lint, test, name="ci")
+
+camas_config = Config(default_task=ci)
+```
+
+Now `camas` runs `ci` and `camas --dry-run` previews it. With no `Config` (or no `default_task`), bare `camas` prints the full help — task listing, effects, hints — and exits non-zero.
+
+`github_task` is the CI counterpart, falling back to `default_task` when unset; it runs under `GITHUB_ACTIONS=true`. Paired with the [automatic `Status` effect](#ci-integration), one bare `camas` does the right thing in both places:
+
+```python
+camas_config = Config(
+  default_task=ci,                            # bare `camas` locally
+  github_task=Sequential(ci, "pytest --cov"), # bare `camas` under GitHub Actions
+)
+```
+
+`Config` is discovered by type, so the binding can be named anything — `camas_config` is convention. Defining two is an error.
+
 ## Effects plugins
 
 Define an `Effect` in your `tasks.py` and it's discovered automatically — usable by name from `--effects` and listed under `camas --effects`. See [examples/effect-plugin/](https://github.com/JPHutchins/camas/tree/main/tests/fixtures/effect-plugin) for a typed `Tail` effect that streams per-task output as it arrives.
@@ -141,7 +168,7 @@ Define an `Effect` in your `tasks.py` and it's discovered automatically — usab
 
 The public API is published through **versioned namespaces** — [`camas.v0`](https://github.com/JPHutchins/camas/tree/main/src/camas/v0) today, `camas.v1` and beyond later. Import from a generation to pin the API shape: a name a generation exports is never removed or changed within that generation. The scheme tracks semver — `v0` pairs with camas 0.x and is as loose as semver says 0.x is (the surface prefers to grow; breaking changes stay possible until 1.0, made deliberately and noted in releases). At 1.0 a generation freezes: a breaking change forces the next `camas.vN`, and published generations keep shipping, so a `tasks.py` or effect plugin pinned to one keeps working across upgrades.
 
-The top-level `camas` namespace is the unversioned alias for the latest generation: `from camas import Task, Sequential, Parallel, Effect` re-exports that generation's four headline definers and is kept **1:1** with its package surface. The rest of the public API for a generation — `TaskNode`, the `TaskEvent` stream, `LeafState`, `Completion` — lives in that generation's submodules, e.g. `from camas.v0.task_event import TaskEvent`. Everything under `camas.core` / `camas.main` is internal — it consumes whatever generations are installed and carries no stability promise.
+The top-level `camas` namespace is the unversioned alias for the latest generation: `from camas import Task, Sequential, Parallel, Effect, Config` re-exports that generation's five headline definers and is kept **1:1** with its package surface. The rest of the public API for a generation — `TaskNode`, the `TaskEvent` stream, `LeafState`, `Completion` — lives in that generation's submodules, e.g. `from camas.v0.task_event import TaskEvent`. Everything under `camas.core` / `camas.main` is internal — it consumes whatever generations are installed and carries no stability promise.
 
 To pin a minimum camas *feature* level, use your dependency declaration (`camas>=0.x` in `pyproject.toml`, or PEP 723 inline metadata) — the import path covers API shape; the package pin covers feature availability.
 

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ The downside is that fork PRs get a read-only `GITHUB_TOKEN` from GitHub and can
 
 **When not to bother.** OSS gets free runners — just GHA-matrix them in parallel for faster wall-clock time. The cost is small: you give up either SSOT (matrix definition moves into YAML) or per-leaf-UI granularity (one PR check entry per runner instead of per leaf) — pick one. What *is* a deal-breaker for OSS is fork PRs: external-contributor PRs return 403 from the Checks API, so per-leaf entries silently don't appear. The `github-checks-demo` job is marked `continue-on-error` so it doesn't block CI when that happens, but `GitHubChecks` isn't a workable OSS solution.
 
-## Default task
+## Config
 
 Bind a `Config` in `tasks.py` and bare `camas` (no arguments) runs its `default_task`:
 
@@ -144,21 +144,21 @@ lint = Task("ruff check .")
 test = Task("pytest")
 ci = Sequential(lint, test, name="ci")
 
-camas_config = Config(default_task=ci)
+_ = Config(default_task=ci)
 ```
 
-Now `camas` runs `ci` and `camas --dry-run` previews it. With no `Config` (or no `default_task`), bare `camas` prints the full help — task listing, effects, hints — and exits non-zero.
+Now `camas` runs `ci`, `camas --dry-run` previews it, and the default's matrix axes stay overridable (`camas --PY 3.13`). With no `Config` (or no `default_task`), bare `camas` prints the full help — task listing, effects, hints — and exits non-zero.
 
 `github_task` is the CI counterpart, falling back to `default_task` when unset; it runs under `GITHUB_ACTIONS=true`. Paired with the [automatic `Status` effect](#ci-integration), one bare `camas` does the right thing in both places:
 
 ```python
-camas_config = Config(
+_ = Config(
   default_task=ci,                            # bare `camas` locally
   github_task=Sequential(ci, "pytest --cov"), # bare `camas` under GitHub Actions
 )
 ```
 
-`Config` is discovered by type, so the binding can be named anything — `camas_config` is convention. Defining two is an error.
+`Config` is discovered by type, so the binding's name never matters — `_` by convention. Defining two is an error.
 
 ## Effects plugins
 
@@ -207,7 +207,7 @@ The header owns version pinning (`dependencies = ["camas>=0.1.8"]`) and the inte
 
 - **[examples/](https://github.com/JPHutchins/camas/tree/main/tests/fixtures)** — full project layouts under test coverage. The canonical reference for how to structure `tasks.py`, use `[tool.camas.tasks]` in `pyproject.toml`, drive a matrix from `.python-version`, or scope a 2-axis matrix from the CLI.
 - **[src/camas/](https://github.com/JPHutchins/camas/tree/main/src/camas)** — typed Python with thorough docstrings. `camas --help` and `camas <task> --help` link back here.
-- **`camas`** with no args lists tasks; `camas <task> --help` shows the expanded tree, matrix axes, and override flags.
+- **`camas`** with no args runs the `Config` default task (or prints the full help when none is defined); `camas <task> --help` shows the expanded tree, matrix axes, and override flags.
 
 ## Walkthrough
 
@@ -219,7 +219,7 @@ The animated tree at the top is generated from this `tasks.py`:
 ```python
 from pathlib import Path
 
-from camas import Parallel, Sequential, Task
+from camas import Config, Parallel, Sequential, Task
 
 src_tauri = Path("src-tauri")
 python_sdk = Path("python-sdk")
@@ -267,6 +267,8 @@ build = Parallel(
     matrix={"FLAG": ("-- --debug", "")},
     help="Debug and release builds (FLAG='-- --debug' debug, FLAG='' release)",
 )
+
+_ = Config(default_task=all)
 ```
 
 </details>

--- a/src/camas/__init__.py
+++ b/src/camas/__init__.py
@@ -22,7 +22,11 @@ rarely needed (the cmd or tree usually self-documents; this codebase
 uses ``help=`` only in a handful of places), but available for
 cryptic commands.
 
-These four are the unversioned alias for the latest API generation; to
+``Config`` declares a project default: bind
+``camas_config = Config(default_task=...)`` and bare ``camas`` runs it
+(``github_task`` overrides under GitHub Actions).
+
+These five are the unversioned alias for the latest API generation; to
 pin a generation, import from its namespace (``camas.v0``). See the
 README's Versioning section.
 
@@ -295,6 +299,7 @@ help: ``camas <task> --help``.
 
 import typing
 
+from .v0 import Config as Config
 from .v0 import Effect as Effect
 from .v0 import Parallel as Parallel
 from .v0 import Sequential as Sequential

--- a/src/camas/__init__.py
+++ b/src/camas/__init__.py
@@ -22,9 +22,9 @@ rarely needed (the cmd or tree usually self-documents; this codebase
 uses ``help=`` only in a handful of places), but available for
 cryptic commands.
 
-``Config`` declares a project default: bind
-``camas_config = Config(default_task=...)`` and bare ``camas`` runs it
-(``github_task`` overrides under GitHub Actions).
+``Config`` is project configuration, discovered by type: bind
+``_ = Config(default_task=...)`` and bare ``camas`` runs that task
+(``github_task`` takes over under GitHub Actions).
 
 These five are the unversioned alias for the latest API generation; to
 pin a generation, import from its namespace (``camas.v0``). See the

--- a/src/camas/main/dispatch.py
+++ b/src/camas/main/dispatch.py
@@ -107,8 +107,8 @@ def dispatch(state: TasksState, argv: list[str] | None = None) -> None:
 
 	Dispatch is structured around the state sum type:
 
-	* :class:`LoadOk` — task-running path. ``camas`` with no expression prints
-	  the listing and exits ``2`` (a la ``just`` / ``task``).
+	* :class:`LoadOk` — task-running path. ``camas`` with no expression runs the
+	  :class:`Config`'s task for the environment, else prints help and exits ``2``.
 	* :class:`LoadErr` — meta actions (``--list`` / ``--tree`` / ``--effects``)
 	  still render; everything else delegates to :func:`exit_for_load_err`.
 	"""
@@ -142,12 +142,14 @@ def dispatch(state: TasksState, argv: list[str] | None = None) -> None:
 			args, _leftover = parser.parse_known_args(split.head)
 			in_github: Final = os.environ.get("GITHUB_ACTIONS") == "true"
 			default_node: Final = config.bare_task(github=in_github) if config is not None else None
-			# Per-axis --AXIS flags are surfaced only for a named task: bare `camas`
-			# has no positional anchor, so `--PY 3.13` would leak its value into the
-			# expression slot. The default task is still overridable via --matrix.
+			axis_node: Final = (
+				tasks[args.expression]
+				if isinstance(args.expression, str) and args.expression in tasks
+				else default_node
+			)
 			augmented_axes: dict[str, tuple[str, ...]] = {}
-			if isinstance(args.expression, str) and args.expression in tasks:
-				for name, values in matrix_axes(tasks[args.expression]).items():
+			if axis_node is not None:
+				for name, values in matrix_axes(axis_node).items():
 					if name.lower() in RESERVED_FLAGS:
 						continue
 					parser.add_argument(
@@ -248,10 +250,9 @@ def dispatch(state: TasksState, argv: list[str] | None = None) -> None:
 def _load_py(path: Path) -> TasksState:
 	"""Evaluate ``path`` and return a :class:`LoadOk` / :class:`LoadErr`."""
 	try:
-		tasks, scope_effects, config = load_tasks_from_py(path)
+		return load_tasks_from_py(path)
 	except Exception as e:
 		return LoadErr(source=path, exception=e)
-	return LoadOk(tasks=tasks, source=path, scope_effects=scope_effects, config=config)
 
 
 def resolve_tasks_source(argv: list[str]) -> tuple[TasksState, list[str]]:
@@ -278,11 +279,11 @@ def resolve_tasks_source(argv: list[str]) -> tuple[TasksState, list[str]]:
 		pyproject = candidate / "pyproject.toml"
 		if pyproject.is_file():
 			try:
-				tasks, _ = load_tasks(pyproject)
+				loaded = load_tasks(pyproject)
 			except ValueError as e:
 				print(f"error: {pyproject}: {e}", file=sys.stderr)
 				sys.exit(2)
-			if tasks:
-				return LoadOk(tasks=tasks, source=pyproject, scope_effects={}), argv
+			if loaded.tasks:
+				return loaded, argv
 
 	return EMPTY_STATE, argv

--- a/src/camas/main/dispatch.py
+++ b/src/camas/main/dispatch.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import asyncio
+import os
 import re
 import sys
 from pathlib import Path
@@ -18,14 +19,12 @@ else:  # pragma: no cover
 
 from ..core.execution import run
 from ..core.matrix import matrix_axes, override_matrix
-from ..core.render import color_on, print_tree
+from ..core.render import print_tree
 from .argv import apply_passthrough, parse_axis_values, parse_matrix_kv, split_passthrough
 from .effects import parse_effects
 from .expression import parse_expression
 from .format import (
 	format_load_error_hint,
-	format_reference,
-	format_try_hint,
 	print_available_effects,
 	print_task_help,
 	print_task_summary_listing,
@@ -33,7 +32,13 @@ from .format import (
 )
 from .parser import RESERVED_FLAGS, build_parser, resolve_jobs
 from .state import EMPTY_STATE, LoadErr, LoadOk, TasksState
-from .tasks import load_tasks, load_tasks_from_py, name_scope_bindings, name_scope_effects
+from .tasks import (
+	load_tasks,
+	load_tasks_from_py,
+	name_scope_bindings,
+	name_scope_config,
+	name_scope_effects,
+)
 
 if TYPE_CHECKING:
 	from collections.abc import Mapping
@@ -85,6 +90,7 @@ def run_cli(scope: Mapping[str, object]) -> None:
 			tasks=name_scope_bindings(scope),
 			source=source,
 			scope_effects=name_scope_effects(scope),
+			config=name_scope_config(scope),
 		)
 	)
 
@@ -132,8 +138,13 @@ def dispatch(state: TasksState, argv: list[str] | None = None) -> None:
 				sys.exit(0)
 			exit_for_load_err(err)
 
-		case LoadOk(tasks=tasks, source=source, scope_effects=scope_effects):
+		case LoadOk(tasks=tasks, source=source, scope_effects=scope_effects, config=config):
 			args, _leftover = parser.parse_known_args(split.head)
+			in_github: Final = os.environ.get("GITHUB_ACTIONS") == "true"
+			default_node: Final = config.bare_task(github=in_github) if config is not None else None
+			# Per-axis --AXIS flags are surfaced only for a named task: bare `camas`
+			# has no positional anchor, so `--PY 3.13` would leak its value into the
+			# expression slot. The default task is still overridable via --matrix.
 			augmented_axes: dict[str, tuple[str, ...]] = {}
 			if isinstance(args.expression, str) and args.expression in tasks:
 				for name, values in matrix_axes(tasks[args.expression]).items():
@@ -167,20 +178,20 @@ def dispatch(state: TasksState, argv: list[str] | None = None) -> None:
 				print_available_effects(scope_effects)
 				sys.exit(0)
 
+			resolved: TaskNode
 			if args.expression is None:
-				if tasks:
-					print(parser.format_usage().rstrip())
-					print()
-					print_task_summary_listing(tasks, source)
-					print()
-					print(format_try_hint(color_on()))
-					print()
-					print(format_reference(color_on()))
-					print()
+				if default_node is None:
+					parser.print_help()
 					sys.stdout.flush()
-					print(f"{parser.prog}: error: task or expression is required", file=sys.stderr)
+					print(
+						f"{parser.prog}: error: task or expression is required "
+						"(define a Config with default_task to set a default)",
+						file=sys.stderr,
+					)
 					sys.exit(2)
-				parser.error("task or expression is required (no tasks defined)")
+				resolved = default_node
+			else:
+				resolved = dispatch_arg(args.expression, tasks)
 
 			try:
 				effects: Final = parse_effects(args.effects, scope_effects)
@@ -205,7 +216,6 @@ def dispatch(state: TasksState, argv: list[str] | None = None) -> None:
 						sys.exit(2)
 					overrides[axis_name] = values
 
-			resolved = dispatch_arg(args.expression, tasks)
 			if overrides:
 				try:
 					resolved = override_matrix(resolved, overrides)
@@ -238,10 +248,10 @@ def dispatch(state: TasksState, argv: list[str] | None = None) -> None:
 def _load_py(path: Path) -> TasksState:
 	"""Evaluate ``path`` and return a :class:`LoadOk` / :class:`LoadErr`."""
 	try:
-		tasks, scope_effects = load_tasks_from_py(path)
+		tasks, scope_effects, config = load_tasks_from_py(path)
 	except Exception as e:
 		return LoadErr(source=path, exception=e)
-	return LoadOk(tasks=tasks, source=path, scope_effects=scope_effects)
+	return LoadOk(tasks=tasks, source=path, scope_effects=scope_effects, config=config)
 
 
 def resolve_tasks_source(argv: list[str]) -> tuple[TasksState, list[str]]:

--- a/src/camas/main/parser.py
+++ b/src/camas/main/parser.py
@@ -165,7 +165,7 @@ def build_parser(state: TasksState = EMPTY_STATE) -> argparse.ArgumentParser:
 	parser.add_argument(
 		"--list",
 		action="store_true",
-		help="list all defined tasks and exit (also the default with no args)",
+		help="list all defined tasks and exit",
 	)
 	parser.add_argument(
 		"--tree",

--- a/src/camas/main/state.py
+++ b/src/camas/main/state.py
@@ -39,7 +39,7 @@ class LoadOk(NamedTuple):
 	"""``None`` only when no tasks file exists anywhere up the tree."""
 	scope_effects: Mapping[str, type[Effect[Any]]]
 	config: Config | None = None
-	"""The project :class:`Config` (default task, GitHub task), if one was defined."""
+	"""The project :class:`Config`, if one was defined."""
 
 
 class LoadErr(NamedTuple):

--- a/src/camas/main/state.py
+++ b/src/camas/main/state.py
@@ -39,7 +39,6 @@ class LoadOk(NamedTuple):
 	"""``None`` only when no tasks file exists anywhere up the tree."""
 	scope_effects: Mapping[str, type[Effect[Any]]]
 	config: Config | None = None
-	"""The project :class:`Config`, if one was defined."""
 
 
 class LoadErr(NamedTuple):

--- a/src/camas/main/state.py
+++ b/src/camas/main/state.py
@@ -21,6 +21,7 @@ if TYPE_CHECKING:
 	from collections.abc import Mapping
 	from pathlib import Path
 
+	from ..v0.config import Config
 	from ..v0.effect import Effect
 	from ..v0.task import TaskNode
 
@@ -37,6 +38,8 @@ class LoadOk(NamedTuple):
 	source: Path | None
 	"""``None`` only when no tasks file exists anywhere up the tree."""
 	scope_effects: Mapping[str, type[Effect[Any]]]
+	config: Config | None = None
+	"""The project :class:`Config` (default task, GitHub task), if one was defined."""
 
 
 class LoadErr(NamedTuple):

--- a/src/camas/main/tasks.py
+++ b/src/camas/main/tasks.py
@@ -17,6 +17,7 @@ else:  # pragma: no cover
 	import tomli as tomllib
 	from typing_extensions import assert_never
 
+from ..v0.config import Config
 from ..v0.effect import Effect
 from ..v0.task import Parallel, Sequential, Task, TaskNode
 from .expression import Ref, parse_task_value, resolve_refs
@@ -131,14 +132,55 @@ def name_scope_effects(scope: Mapping[str, object]) -> dict[str, type[Effect[Any
 	}
 
 
+def name_scope_config(scope: Mapping[str, object]) -> Config | None:
+	"""The project :class:`Config` discovered in a scope by type — like tasks and
+	Effects, it is found by ``isinstance`` rather than a reserved name, so any
+	binding (conventionally ``camas_config``) works.
+
+	Each task field is resolved to its promoted (named) binding by identity, so a
+	``Config(default_task=ci)`` alias of a top-level ``ci`` runs with ``ci``'s name.
+
+	Raises:
+		ValueError: when more than one ``Config`` is bound in the scope.
+	"""
+	configs: Final = [
+		(name, val)
+		for name, val in scope.items()
+		if not name.startswith("_") and isinstance(val, Config)
+	]
+	if not configs:
+		return None
+	if len(configs) > 1:
+		names = ", ".join(sorted(name for name, _ in configs))
+		raise ValueError(f"multiple Config instances defined ({names}); expected at most one")
+	config: Final = configs[0][1]
+	promoted: Final = name_scope_bindings(scope)
+	name_by_id: Final = {
+		id(val): name
+		for name, val in scope.items()
+		if not name.startswith("_") and isinstance(val, Task | Sequential | Parallel)
+	}
+
+	def promote_field(node: TaskNode | None) -> TaskNode | None:
+		if node is None:
+			return None
+		name = name_by_id.get(id(node))
+		return promoted[name] if name is not None else node
+
+	return Config(
+		default_task=promote_field(config.default_task),
+		github_task=promote_field(config.github_task),
+	)
+
+
 def load_tasks_from_py(
 	path: Path,
-) -> tuple[dict[str, TaskNode], dict[str, type[Effect[Any]]]]:
+) -> tuple[dict[str, TaskNode], dict[str, type[Effect[Any]]], Config | None]:
 	"""Execute a Python task-definition file and collect module-level bindings.
 
-	Returns ``(tasks, scope_effects)`` — the TaskNode bindings (with name
-	propagation) and any Effect classes defined in the file's module-level
-	scope.
+	Returns ``(tasks, scope_effects, config)`` — the TaskNode bindings (with name
+	propagation), any Effect classes, and the project :class:`Config` (if defined)
+	from the file's module-level scope.
 	"""
 	scope: Final = runpy.run_path(str(path))
-	return name_scope_bindings(scope), name_scope_effects(scope)
+	return name_scope_bindings(scope), name_scope_effects(scope), name_scope_config(scope)

--- a/src/camas/main/tasks.py
+++ b/src/camas/main/tasks.py
@@ -21,6 +21,7 @@ from ..v0.config import Config
 from ..v0.effect import Effect
 from ..v0.task import Parallel, Sequential, Task, TaskNode
 from .expression import Ref, parse_task_value, resolve_refs
+from .state import LoadOk
 
 if TYPE_CHECKING:
 	from collections.abc import Mapping
@@ -56,12 +57,8 @@ def assign_key_name(node: TaskNode | Ref, key: str) -> TaskNode | Ref:
 			return node
 
 
-def load_tasks(path: Path) -> tuple[dict[str, TaskNode], dict[str, type[Effect[Any]]]]:
+def load_tasks(path: Path) -> LoadOk:
 	"""Read [tool.camas.tasks] from a pyproject.toml and resolve all refs.
-
-	Returns ``(tasks, scope_effects)``; ``scope_effects`` is always empty for
-	pyproject sources (TOML can't host Python classes) — the pair shape is
-	for symmetry with :func:`load_tasks_from_py`.
 
 	Raises:
 		ValueError: when the table or a task value has the wrong type, or a
@@ -79,7 +76,11 @@ def load_tasks(path: Path) -> tuple[dict[str, TaskNode], dict[str, type[Effect[A
 			pre[name] = assign_key_name(parse_task_value(value), name)
 		except ValueError as e:
 			raise ValueError(f"task {name!r}: {e}") from e
-	return {name: resolve_refs(tree, pre, frozenset({name})) for name, tree in pre.items()}, {}
+	return LoadOk(
+		tasks={name: resolve_refs(tree, pre, frozenset({name})) for name, tree in pre.items()},
+		source=path,
+		scope_effects={},
+	)
 
 
 def name_scope_bindings(scope: Mapping[str, object]) -> dict[str, TaskNode]:
@@ -133,21 +134,13 @@ def name_scope_effects(scope: Mapping[str, object]) -> dict[str, type[Effect[Any
 
 
 def name_scope_config(scope: Mapping[str, object]) -> Config | None:
-	"""The project :class:`Config` discovered in a scope by type — like tasks and
-	Effects, it is found by ``isinstance`` rather than a reserved name, so any
-	binding (conventionally ``camas_config``) works.
-
-	Each task field is resolved to its promoted (named) binding by identity, so a
-	``Config(default_task=ci)`` alias of a top-level ``ci`` runs with ``ci``'s name.
+	"""The scope's :class:`Config`, found by ``isinstance`` under any binding name,
+	its task fields resolved to their promoted bindings.
 
 	Raises:
 		ValueError: when more than one ``Config`` is bound in the scope.
 	"""
-	configs: Final = [
-		(name, val)
-		for name, val in scope.items()
-		if not name.startswith("_") and isinstance(val, Config)
-	]
+	configs: Final = [(name, val) for name, val in scope.items() if isinstance(val, Config)]
 	if not configs:
 		return None
 	if len(configs) > 1:
@@ -173,14 +166,12 @@ def name_scope_config(scope: Mapping[str, object]) -> Config | None:
 	)
 
 
-def load_tasks_from_py(
-	path: Path,
-) -> tuple[dict[str, TaskNode], dict[str, type[Effect[Any]]], Config | None]:
-	"""Execute a Python task-definition file and collect module-level bindings.
-
-	Returns ``(tasks, scope_effects, config)`` — the TaskNode bindings (with name
-	propagation), any Effect classes, and the project :class:`Config` (if defined)
-	from the file's module-level scope.
-	"""
+def load_tasks_from_py(path: Path) -> LoadOk:
+	"""Execute a Python task-definition file and collect its module-level bindings."""
 	scope: Final = runpy.run_path(str(path))
-	return name_scope_bindings(scope), name_scope_effects(scope), name_scope_config(scope)
+	return LoadOk(
+		tasks=name_scope_bindings(scope),
+		source=path,
+		scope_effects=name_scope_effects(scope),
+		config=name_scope_config(scope),
+	)

--- a/src/camas/v0/__init__.py
+++ b/src/camas/v0/__init__.py
@@ -4,6 +4,7 @@
 
 import typing
 
+from .config import Config as Config
 from .effect import Effect as Effect
 from .task import Parallel as Parallel
 from .task import Sequential as Sequential

--- a/src/camas/v0/config.py
+++ b/src/camas/v0/config.py
@@ -1,0 +1,40 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2026 JP Hutchins
+
+"""Project-wide configuration discovered from a ``tasks.py`` scope by type."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, NamedTuple
+
+if TYPE_CHECKING:
+	from .task import TaskNode
+
+
+class Config(NamedTuple):
+	"""Project-wide camas configuration, bound at module scope in ``tasks.py``
+	(conventionally ``camas_config = Config(...)``) and discovered by type.
+
+	``default_task`` is what bare ``camas`` runs; ``github_task`` is its
+	GitHub Actions counterpart, falling back to ``default_task`` when unset.
+
+	>>> from camas.v0.task import Task
+	>>> Config().bare_task(github=False) is None
+	True
+	>>> Config(default_task=Task("pytest")).bare_task(github=True)
+	Task(cmd='pytest', name=None, env={}, cwd=None)
+	>>> ci = Config(default_task=Task("pytest"), github_task=Task("pytest --cov"))
+	>>> ci.bare_task(github=True)
+	Task(cmd='pytest --cov', name=None, env={}, cwd=None)
+	"""
+
+	default_task: TaskNode | None = None
+	github_task: TaskNode | None = None
+
+	def bare_task(self, *, github: bool) -> TaskNode | None:
+		"""The task bare ``camas`` runs: ``github_task`` under GitHub Actions
+		(falling back to ``default_task``), else ``default_task``.
+		"""
+		if github and self.github_task is not None:
+			return self.github_task
+		return self.default_task

--- a/src/camas/v0/config.py
+++ b/src/camas/v0/config.py
@@ -12,29 +12,15 @@ if TYPE_CHECKING:
 
 
 class Config(NamedTuple):
-	"""Project-wide camas configuration, bound at module scope in ``tasks.py``
-	(conventionally ``camas_config = Config(...)``) and discovered by type.
-
-	``default_task`` is what bare ``camas`` runs; ``github_task`` is its
-	GitHub Actions counterpart, falling back to ``default_task`` when unset.
-
-	>>> from camas.v0.task import Task
-	>>> Config().bare_task(github=False) is None
-	True
-	>>> Config(default_task=Task("pytest")).bare_task(github=True)
-	Task(cmd='pytest', name=None, env={}, cwd=None)
-	>>> ci = Config(default_task=Task("pytest"), github_task=Task("pytest --cov"))
-	>>> ci.bare_task(github=True)
-	Task(cmd='pytest --cov', name=None, env={}, cwd=None)
+	"""Project configuration, bound under any name (conventionally ``_``) at
+	module scope in ``tasks.py``.
 	"""
 
 	default_task: TaskNode | None = None
 	github_task: TaskNode | None = None
 
 	def bare_task(self, *, github: bool) -> TaskNode | None:
-		"""The task bare ``camas`` runs: ``github_task`` under GitHub Actions
-		(falling back to ``default_task``), else ``default_task``.
-		"""
+		"""The task a bare ``camas`` invocation runs."""
 		if github and self.github_task is not None:
 			return self.github_task
 		return self.default_task

--- a/tasks.py
+++ b/tasks.py
@@ -2,7 +2,7 @@
 
 from pathlib import Path
 
-from camas import Parallel, Sequential, Task
+from camas import Config, Parallel, Sequential, Task
 
 format = Task("uv run ruff format .")
 format_check = Task("uv run ruff format --check .")
@@ -65,3 +65,5 @@ matrix = Sequential(
 		)
 	},
 )
+
+_ = Config(default_task=check, github_task=coverage)

--- a/tasks.py
+++ b/tasks.py
@@ -66,4 +66,4 @@ matrix = Sequential(
 	},
 )
 
-_ = Config(default_task=check, github_task=coverage)
+_ = Config(default_task=all, github_task=check)

--- a/tests/fixtures/config/tasks.py
+++ b/tests/fixtures/config/tasks.py
@@ -13,4 +13,4 @@ ci_full = Parallel(
 	name="ci_full",
 )
 
-camas_config = Config(default_task=ci, github_task=ci_full)
+_ = Config(default_task=ci, github_task=ci_full)

--- a/tests/fixtures/config/tasks.py
+++ b/tests/fixtures/config/tasks.py
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2026 JP Hutchins
+
+from camas import Config, Parallel, Sequential, Task
+
+lint = Task(("python", "-c", "print('lint ran')"), name="lint")
+test = Task(("python", "-c", "print('test ran')"), name="test")
+ci = Sequential(lint, test, name="ci")
+ci_full = Parallel(
+	lint,
+	test,
+	Task(("python", "-c", "print('cov ran')"), name="cov"),
+	name="ci_full",
+)
+
+camas_config = Config(default_task=ci, github_task=ci_full)

--- a/tests/fixtures/effect-plugin/tasks.py
+++ b/tests/fixtures/effect-plugin/tasks.py
@@ -9,6 +9,7 @@ from typing import Final
 
 from tail import Tail as Tail
 
+from camas.v0.config import Config
 from camas.v0.effect import Effect
 from camas.v0.leaf_state import LeafState
 from camas.v0.task import Parallel, Sequential, Task, TaskNode
@@ -77,3 +78,5 @@ build = Parallel(
 	matrix={"STAGE": ("compile", "link")},
 	name="build",
 )
+
+_ = Config(default_task=check)

--- a/tests/fixtures/playwright-matrix-override/tasks.py
+++ b/tests/fixtures/playwright-matrix-override/tasks.py
@@ -5,7 +5,7 @@ of cross-browser end-to-end testing. The matrix override CLI lets you scope
 a run to a slice without editing tasks.py.
 """
 
-from camas import Parallel, Sequential, Task
+from camas import Config, Parallel, Sequential, Task
 
 install = Task("npx playwright install --with-deps")
 
@@ -26,3 +26,5 @@ smoke = Parallel(
 )
 
 ci = Sequential(install, e2e)
+
+_ = Config(default_task=ci)

--- a/tests/fixtures/python-version-matrix/tasks.py
+++ b/tests/fixtures/python-version-matrix/tasks.py
@@ -2,7 +2,7 @@
 
 from pathlib import Path
 
-from camas import Sequential, Task
+from camas import Config, Sequential, Task
 
 
 def read_python_versions(path: Path) -> tuple[str, ...]:
@@ -21,3 +21,5 @@ check = Sequential(
 	env={"UV_PROJECT_ENVIRONMENT": ".venv-{PY}", "UV_PYTHON": "{PY}"},
 	matrix={"PY": PYTHON_VERSIONS},
 )
+
+_ = Config(default_task=check)

--- a/tests/fixtures/tauri-app/tasks.py
+++ b/tests/fixtures/tauri-app/tasks.py
@@ -2,7 +2,7 @@
 
 from pathlib import Path
 
-from camas import Parallel, Sequential, Task
+from camas import Config, Parallel, Sequential, Task
 
 src_tauri = Path("src-tauri")
 python_sdk = Path("python-sdk")
@@ -50,3 +50,5 @@ build = Parallel(
 	matrix={"FLAG": ("-- --debug", "")},
 	help="Debug and release builds (FLAG='-- --debug' debug, FLAG='' release)",
 )
+
+_ = Config(default_task=all)

--- a/tests/main/test_dispatch.py
+++ b/tests/main/test_dispatch.py
@@ -162,12 +162,22 @@ def test_bare_default_runs_to_completion(monkeypatch: pytest.MonkeyPatch) -> Non
 def test_bare_default_task_matrix_override(
 	monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
-	"""A bare default task is overridable via the general --matrix form (the
-	per-axis --AXIS flag needs a named task to anchor the positional slot)."""
 	monkeypatch.delenv("GITHUB_ACTIONS", raising=False)
 	config = Config(default_task=Parallel(Task("echo {PY}"), matrix={"PY": ("3.12", "3.13")}))
 	with pytest.raises(SystemExit, match="0"):
 		dispatch(_state({}, config), ["--dry-run", "--matrix", "PY=3.13"])
+	out = capsys.readouterr().out
+	assert "[PY=3.13]" in out
+	assert "[PY=3.12]" not in out
+
+
+def test_bare_default_task_per_axis_flag_override(
+	monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+	monkeypatch.delenv("GITHUB_ACTIONS", raising=False)
+	config = Config(default_task=Parallel(Task("echo {PY}"), matrix={"PY": ("3.12", "3.13")}))
+	with pytest.raises(SystemExit, match="0"):
+		dispatch(_state({}, config), ["--dry-run", "--PY", "3.13"])
 	out = capsys.readouterr().out
 	assert "[PY=3.13]" in out
 	assert "[PY=3.12]" not in out

--- a/tests/main/test_dispatch.py
+++ b/tests/main/test_dispatch.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Any
 
 import pytest
 
-from camas import Parallel, Task
+from camas import Config, Parallel, Task
 from camas.main.dispatch import dispatch
 from camas.main.state import LoadOk
 
@@ -18,10 +18,10 @@ if TYPE_CHECKING:
 	from camas.v0.task import TaskNode
 
 
-def _state(tasks: Mapping[str, TaskNode]) -> LoadOk:
+def _state(tasks: Mapping[str, TaskNode], config: Config | None = None) -> LoadOk:
 	loaded: dict[str, TaskNode] = dict(tasks)
 	effects: dict[str, type[Effect[Any]]] = {}
-	return LoadOk(tasks=loaded, source=None, scope_effects=effects)
+	return LoadOk(tasks=loaded, source=None, scope_effects=effects, config=config)
 
 
 def test_print_task_help_with_axes(capsys: pytest.CaptureFixture[str]) -> None:
@@ -107,3 +107,67 @@ def test_dispatch_bad_camas_jobs_errors(
 	with pytest.raises(SystemExit, match="2"):
 		dispatch(_state({"go": Task(("python", "-c", "pass"))}), ["go", "--effects", "()"])
 	assert "CAMAS_JOBS" in capsys.readouterr().err
+
+
+def test_bare_runs_default_task_locally(
+	monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+	monkeypatch.delenv("GITHUB_ACTIONS", raising=False)
+	config = Config(default_task=Task("echo DEFAULT", name="default"))
+	with pytest.raises(SystemExit, match="0"):
+		dispatch(_state({}, config), ["--dry-run"])
+	assert "echo DEFAULT" in capsys.readouterr().out
+
+
+def test_bare_runs_github_task_under_actions(
+	monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+	monkeypatch.setenv("GITHUB_ACTIONS", "true")
+	config = Config(default_task=Task("echo DEFAULT"), github_task=Task("echo GH"))
+	with pytest.raises(SystemExit, match="0"):
+		dispatch(_state({}, config), ["--dry-run"])
+	out = capsys.readouterr().out
+	assert "echo GH" in out
+	assert "echo DEFAULT" not in out
+
+
+def test_bare_github_falls_back_to_default(
+	monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+	monkeypatch.setenv("GITHUB_ACTIONS", "true")
+	config = Config(default_task=Task("echo DEFAULT"))
+	with pytest.raises(SystemExit, match="0"):
+		dispatch(_state({}, config), ["--dry-run"])
+	assert "echo DEFAULT" in capsys.readouterr().out
+
+
+def test_bare_no_config_prints_help_and_errors(
+	monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+	monkeypatch.delenv("GITHUB_ACTIONS", raising=False)
+	with pytest.raises(SystemExit, match="2"):
+		dispatch(_state({"lint": Task("ruff check .")}), [])
+	captured = capsys.readouterr()
+	assert "task or expression is required" in captured.err
+	assert "Reference:" in captured.out
+
+
+def test_bare_default_runs_to_completion(monkeypatch: pytest.MonkeyPatch) -> None:
+	monkeypatch.delenv("GITHUB_ACTIONS", raising=False)
+	config = Config(default_task=Task(("python", "-c", "pass")))
+	with pytest.raises(SystemExit, match="0"):
+		dispatch(_state({}, config), ["--effects", "()"])
+
+
+def test_bare_default_task_matrix_override(
+	monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+	"""A bare default task is overridable via the general --matrix form (the
+	per-axis --AXIS flag needs a named task to anchor the positional slot)."""
+	monkeypatch.delenv("GITHUB_ACTIONS", raising=False)
+	config = Config(default_task=Parallel(Task("echo {PY}"), matrix={"PY": ("3.12", "3.13")}))
+	with pytest.raises(SystemExit, match="0"):
+		dispatch(_state({}, config), ["--dry-run", "--matrix", "PY=3.13"])
+	out = capsys.readouterr().out
+	assert "[PY=3.13]" in out
+	assert "[PY=3.12]" not in out

--- a/tests/main/test_tasks.py
+++ b/tests/main/test_tasks.py
@@ -208,8 +208,10 @@ test = "pytest"
 ci = 'Sequential(Ref("lint"), Ref("typecheck"), Ref("test"))'
 """
 	)
-	tasks, scope_effects = load_tasks(pyproject)
-	assert scope_effects == {}
+	loaded = load_tasks(pyproject)
+	assert loaded.scope_effects == {}
+	assert loaded.source == pyproject
+	tasks = loaded.tasks
 	assert tasks["lint"] == Task("ruff check .", name="lint")
 	assert tasks["typecheck"] == Parallel(
 		Task("mypy .", name="mypy"), Task("pyright .", name="pyright"), name="typecheck"
@@ -231,7 +233,7 @@ def test_load_tasks_threads_cwd_and_help(tmp_path: Path) -> None:
 		'build = \'Task("cargo build", cwd="src-tauri", help="Build the app")\'\n'
 		'checks = \'Parallel(Task("a"), Task("b"), cwd="work", help="Run checks")\'\n'
 	)
-	tasks, _ = load_tasks(pyproject)
+	tasks = load_tasks(pyproject).tasks
 	assert tasks["build"] == Task(
 		"cargo build", name="build", cwd="src-tauri", help="Build the app"
 	)
@@ -248,7 +250,7 @@ def test_load_tasks_matrix(tmp_path: Path) -> None:
 tests = 'Parallel(Task("pytest --python {PY}"), matrix={"PY": ("3.12","3.13")})'
 """
 	)
-	tasks, _ = load_tasks(pyproject)
+	tasks = load_tasks(pyproject).tasks
 	assert tasks["tests"] == Parallel(
 		Task("pytest --python {PY}"), matrix={"PY": ("3.12", "3.13")}, name="tests"
 	)
@@ -257,7 +259,7 @@ tests = 'Parallel(Task("pytest --python {PY}"), matrix={"PY": ("3.12","3.13")})'
 def test_load_tasks_empty(tmp_path: Path) -> None:
 	pyproject = tmp_path / "pyproject.toml"
 	pyproject.write_text('[project]\nname = "x"\nversion = "0"\n')
-	assert load_tasks(pyproject) == ({}, {})
+	assert load_tasks(pyproject).tasks == {}
 
 
 def test_load_tasks_rejects_non_table(tmp_path: Path) -> None:
@@ -496,13 +498,14 @@ def test_load_tasks_from_py_propagates_names(tmp_path: Path) -> None:
 		"typecheck = Parallel(mypy, pyright)\n"
 		"_private = Task('nope')\n"
 	)
-	tasks, scope_effects, _config = load_tasks_from_py(tasks_py)
-	assert scope_effects == {}
-	assert tasks["mypy"] == Task("mypy .", name="mypy")
-	assert tasks["typecheck"] == Parallel(
+	loaded = load_tasks_from_py(tasks_py)
+	assert loaded.scope_effects == {}
+	assert loaded.source == tasks_py
+	assert loaded.tasks["mypy"] == Task("mypy .", name="mypy")
+	assert loaded.tasks["typecheck"] == Parallel(
 		Task("mypy .", name="mypy"), Task("pyright .", name="pyright"), name="typecheck"
 	)
-	assert "_private" not in tasks
+	assert "_private" not in loaded.tasks
 
 
 def test_tasks_py_preferred_over_pyproject(
@@ -563,7 +566,7 @@ def test_load_tasks_from_py_preserves_cwd(tmp_path: Path) -> None:
 		"leaf = Task('cargo test', cwd=Path('src-tauri'))\n"
 		"group = Parallel(Task('cargo check'), cwd=Path('src-tauri'))\n"
 	)
-	tasks, _, _ = load_tasks_from_py(tasks_py)
+	tasks = load_tasks_from_py(tasks_py).tasks
 	assert tasks["leaf"].cwd == Path("src-tauri")
 	assert tasks["group"].cwd == Path("src-tauri")
 
@@ -730,14 +733,18 @@ def test_name_scope_config_none_when_absent() -> None:
 
 
 def test_name_scope_config_discovered_by_type_under_any_name() -> None:
-	"""Found by ``isinstance``, not a reserved name — ``cfg`` works as well as
-	the conventional ``camas_config``."""
+	"""Found by ``isinstance``, not a reserved name."""
 	cfg = Config(default_task=Task("pytest"))
 	assert name_scope_config({"cfg": cfg}) == cfg
 
 
+def test_name_scope_config_discovered_under_underscore_convention() -> None:
+	cfg = Config(default_task=Task("pytest"))
+	assert name_scope_config({"_": cfg}) == cfg
+
+
 def test_name_scope_config_multiple_raises() -> None:
-	scope = {"camas_config": Config(), "other": Config()}
+	scope = {"_": Config(), "other": Config()}
 	with pytest.raises(ValueError, match="multiple Config instances"):
 		name_scope_config(scope)
 
@@ -752,7 +759,7 @@ def test_name_scope_config_promotes_aliased_task_fields() -> None:
 		"mypy": mypy,
 		"pyright": pyright,
 		"ci": ci,
-		"camas_config": Config(default_task=ci),
+		"_": Config(default_task=ci),
 	}
 	resolved = name_scope_config(scope)
 	assert resolved is not None
@@ -764,10 +771,6 @@ def test_name_scope_config_promotes_aliased_task_fields() -> None:
 def test_name_scope_config_keeps_inline_task_field() -> None:
 	"""A field bound to an unaliased inline node is returned as-is."""
 	inline = Sequential(Task("a"), Task("b"))
-	resolved = name_scope_config({"camas_config": Config(default_task=inline)})
+	resolved = name_scope_config({"_": Config(default_task=inline)})
 	assert resolved is not None
 	assert resolved.default_task is inline
-
-
-def test_name_scope_config_skips_private_binding() -> None:
-	assert name_scope_config({"_camas_config": Config(default_task=Task("x"))}) is None

--- a/tests/main/test_tasks.py
+++ b/tests/main/test_tasks.py
@@ -11,7 +11,7 @@ from unittest.mock import patch
 
 import pytest
 
-from camas import Parallel, Sequential, Task
+from camas import Config, Parallel, Sequential, Task
 from camas.main import main
 from camas.main.dispatch import dispatch_arg, run_cli
 from camas.main.expression import (
@@ -25,6 +25,7 @@ from camas.main.tasks import (
 	is_str_dict,
 	load_tasks,
 	load_tasks_from_py,
+	name_scope_config,
 	name_scope_effects,
 )
 
@@ -495,7 +496,7 @@ def test_load_tasks_from_py_propagates_names(tmp_path: Path) -> None:
 		"typecheck = Parallel(mypy, pyright)\n"
 		"_private = Task('nope')\n"
 	)
-	tasks, scope_effects = load_tasks_from_py(tasks_py)
+	tasks, scope_effects, _config = load_tasks_from_py(tasks_py)
 	assert scope_effects == {}
 	assert tasks["mypy"] == Task("mypy .", name="mypy")
 	assert tasks["typecheck"] == Parallel(
@@ -562,7 +563,7 @@ def test_load_tasks_from_py_preserves_cwd(tmp_path: Path) -> None:
 		"leaf = Task('cargo test', cwd=Path('src-tauri'))\n"
 		"group = Parallel(Task('cargo check'), cwd=Path('src-tauri'))\n"
 	)
-	tasks, _ = load_tasks_from_py(tasks_py)
+	tasks, _, _ = load_tasks_from_py(tasks_py)
 	assert tasks["leaf"].cwd == Path("src-tauri")
 	assert tasks["group"].cwd == Path("src-tauri")
 
@@ -722,3 +723,51 @@ def test_name_scope_effects_skips_builtins_and_private() -> None:
 		"plain": 42,
 	}
 	assert name_scope_effects(scope) == {}
+
+
+def test_name_scope_config_none_when_absent() -> None:
+	assert name_scope_config({"lint": Task("ruff check .")}) is None
+
+
+def test_name_scope_config_discovered_by_type_under_any_name() -> None:
+	"""Found by ``isinstance``, not a reserved name — ``cfg`` works as well as
+	the conventional ``camas_config``."""
+	cfg = Config(default_task=Task("pytest"))
+	assert name_scope_config({"cfg": cfg}) == cfg
+
+
+def test_name_scope_config_multiple_raises() -> None:
+	scope = {"camas_config": Config(), "other": Config()}
+	with pytest.raises(ValueError, match="multiple Config instances"):
+		name_scope_config(scope)
+
+
+def test_name_scope_config_promotes_aliased_task_fields() -> None:
+	"""A ``Config`` field aliasing a top-level binding runs with that binding's
+	propagated name, matching :func:`name_scope_bindings`."""
+	mypy = Task("mypy .")
+	pyright = Task("pyright .")
+	ci = Parallel(mypy, pyright)
+	scope: dict[str, object] = {
+		"mypy": mypy,
+		"pyright": pyright,
+		"ci": ci,
+		"camas_config": Config(default_task=ci),
+	}
+	resolved = name_scope_config(scope)
+	assert resolved is not None
+	assert resolved.default_task == Parallel(
+		Task("mypy .", name="mypy"), Task("pyright .", name="pyright"), name="ci"
+	)
+
+
+def test_name_scope_config_keeps_inline_task_field() -> None:
+	"""A field bound to an unaliased inline node is returned as-is."""
+	inline = Sequential(Task("a"), Task("b"))
+	resolved = name_scope_config({"camas_config": Config(default_task=inline)})
+	assert resolved is not None
+	assert resolved.default_task is inline
+
+
+def test_name_scope_config_skips_private_binding() -> None:
+	assert name_scope_config({"_camas_config": Config(default_task=Task("x"))}) is None

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2026 JP Hutchins
+
+from __future__ import annotations
+
+import pytest
+
+from camas import Config, Task
+
+DEFAULT = Task("default", name="default")
+GH = Task("gh", name="gh")
+
+
+@pytest.mark.parametrize(
+	("config", "github", "expected"),
+	[
+		(Config(), False, None),
+		(Config(), True, None),
+		(Config(default_task=DEFAULT), False, DEFAULT),
+		(Config(default_task=DEFAULT), True, DEFAULT),
+		(Config(default_task=DEFAULT, github_task=GH), False, DEFAULT),
+		(Config(default_task=DEFAULT, github_task=GH), True, GH),
+		(Config(github_task=GH), False, None),
+		(Config(github_task=GH), True, GH),
+	],
+)
+def test_bare_task_resolution(config: Config, github: bool, expected: Task | None) -> None:
+	"""``github_task`` wins under GitHub Actions, falling back to ``default_task``."""
+	assert config.bare_task(github=github) is expected

--- a/tests/test_config_fixture.py
+++ b/tests/test_config_fixture.py
@@ -34,7 +34,7 @@ def _camas(*args: str, github: bool) -> subprocess.CompletedProcess[str]:
 def test_config_resolves_promoted_default_and_github_tasks() -> None:
 	"""The loader exposes the project ``Config`` with both task fields resolved to
 	their promoted (named) bindings."""
-	_tasks, _effects, config = load_tasks_from_py(FIXTURE)
+	config = load_tasks_from_py(FIXTURE).config
 	assert config is not None
 	assert config.default_task == Sequential(
 		Task(("python", "-c", "print('lint ran')"), name="lint"),

--- a/tests/test_config_fixture.py
+++ b/tests/test_config_fixture.py
@@ -1,0 +1,61 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2026 JP Hutchins
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from camas import Parallel, Sequential, Task
+from camas.main.tasks import load_tasks_from_py
+
+FIXTURE = Path(__file__).parent / "fixtures" / "config" / "tasks.py"
+SUMMARY = "--effects=(Summary(SummaryOptions(show_passing=True)),)"
+
+
+def _camas(*args: str, github: bool) -> subprocess.CompletedProcess[str]:
+	env = {**os.environ, "NO_COLOR": "1"}
+	env.pop("GITHUB_ACTIONS", None)
+	if github:
+		env["GITHUB_ACTIONS"] = "true"
+	return subprocess.run(
+		[sys.executable, "-m", "camas", *args],
+		cwd=FIXTURE.parent,
+		capture_output=True,
+		text=True,
+		encoding="utf-8",
+		env=env,
+		check=False,
+	)
+
+
+def test_config_resolves_promoted_default_and_github_tasks() -> None:
+	"""The loader exposes the project ``Config`` with both task fields resolved to
+	their promoted (named) bindings."""
+	_tasks, _effects, config = load_tasks_from_py(FIXTURE)
+	assert config is not None
+	assert config.default_task == Sequential(
+		Task(("python", "-c", "print('lint ran')"), name="lint"),
+		Task(("python", "-c", "print('test ran')"), name="test"),
+		name="ci",
+	)
+	assert isinstance(config.github_task, Parallel)
+	assert config.github_task.name == "ci_full"
+
+
+def test_bare_camas_runs_default_task() -> None:
+	"""Bare ``camas`` (no GitHub Actions) runs ``default_task`` (``ci``)."""
+	result = _camas(SUMMARY, github=False)
+	assert result.returncode == 0, result.stderr
+	assert "lint ran" in result.stdout
+	assert "test ran" in result.stdout
+	assert "cov ran" not in result.stdout
+
+
+def test_bare_camas_runs_github_task_under_actions() -> None:
+	"""Bare ``camas`` under ``GITHUB_ACTIONS=true`` runs ``github_task`` (``ci_full``)."""
+	result = _camas(SUMMARY, github=True)
+	assert result.returncode == 0, result.stderr
+	assert "cov ran" in result.stdout

--- a/tests/test_pep723_fixture.py
+++ b/tests/test_pep723_fixture.py
@@ -16,7 +16,7 @@ FIXTURE = Path(__file__).parent / "fixtures" / "pep723" / "tasks.py"
 def test_pep723_header_is_inert_to_loader() -> None:
 	"""The PEP 723 header (and the ``__main__`` block) leave the loader's view of
 	the module unchanged — it reads identically to a header-less ``tasks.py``."""
-	tasks, effects = load_tasks_from_py(FIXTURE)
+	tasks, effects, _config = load_tasks_from_py(FIXTURE)
 	assert effects == {}
 	assert tasks["hello"] == Task(("python", "-c", "print('hello from pep723')"), name="hello")
 

--- a/tests/test_pep723_fixture.py
+++ b/tests/test_pep723_fixture.py
@@ -16,9 +16,11 @@ FIXTURE = Path(__file__).parent / "fixtures" / "pep723" / "tasks.py"
 def test_pep723_header_is_inert_to_loader() -> None:
 	"""The PEP 723 header (and the ``__main__`` block) leave the loader's view of
 	the module unchanged — it reads identically to a header-less ``tasks.py``."""
-	tasks, effects, _config = load_tasks_from_py(FIXTURE)
-	assert effects == {}
-	assert tasks["hello"] == Task(("python", "-c", "print('hello from pep723')"), name="hello")
+	loaded = load_tasks_from_py(FIXTURE)
+	assert loaded.scope_effects == {}
+	assert loaded.tasks["hello"] == Task(
+		("python", "-c", "print('hello from pep723')"), name="hello"
+	)
 
 
 def test_pep723_runs_standalone() -> None:

--- a/tests/test_v0.py
+++ b/tests/test_v0.py
@@ -13,18 +13,20 @@ import pytest
 import camas
 import camas.v0
 from camas.v0.completion import Completion, Finished, Skipped
+from camas.v0.config import Config
 from camas.v0.effect import Effect
 from camas.v0.leaf_state import Completed, LeafState, Running, Waiting
 from camas.v0.task import Group, Parallel, Sequential, Task, TaskNode
 from camas.v0.task_event import CompletedEvent, OutputEvent, StartedEvent, TaskEvent
 
-HEADLINE: Final = frozenset({"Effect", "Parallel", "Sequential", "Task"})
+HEADLINE: Final = frozenset({"Config", "Effect", "Parallel", "Sequential", "Task"})
 """The unversioned definers re-exported by both ``camas`` and ``camas.v0``."""
 
 PUBLIC_API: Final = (
 	Completion,
 	Finished,
 	Skipped,
+	Config,
 	Effect,
 	Completed,
 	LeafState,


### PR DESCRIPTION
## What

Implements the `Config` slice of #21. A new public **`Config`** type (`camas.v0.config`, re-exported as a fifth headline name) is bound at module scope in `tasks.py` and **discovered by type** — like tasks and Effects — so any binding works (conventionally `camas_config = Config(...)`). Two fields to start:

- **`default_task`** — the task bare `camas` runs.
- **`github_task`** — its GitHub Actions counterpart (`GITHUB_ACTIONS=true`), falling back to `default_task` when unset. Pairs with the existing automatic `Status` effect so one bare `camas` does the right thing locally and in CI.

```python
from camas import Config, Sequential, Task

ci = Sequential(Task("ruff check ."), Task("pytest"), name="ci")
camas_config = Config(
    default_task=ci,
    github_task=Sequential(ci, "pytest --cov"),
)
```

## Why discovered by type (not a reserved `camas_config` name)

`camas` already finds tasks (`isinstance(..., Task|Sequential|Parallel)`) and Effects (`issubclass(..., Effect)`) by type. Type-discovery honors `camas_config = Config(...)` verbatim while staying name-agnostic — `cfg = Config(...)` works too, avoiding the silent footgun where a renamed binding is ignored with no error. Two `Config` instances in one scope raise a clear `ValueError`.

## Deletes the "weird no-arg help endpoint"

When no default resolves, bare `camas` now prints the real `parser.print_help()` (task listing + effects + hints + reference) and exits 2 — replacing ~13 lines of hand-rolled output in `dispatch.py` that duplicated `CamasArgumentParser.format_help()`.

## Notes / scope

- `Config` is a `NamedTuple`, so further config fields (default effects, jobs, cwd/help) are additive later — deliberately out of scope here.
- TOML config is out of scope (TOML can't host a `TaskNode`).
- Aliased task fields (`Config(default_task=ci)`) are resolved to their promoted/named binding, consistent with `name_scope_bindings`, so the running tree displays the right name.
- Per-axis `--AXIS` override flags stay named-task only (bare `camas` has no positional anchor — `--PY 3.13` would leak into the expression slot); a bare default is still overridable via the general `--matrix PY=3.13`.

## Verification (all green locally)

- `ruff format --check`, `ruff check`
- mypy, pyright, ty, zuban, pyrefly (scoped to `src tests` to dodge stale `.claude/worktrees`)
- `pytest --doctest-modules -m 'not slow' --cov` — **670 passed, 100% coverage**

New tests: `tests/test_config.py` (Config + `bare_task` matrix), `name_scope_config` cases in `tests/main/test_tasks.py`, default-task dispatch + CI-env selection in `tests/main/test_dispatch.py`, and a `tests/fixtures/config/` end-to-end fixture (`tests/test_config_fixture.py`).

Closes #21.

🤖 Generated with [Claude Code](https://claude.com/claude-code)