### PR TITLE
feat(cli): add --init to scaffold a starter tasks.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ dist/
 src/**/*.so
 src/**/*.c
 result*
+.claude/

--- a/README.md
+++ b/README.md
@@ -59,6 +59,14 @@ nix run github:JPHutchins/camas#with-check          # adds ty for `camas --check
 nix run github:JPHutchins/camas#all                 # both extras
 ```
 
+Then scaffold a starter `tasks.py` in your project root:
+
+```
+camas --init
+```
+
+The starter demonstrates leaf tasks, `Sequential`/`Parallel` composition, a matrix, a [`Config`](#config) default task, and the optional [PEP 723 standalone block](#standalone-taskspy-pep-723) — cross-platform placeholder commands ready to be swapped for your real ones.
+
 ## Why camas?
 
 camas is **not a build system**. camas is for the specific job of running structured trees of shell commands.

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,9 @@ if use_mypyc:
 	# in the isolated build env, so mypy/mypyc compilation can't resolve it.
 	# check.py and state.py stay interpreted: mypyc's NamedTuple codegen rejects
 	# the built-in ``Exception`` as a field type (KeyError: 'Exception' at import).
-	_main_excluded = {"check.py", "state.py"}
+	# starter.py stays interpreted: it is the --init template, shipped as plain
+	# source and read back as text by init.py.
+	_main_excluded = {"check.py", "state.py", "starter.py"}
 	ext_modules = mypycify(
 		[
 			*(str(p) for p in Path("src/camas/main").glob("*.py") if p.name not in _main_excluded),

--- a/src/camas/main/dispatch.py
+++ b/src/camas/main/dispatch.py
@@ -30,6 +30,7 @@ from .format import (
 	print_task_summary_listing,
 	print_task_trees,
 )
+from .init import write_starter_tasks_py
 from .parser import RESERVED_FLAGS, build_parser, resolve_jobs
 from .state import EMPTY_STATE, LoadErr, LoadOk, TasksState
 from .tasks import (
@@ -109,8 +110,8 @@ def dispatch(state: TasksState, argv: list[str] | None = None) -> None:
 
 	* :class:`LoadOk` — task-running path. ``camas`` with no expression runs the
 	  :class:`Config`'s task for the environment, else prints help and exits ``2``.
-	* :class:`LoadErr` — meta actions (``--list`` / ``--tree`` / ``--effects``)
-	  still render; everything else delegates to :func:`exit_for_load_err`.
+	* :class:`LoadErr` — meta actions (``--list`` / ``--tree`` / ``--effects`` /
+	  ``--init``) still work; everything else delegates to :func:`exit_for_load_err`.
 	"""
 	split: Final = split_passthrough(sys.argv[1:] if argv is None else argv)
 	tasks: Mapping[str, TaskNode] = state.tasks if isinstance(state, LoadOk) else {}
@@ -130,6 +131,8 @@ def dispatch(state: TasksState, argv: list[str] | None = None) -> None:
 			# No per-task matrix axes to augment; parse strictly so typos in
 			# flags surface instead of being silently consumed.
 			args = parser.parse_args(split.head)
+			if args.init:
+				sys.exit(write_starter_tasks_py(Path.cwd()))
 			if args.list or args.tree:
 				print(format_load_error_hint(err.source, err.exception))
 				sys.exit(0)
@@ -162,6 +165,9 @@ def dispatch(state: TasksState, argv: list[str] | None = None) -> None:
 					)
 					augmented_axes[name] = values
 			args = parser.parse_args(split.head)
+
+			if args.init:
+				sys.exit(write_starter_tasks_py(Path.cwd()))
 
 			if args.list:
 				print_task_summary_listing(tasks, source)

--- a/src/camas/main/dispatch.py
+++ b/src/camas/main/dispatch.py
@@ -10,7 +10,7 @@ import os
 import re
 import sys
 from pathlib import Path
-from typing import TYPE_CHECKING, Final
+from typing import TYPE_CHECKING, Final, cast
 
 if sys.version_info >= (3, 11):
 	from typing import assert_never
@@ -42,6 +42,7 @@ from .tasks import (
 )
 
 if TYPE_CHECKING:
+	import io
 	from collections.abc import Mapping
 
 	from ..v0.task import TaskNode
@@ -71,6 +72,15 @@ def dispatch_arg(arg: str, tasks: Mapping[str, TaskNode]) -> TaskNode:
 	return parse_expression(arg, tasks=tasks)
 
 
+def reconfigure_stdio_utf8() -> None:
+	"""UTF-8 with ``errors="replace"`` on stdout/stderr so Windows consoles and
+	pipes (ANSI code page by default before Python 3.15) can carry the
+	box-drawing tree output and ``×`` matrix annotations.
+	"""
+	for stream in (sys.stdout, sys.stderr):
+		cast("io.TextIOWrapper", stream).reconfigure(encoding="utf-8", errors="replace")
+
+
 def run_cli(scope: Mapping[str, object]) -> None:
 	"""Collect Task/Sequential/Parallel and Effect bindings from ``scope`` (skipping
 	``_``-prefixed names) and dispatch CLI args, citing ``scope['__file__']`` as the
@@ -84,6 +94,7 @@ def run_cli(scope: Mapping[str, object]) -> None:
 
 	        run_cli(globals())
 	"""
+	reconfigure_stdio_utf8()
 	source_obj = scope.get("__file__")
 	source = Path(source_obj) if isinstance(source_obj, (str, Path)) else None
 	dispatch(

--- a/src/camas/main/entrypoint.py
+++ b/src/camas/main/entrypoint.py
@@ -6,22 +6,13 @@
 from __future__ import annotations
 
 import sys
-from typing import TYPE_CHECKING, cast
 
-from .dispatch import dispatch, resolve_tasks_source
-
-if TYPE_CHECKING:
-	import io
+from .dispatch import dispatch, reconfigure_stdio_utf8, resolve_tasks_source
 
 
 def main() -> None:
-	"""Console script entry: resolves tasks source and dispatches.
-
-	Reconfigures stdout/stderr to UTF-8 so Windows consoles (cp1252 by default) can
-	render the box-drawing characters used in the tree output.
-	"""
-	for stream in (sys.stdout, sys.stderr):
-		cast("io.TextIOWrapper", stream).reconfigure(encoding="utf-8", errors="replace")
+	"""Console script entry: resolves tasks source and dispatches."""
+	reconfigure_stdio_utf8()
 	dispatch(*resolve_tasks_source(sys.argv[1:]))
 
 

--- a/src/camas/main/init.py
+++ b/src/camas/main/init.py
@@ -6,72 +6,26 @@
 from __future__ import annotations
 
 import sys
-from typing import TYPE_CHECKING, Final
+from pathlib import Path
+from typing import Final
 
-if TYPE_CHECKING:
-	from pathlib import Path
-
-STARTER: Final = '''\
-# /// script
-# requires-python = ">=3.10"
-# dependencies = ["camas"]
-# ///
-"""Project tasks — run with ``camas``, or standalone via ``uv run tasks.py``.
-
-Every task below is a cross-platform placeholder (``python -c ...``);
-replace the placeholders with your real commands:
-
-	lint = Task("ruff check .")
-	test = Task("cargo test", cwd=Path("rust"))
-	build = Task("npm run build")
-"""
-
-from camas import Config, Parallel, Sequential, Task, run_cli
-
-# A leaf is any shell command. Tuple form runs as-is; string form is
-# shlex-split. A bare string inside Sequential/Parallel coerces to an
-# anonymous Task.
-hello = Task(("python", "-c", "print('hello from camas')"))
-
-# matrix= clones the subtree per axis value, interpolating {NAME} into
-# cmd/env/cwd; env= is scoped to the subtree. Pin an axis from the CLI:
-# camas greet --NAME Grace
-greet = Parallel(
-	Task(("python", "-c", "import os; print(os.environ['GREETING'] + ', {NAME}!')")),
-	matrix={"NAME": ("Ada", "Grace")},
-	env={"GREETING": "hello"},
-	help="say hello to everyone at once",
-)
-
-# Sequential runs in order, short-circuiting on the first failure;
-# Parallel runs concurrently. They nest freely.
-ci = Sequential(
-	hello,
-	Parallel(greet, "python --version"),
-	name="ci",
-)
-
-# Discovered by type (the binding name never matters): bare `camas` runs
-# default_task — or github_task under GitHub Actions, falling back to
-# default_task when unset.
-_ = Config(default_task=ci)
-
-# Optional: with the PEP 723 header above, any PEP 723-aware tool runs
-# this file directly (`uv run tasks.py --list`). camas auto-discovery
-# ignores this block.
-if __name__ == "__main__":
-	run_cli(globals())
-'''
+STARTER: Final = (Path(__file__).parent / "starter.py").read_text(encoding="utf-8")
+"""The packaged :mod:`camas.main.starter` template, scaffolded verbatim.
+mypyc ships the original ``.py`` next to the compiled artifact, so the read
+works identically from a compiled wheel."""
 
 
 def write_starter_tasks_py(directory: Path) -> int:
 	"""Write :data:`STARTER` to ``directory/tasks.py`` — the exit code for
-	``camas --init``. Refuses to overwrite an existing file.
+	``camas --init``. Exclusive create: an existing file is never touched, and
+	any ``OSError`` (exists, permissions, ...) becomes a clean error exit.
 	"""
 	target: Final = directory / "tasks.py"
-	if target.exists():
-		print(f"error: {target} already exists", file=sys.stderr)
+	try:
+		with target.open("x", encoding="utf-8") as f:
+			f.write(STARTER)
+	except OSError as e:
+		print(f"error: {e}", file=sys.stderr)
 		return 2
-	target.write_text(STARTER, encoding="utf-8")
 	print(f"Wrote {target}\n\nTry:\n  camas --list\n  camas greet --help\n  camas")
 	return 0

--- a/src/camas/main/init.py
+++ b/src/camas/main/init.py
@@ -9,21 +9,27 @@ import sys
 from pathlib import Path
 from typing import Final
 
-STARTER: Final = (Path(__file__).parent / "starter.py").read_text(encoding="utf-8")
-"""The packaged :mod:`camas.main.starter` template, scaffolded verbatim.
-mypyc ships the original ``.py`` next to the compiled artifact, so the read
-works identically from a compiled wheel."""
+
+def starter_text() -> str:
+	"""The packaged :mod:`camas.main.starter` template, scaffolded verbatim.
+
+	Read at call time, not import time: mypyc-compiled modules may not define
+	``__file__`` while the module body executes (nixpkgs' mypyc doesn't), and
+	mypyc ships the original ``.py`` next to the compiled artifact, so the
+	call-time read works identically from a compiled wheel.
+	"""
+	return (Path(__file__).parent / "starter.py").read_text(encoding="utf-8")
 
 
 def write_starter_tasks_py(directory: Path) -> int:
-	"""Write :data:`STARTER` to ``directory/tasks.py`` — the exit code for
+	"""Write :func:`starter_text` to ``directory/tasks.py`` — the exit code for
 	``camas --init``. Exclusive create: an existing file is never touched, and
 	any ``OSError`` (exists, permissions, ...) becomes a clean error exit.
 	"""
 	target: Final = directory / "tasks.py"
 	try:
 		with target.open("x", encoding="utf-8") as f:
-			f.write(STARTER)
+			f.write(starter_text())
 	except OSError as e:
 		print(f"error: {e}", file=sys.stderr)
 		return 2

--- a/src/camas/main/init.py
+++ b/src/camas/main/init.py
@@ -1,0 +1,77 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2026 JP Hutchins
+
+"""``--init``: scaffold a commented starter ``tasks.py``."""
+
+from __future__ import annotations
+
+import sys
+from typing import TYPE_CHECKING, Final
+
+if TYPE_CHECKING:
+	from pathlib import Path
+
+STARTER: Final = '''\
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["camas"]
+# ///
+"""Project tasks — run with ``camas``, or standalone via ``uv run tasks.py``.
+
+Every task below is a cross-platform placeholder (``python -c ...``);
+replace the placeholders with your real commands:
+
+	lint = Task("ruff check .")
+	test = Task("cargo test", cwd=Path("rust"))
+	build = Task("npm run build")
+"""
+
+from camas import Config, Parallel, Sequential, Task, run_cli
+
+# A leaf is any shell command. Tuple form runs as-is; string form is
+# shlex-split. A bare string inside Sequential/Parallel coerces to an
+# anonymous Task.
+hello = Task(("python", "-c", "print('hello from camas')"))
+
+# matrix= clones the subtree per axis value, interpolating {NAME} into
+# cmd/env/cwd; env= is scoped to the subtree. Pin an axis from the CLI:
+# camas greet --NAME Grace
+greet = Parallel(
+	Task(("python", "-c", "import os; print(os.environ['GREETING'] + ', {NAME}!')")),
+	matrix={"NAME": ("Ada", "Grace")},
+	env={"GREETING": "hello"},
+	help="say hello to everyone at once",
+)
+
+# Sequential runs in order, short-circuiting on the first failure;
+# Parallel runs concurrently. They nest freely.
+ci = Sequential(
+	hello,
+	Parallel(greet, "python --version"),
+	name="ci",
+)
+
+# Discovered by type (the binding name never matters): bare `camas` runs
+# default_task — or github_task under GitHub Actions, falling back to
+# default_task when unset.
+_ = Config(default_task=ci)
+
+# Optional: with the PEP 723 header above, any PEP 723-aware tool runs
+# this file directly (`uv run tasks.py --list`). camas auto-discovery
+# ignores this block.
+if __name__ == "__main__":
+	run_cli(globals())
+'''
+
+
+def write_starter_tasks_py(directory: Path) -> int:
+	"""Write :data:`STARTER` to ``directory/tasks.py`` — the exit code for
+	``camas --init``. Refuses to overwrite an existing file.
+	"""
+	target: Final = directory / "tasks.py"
+	if target.exists():
+		print(f"error: {target} already exists", file=sys.stderr)
+		return 2
+	target.write_text(STARTER, encoding="utf-8")
+	print(f"Wrote {target}\n\nTry:\n  camas --list\n  camas greet --help\n  camas")
+	return 0

--- a/src/camas/main/parser.py
+++ b/src/camas/main/parser.py
@@ -178,6 +178,11 @@ def build_parser(state: TasksState = EMPTY_STATE) -> argparse.ArgumentParser:
 		help=describe_check_help(),
 	)
 	parser.add_argument(
+		"--init",
+		action="store_true",
+		help="write a commented starter tasks.py into the current directory and exit",
+	)
+	parser.add_argument(
 		"--effects",
 		nargs="?",
 		default=default_effects_expr(),
@@ -206,7 +211,7 @@ def build_parser(state: TasksState = EMPTY_STATE) -> argparse.ArgumentParser:
 
 
 RESERVED_FLAGS: Final = frozenset(
-	{"help", "version", "dry-run", "list", "tree", "check", "effects", "matrix", "jobs"}
+	{"help", "version", "dry-run", "list", "tree", "check", "init", "effects", "matrix", "jobs"}
 )
 
 

--- a/src/camas/main/starter.py
+++ b/src/camas/main/starter.py
@@ -1,0 +1,54 @@
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["camas"]
+# ///
+"""Project tasks — run with ``camas``.
+
+Every task below is a cross-platform placeholder (``python -c ...``);
+replace the placeholders with your real commands:
+
+	lint = Task("ruff check .")
+	test = Task("cargo test", cwd=Path("rust"))
+	build = Task("npm run build")
+
+The ``# /// script`` block above is optional PEP 723 inline metadata. With
+it (plus the ``__main__`` block at the bottom), PEP 723-aware tools can run
+this file standalone — ``uv run tasks.py``, ``pipx run tasks.py`` — building
+a throwaway env with camas installed; handy for non-Python projects. It is
+also where camas gets version-pinned (``dependencies = ["camas>=X.Y"]``).
+Both are inert under plain ``camas``; delete them if you don't want the
+standalone path.
+"""
+
+from camas import Config, Parallel, Sequential, Task, run_cli
+
+# A leaf is any shell command, shlex-split (so quote the -c payload). A bare
+# string inside Sequential/Parallel coerces to an anonymous Task; tuple form
+# Task(("python", "-c", "...")) skips shlex when quoting gets hairy.
+hello = Task("python -c \"print('hello from camas')\"")
+
+# matrix= clones the subtree per axis value, interpolating {NAME} into
+# cmd/env/cwd; env= is scoped to the subtree. Pin an axis from the CLI:
+# camas greet --NAME Grace
+greet = Parallel(
+	Task("python -c \"import os; print(os.environ['GREETING'] + ', {NAME}!')\""),
+	matrix={"NAME": ("Ada", "Grace")},
+	env={"GREETING": "hello"},
+	help="say hello to everyone at once",
+)
+
+# Sequential runs in order, short-circuiting on the first failure;
+# Parallel runs concurrently. They nest freely.
+ci = Sequential(
+	hello,
+	Parallel(greet, "python --version"),
+	name="ci",
+)
+
+# Discovered by type (the binding name never matters): bare `camas` runs
+# default_task — or github_task under GitHub Actions, falling back to
+# default_task when unset.
+_ = Config(default_task=ci)
+
+if __name__ == "__main__":
+	run_cli(globals())

--- a/src/camas/main/starter.py
+++ b/src/camas/main/starter.py
@@ -50,5 +50,8 @@ ci = Sequential(
 # default_task when unset.
 _ = Config(default_task=ci)
 
+# The PEP 723 standalone flow (see the docstring): running this file directly
+# (`uv run tasks.py <task>`) dispatches through camas. Inert when the `camas`
+# command discovers this file itself.
 if __name__ == "__main__":
 	run_cli(globals())

--- a/tests/main/test_init.py
+++ b/tests/main/test_init.py
@@ -44,7 +44,7 @@ def test_write_starter_refuses_existing(tmp_path: Path, capsys: pytest.CaptureFi
 	(tmp_path / "tasks.py").write_text("untouched = 1\n")
 	assert write_starter_tasks_py(tmp_path) == 2
 	assert (tmp_path / "tasks.py").read_text() == "untouched = 1\n"
-	assert "already exists" in capsys.readouterr().err
+	assert "exists" in capsys.readouterr().err
 
 
 def test_dispatch_init(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -90,7 +90,7 @@ def test_starter_cli_init_then_list(tmp_path: Path) -> None:
 	assert created.returncode == 0, created.stderr
 	again = _camas("--init", cwd=tmp_path)
 	assert again.returncode == 2
-	assert "already exists" in again.stderr
+	assert "exists" in again.stderr
 	listed = _camas("--list", cwd=tmp_path)
 	assert listed.returncode == 0, listed.stderr
 	assert "say hello to everyone at once" in listed.stdout

--- a/tests/main/test_init.py
+++ b/tests/main/test_init.py
@@ -1,0 +1,114 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2026 JP Hutchins
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from typing import TYPE_CHECKING
+
+import pytest
+
+from camas import Sequential
+from camas.main.dispatch import dispatch
+from camas.main.init import STARTER, write_starter_tasks_py
+from camas.main.state import EMPTY_STATE, LoadErr
+from camas.main.tasks import load_tasks_from_py
+
+if TYPE_CHECKING:
+	from pathlib import Path
+
+
+def _camas(*args: str, cwd: Path) -> subprocess.CompletedProcess[str]:
+	env = {**os.environ, "NO_COLOR": "1"}
+	env.pop("GITHUB_ACTIONS", None)
+	return subprocess.run(
+		[sys.executable, "-m", "camas", *args],
+		cwd=cwd,
+		capture_output=True,
+		text=True,
+		encoding="utf-8",
+		env=env,
+		check=False,
+	)
+
+
+def test_write_starter(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+	assert write_starter_tasks_py(tmp_path) == 0
+	assert (tmp_path / "tasks.py").read_text(encoding="utf-8") == STARTER
+	assert "Wrote" in capsys.readouterr().out
+
+
+def test_write_starter_refuses_existing(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+	(tmp_path / "tasks.py").write_text("untouched = 1\n")
+	assert write_starter_tasks_py(tmp_path) == 2
+	assert (tmp_path / "tasks.py").read_text() == "untouched = 1\n"
+	assert "already exists" in capsys.readouterr().err
+
+
+def test_dispatch_init(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+	monkeypatch.chdir(tmp_path)
+	with pytest.raises(SystemExit, match="0"):
+		dispatch(EMPTY_STATE, ["--init"])
+	assert (tmp_path / "tasks.py").exists()
+
+
+def test_dispatch_init_under_load_err(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+	"""``--init`` still works when a tasks file elsewhere failed to load."""
+	monkeypatch.chdir(tmp_path)
+	state = LoadErr(source=tmp_path / "parent" / "tasks.py", exception=ValueError("boom"))
+	with pytest.raises(SystemExit, match="0"):
+		dispatch(state, ["--init"])
+	assert (tmp_path / "tasks.py").exists()
+
+
+def test_starter_loads_with_config_default(tmp_path: Path) -> None:
+	write_starter_tasks_py(tmp_path)
+	loaded = load_tasks_from_py(tmp_path / "tasks.py")
+	assert set(loaded.tasks) == {"hello", "greet", "ci"}
+	assert loaded.scope_effects == {}
+	assert loaded.config is not None
+	assert loaded.config.default_task == loaded.tasks["ci"]
+	assert isinstance(loaded.config.default_task, Sequential)
+
+
+def test_starter_runs_to_completion(tmp_path: Path) -> None:
+	"""Bare ``camas`` in a freshly scaffolded directory runs the whole default
+	tree green — the placeholder tasks must be infallible cross-platform."""
+	write_starter_tasks_py(tmp_path)
+	result = _camas("--effects=(Summary(SummaryOptions(show_passing=True)),)", cwd=tmp_path)
+	assert result.returncode == 0, result.stderr
+	assert "hello from camas" in result.stdout
+	assert "hello, Ada!" in result.stdout
+	assert "hello, Grace!" in result.stdout
+	assert "Python" in result.stdout
+
+
+def test_starter_cli_init_then_list(tmp_path: Path) -> None:
+	created = _camas("--init", cwd=tmp_path)
+	assert created.returncode == 0, created.stderr
+	again = _camas("--init", cwd=tmp_path)
+	assert again.returncode == 2
+	assert "already exists" in again.stderr
+	listed = _camas("--list", cwd=tmp_path)
+	assert listed.returncode == 0, listed.stderr
+	assert "say hello to everyone at once" in listed.stdout
+	assert all(name in listed.stdout for name in ("hello", "greet", "ci"))
+
+
+def test_starter_runs_standalone(tmp_path: Path) -> None:
+	"""``python tasks.py --list`` dispatches through the scaffold's
+	``run_cli(globals())`` block."""
+	write_starter_tasks_py(tmp_path)
+	env = {**os.environ, "NO_COLOR": "1"}
+	result = subprocess.run(
+		[sys.executable, str(tmp_path / "tasks.py"), "--list"],
+		capture_output=True,
+		text=True,
+		encoding="utf-8",
+		env=env,
+		check=False,
+	)
+	assert result.returncode == 0, result.stderr
+	assert all(name in result.stdout for name in ("hello", "greet", "ci"))

--- a/tests/main/test_init.py
+++ b/tests/main/test_init.py
@@ -12,7 +12,7 @@ import pytest
 
 from camas import Sequential
 from camas.main.dispatch import dispatch
-from camas.main.init import STARTER, write_starter_tasks_py
+from camas.main.init import starter_text, write_starter_tasks_py
 from camas.main.state import EMPTY_STATE, LoadErr
 from camas.main.tasks import load_tasks_from_py
 
@@ -36,7 +36,7 @@ def _camas(*args: str, cwd: Path) -> subprocess.CompletedProcess[str]:
 
 def test_write_starter(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
 	assert write_starter_tasks_py(tmp_path) == 0
-	assert (tmp_path / "tasks.py").read_text(encoding="utf-8") == STARTER
+	assert (tmp_path / "tasks.py").read_text(encoding="utf-8") == starter_text()
 	assert "Wrote" in capsys.readouterr().out
 
 


### PR DESCRIPTION
Closes #18

`camas --init` writes a commented starter `tasks.py` into the current directory and exits. The template demonstrates, with infallible cross-platform placeholder commands (`python -c ...`):

- leaf `Task` (tuple cmd as-is, string cmd shlex-split, bare-string coercion inside groups)
- `Sequential` (ordered, short-circuit) / `Parallel` (concurrent) composition
- a matrix with `{AXIS}` interpolation, scoped `env=`, and `help=`
- a `Config` default task (#21), so bare `camas` runs green immediately after scaffolding
- the PEP 723 header + `run_cli(globals())` standalone block, per the canonical shape settled in #32

Behavior:
- refuses to overwrite an existing `tasks.py` (stderr + exit 2)
- handled in both dispatch arms, so a broken tasks file elsewhere up the tree (`LoadErr`) doesn't block scaffolding a fresh one
- `init` added to `RESERVED_FLAGS` so a matrix axis named `INIT` can't collide

Tests cover the write/refuse paths, both dispatch arms, loader round-trip (task names + promoted `Config.default_task`), an end-to-end bare-`camas` run of the scaffold (proving the placeholders are infallible), `--init`-then-`--list` via the real CLI, and the standalone `python tasks.py --list` path.

Verified locally: ruff format/check, mypy, pyright, ty, zuban, full suite at 100% coverage (pyrefly + unscoped variants via CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)