### PR TITLE
refactor(effects): drop the *Options wrappers, flatten fields into constructors

### DIFF
--- a/.github/scripts/record-demo.sh
+++ b/.github/scripts/record-demo.sh
@@ -26,7 +26,7 @@ done
 
 mkdir -p "$OUT_DIR"
 
-ROWS=$(cd "$FIXTURE" && camas all --dry-run --effects='(Summary(SummaryOptions(Fixed(90))),)' 2>/dev/null | wc -l)
+ROWS=$(cd "$FIXTURE" && camas all --dry-run --effects='(Summary(Fixed(90)),)' 2>/dev/null | wc -l)
 ROWS=$((ROWS + 3))
 
 echo "::group::Record asciicast"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -60,7 +60,7 @@ jobs:
 
       - uses: astral-sh/setup-uv@v6
 
-      - run: uv run camas coverage --effects='(Status(StatusOptions(output_mode="all")),)'
+      - run: uv run camas coverage --effects='(Status(output_mode="all"),)'
 
       - uses: codecov/codecov-action@v5
         if: always()
@@ -82,10 +82,8 @@ jobs:
 
       - run: |
           uv run --extra github_checks camas matrix --effects='(
-            Status(StatusOptions(output_mode="github")),
-            GitHubChecks(GitHubChecksOptions(
-              sha="${{ github.event.pull_request.head.sha || github.sha }}",
-            )),
+            Status(output_mode="github"),
+            GitHubChecks(sha="${{ github.event.pull_request.head.sha || github.sha }}"),
           )'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -104,7 +102,7 @@ jobs:
 
       - uses: astral-sh/setup-uv@v6
 
-      - run: uv run camas check --effects='(Status(StatusOptions(output_mode="${{ matrix.mode }}")),)'
+      - run: uv run camas check --effects='(Status(output_mode="${{ matrix.mode }}"),)'
 
   nix:
     strategy:

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ camas is **not a build system**. camas is for the specific job of running struct
 
 The renderer is swappable, not the tree. Run the same `tasks.py` locally with the live `Termtree` and in CI with `Status` — one flag changes the output, the pipeline definition is unchanged.
 
-**On GitHub Actions, no flag is needed.** Camas detects `GITHUB_ACTIONS=true` and defaults `--effects` to `(Status(StatusOptions(output_mode="github")),)` — collapsed workflow groups, ISO timestamps with millisecond precision, ANSI colors preserved.
+**On GitHub Actions, no flag is needed.** Camas detects `GITHUB_ACTIONS=true` and defaults `--effects` to `(Status(output_mode="github"),)` — collapsed workflow groups, ISO timestamps with millisecond precision, ANSI colors preserved.
 
 ```yaml
 - run: uv run camas check
@@ -111,7 +111,7 @@ The renderer is swappable, not the tree. Run the same `tasks.py` locally with th
 On other CI providers (or to opt into a specific mode), spell it out:
 
 ```yaml
-- run: uv run camas check --effects='(Status(StatusOptions(output_mode="errors")),)'
+- run: uv run camas check --effects='(Status(output_mode="errors"),)'
 ```
 
 See the [`OutputMode`](https://github.com/JPHutchins/camas/blob/main/src/camas/effect/status.py) literal and `block_for` doctests for the per-mode behavior. The [`status-modes-demo` job](https://github.com/JPHutchins/camas/blob/main/.github/workflows/ci.yaml) renders one CI run per mode for visual comparison.
@@ -121,10 +121,8 @@ For per-leaf visibility in the PR Checks panel, add the `GitHubChecks` effect al
 ```yaml
 - run: |
     uv run --extra github_checks camas matrix --effects='(
-      Status(StatusOptions(output_mode="github")),
-      GitHubChecks(GitHubChecksOptions(
-        sha="${{ github.event.pull_request.head.sha || github.sha }}",
-      )),
+      Status(output_mode="github"),
+      GitHubChecks(sha="${{ github.event.pull_request.head.sha || github.sha }}"),
     )'
   env:
     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,45 +105,45 @@ exclude = ["tests/fixtures/"]
 preview = true
 explicit-preview-rules = true
 select = [
-"ASYNC", # flake8-async
-"B", # flake8-bugbear
-"C4", # flake8-comprehensions
-"D", # pydocstyle
+"ASYNC",  # flake8-async
+"B",      # flake8-bugbear
+"C4",     # flake8-comprehensions
+"D",      # pydocstyle
 "DOC102", # pydoclint (preview): documented params that don't exist
 "DOC202", # pydoclint (preview): documented returns that don't exist
 "DOC403", # pydoclint (preview): documented yields that don't exist
 "DOC501", # pydoclint (preview): raised exceptions must be documented
 "DOC502", # pydoclint (preview): documented exceptions that aren't raised
-"E", # pycodestyle errors
-"F", # pyflakes
-"FA", # flake8-future-annotations
-"FLY", # flynt
-"FURB", # refurb
-"G", # flake8-logging-format
-"I", # isort
-"ICN", # flake8-import-conventions
-"INP", # flake8-no-pep420
-"ISC", # flake8-implicit-str-concat
-"LOG", # flake8-logging
-"N", # pep8-naming
-"PERF", # perflint
-"PGH", # pygrep-hooks
-"PIE", # flake8-pie
-"PL", # pylint
-"PT", # flake8-pytest-style
-"PTH", # flake8-use-pathlib
-"PYI", # flake8-pyi
-"RET", # flake8-return
-"RSE", # flake8-raise
-"RUF", # ruff-specific
-"SIM", # flake8-simplify
-"SLF", # flake8-self
-"SLOT", # flake8-slots
-"TC", # flake8-type-checking
-"TRY", # tryceratops
-"UP", # pyupgrade
-"W", # pycodestyle warnings
-"YTT", # flake8-2020
+"E",      # pycodestyle errors
+"F",      # pyflakes
+"FA",     # flake8-future-annotations
+"FLY",    # flynt
+"FURB",   # refurb
+"G",      # flake8-logging-format
+"I",      # isort
+"ICN",    # flake8-import-conventions
+"INP",    # flake8-no-pep420
+"ISC",    # flake8-implicit-str-concat
+"LOG",    # flake8-logging
+"N",      # pep8-naming
+"PERF",   # perflint
+"PGH",    # pygrep-hooks
+"PIE",    # flake8-pie
+"PL",     # pylint
+"PT",     # flake8-pytest-style
+"PTH",    # flake8-use-pathlib
+"PYI",    # flake8-pyi
+"RET",    # flake8-return
+"RSE",    # flake8-raise
+"RUF",    # ruff-specific
+"SIM",    # flake8-simplify
+"SLF",    # flake8-self
+"SLOT",   # flake8-slots
+"TC",     # flake8-type-checking
+"TRY",    # tryceratops
+"UP",     # pyupgrade
+"W",      # pycodestyle warnings
+"YTT",    # flake8-2020
 ]
 # DOC201/DOC402 (missing returns/yields sections) are deliberately absent:
 # annotations are the single source of truth for parameter and return types,
@@ -160,21 +160,21 @@ ignore = [
 "D300",
 "ISC001",
 "ISC002",
-"E501", # the formatter owns line length; the rest is unbreakable doctest output
-"D102", # effect methods implement the documented Effect protocol contract
-"D103", # code should document itself; a needed comment is a symptom
-"D105", # magic method contracts are defined by the data model, not prose
-"D107", # __init__ is documented by its class
-"D205", # summaries here are flowing paragraphs, not one-liners
-"D417", # params belong to the type system, not prose (see DOC201/DOC402 above)
+"E501",    # the formatter owns line length; the rest is unbreakable doctest output
+"D102",    # effect methods implement the documented Effect protocol contract
+"D103",    # code should document itself; a needed comment is a symptom
+"D105",    # magic method contracts are defined by the data model, not prose
+"D107",    # __init__ is documented by its class
+"D205",    # summaries here are flowing paragraphs, not one-liners
+"D417",    # params belong to the type system, not prose (see DOC201/DOC402 above)
 "PLC0415", # imports are scoped as narrowly as possible, by design
 "PLR0911", # complexity thresholds reward fragmentation over clarity
 "PLR0912",
 "PLR0913",
 "PLR0915",
 "PLR2004", # renderer geometry is full of honest small numbers
-"TRY003", # messages live in the raise; no exception-class zoo
-"TRY004", # ValueError is the CLI's user-error channel (dispatch catches it)
+"TRY003",  # messages live in the raise; no exception-class zoo
+"TRY004",  # ValueError is the CLI's user-error channel (dispatch catches it)
 ]
 allowed-confusables = ["×"] # matrix axes render as PY×6
 
@@ -182,13 +182,8 @@ allowed-confusables = ["×"] # matrix axes render as PY×6
 convention = "google"
 
 [tool.ruff.lint.flake8-bugbear]
-# Options are immutable NamedTuples; constructing defaults in signatures is safe.
-extend-immutable-calls = [
-"camas.effect.github_checks.GitHubChecksOptions",
-"camas.effect.status.StatusOptions",
-"camas.effect.summary.SummaryOptions",
-"camas.effect.termtree.TermtreeOptions",
-]
+# Auto() is an immutable NamedTuple; constructing it as Summary's term_width default is safe.
+extend-immutable-calls = ["camas.effect.summary.Auto"]
 
 [tool.ruff.lint.per-file-ignores]
 "tests/**" = ["D"] # test functions document themselves by name

--- a/src/camas/__init__.py
+++ b/src/camas/__init__.py
@@ -68,7 +68,7 @@ those at the shell from ``tmp``.
 	...     return camas
 
 A single leaf — the smallest viable ``tasks.py``. Passing
-``Summary(SummaryOptions(show_passing=True))`` prints every passing
+``Summary(show_passing=True)`` prints every passing
 task's stdout so the leaf's output is verifiable from the run record;
 ``camas --help`` lists the task by name:
 
@@ -79,7 +79,7 @@ task's stdout so the leaf's output is verifiable from the run record;
 	...         hello = Task(("python", "-c", "print('hello world')"))
 	...     '''))
 	...     # Equivalent shell: $ camas --effects='(Summary(...))' hello
-	...     run_ = camas("--effects=(Summary(SummaryOptions(show_passing=True)),)", "hello")
+	...     run_ = camas("--effects=(Summary(show_passing=True),)", "hello")
 	...     helped = camas("--help")
 	>>> run_.returncode, helped.returncode
 	(0, 0)
@@ -123,7 +123,7 @@ the dispatched task's command:
 	...     '''))
 	...     dry = camas("--dry-run", "ci")
 	...     tree = camas("--tree")
-	...     run_ = camas("--effects=(Summary(SummaryOptions(show_passing=True)),)", "ci")
+	...     run_ = camas("--effects=(Summary(show_passing=True),)", "ci")
 	...     fwd = camas("echo", "--", "one", "two", "three")
 	>>> [r.returncode for r in (dry, tree, run_, fwd)]
 	[0, 0, 0, 0]
@@ -202,9 +202,9 @@ axes:
 	...             name="meet",
 	...         )
 	...     '''))
-	...     baseline = camas("--effects=(Summary(SummaryOptions(show_passing=True)),)", "meet")
+	...     baseline = camas("--effects=(Summary(show_passing=True),)", "meet")
 	...     overridden = camas(
-	...         "--effects=(Summary(SummaryOptions(show_passing=True)),)",
+	...         "--effects=(Summary(show_passing=True),)",
 	...         "meet", "--NAME1=Clara,Dolores", "--NAME2=Jane,Ada",
 	...     )
 	...     axes = camas("meet", "--help")

--- a/src/camas/effect/github_checks.py
+++ b/src/camas/effect/github_checks.py
@@ -16,7 +16,7 @@ In ``pull_request`` events ``GITHUB_SHA`` points at the **merge commit**, not
 the PR's head — checks attached to it don't render in the PR Checks panel.
 Pass the head SHA explicitly::
 
-	GitHubChecks(GitHubChecksOptions(sha="${{ github.event.pull_request.head.sha || github.sha }}"))
+	GitHubChecks(sha="${{ github.event.pull_request.head.sha || github.sha }}")
 
 HTTP is fired-and-forgotten in ``on_event`` (``asyncio.create_task``) and
 awaited only in ``teardown``, so the run isn't slowed by network latency.
@@ -55,29 +55,6 @@ GH_API_VERSION: Final = "2022-11-28"
 GH_API_HOST: Final = "api.github.com"
 OUTPUT_TEXT_LIMIT: Final = 65_000
 NAME_LIMIT: Final = 100
-
-
-class GitHubChecksOptions(NamedTuple):
-	"""Configuration for the GitHubChecks Effect.
-
-	>>> GitHubChecksOptions()
-	GitHubChecksOptions(token=None, repository=None, sha=None, name_prefix='', tail_bytes=8192, fail_on_api_error=False)
-	>>> GitHubChecksOptions(name_prefix="ubuntu/").name_prefix
-	'ubuntu/'
-	"""
-
-	token: str | None = None
-	"""Auth token. None → reads ``GITHUB_TOKEN`` env var at setup time."""
-	repository: str | None = None
-	"""``owner/repo`` slug. None → reads ``GITHUB_REPOSITORY``."""
-	sha: str | None = None
-	"""Commit SHA. None → reads ``GITHUB_SHA`` (see module docstring caveat)."""
-	name_prefix: str = ""
-	"""Prepended to each check-run name (use for matrix-cell discrimination)."""
-	tail_bytes: int = 8192
-	"""Max bytes of stdout/stderr included in the check-run output text."""
-	fail_on_api_error: bool = False
-	"""If True, HTTP failures surface in teardown as a BaseExceptionGroup."""
 
 
 class ResolvedConfig(NamedTuple):
@@ -156,42 +133,54 @@ def require_httpx() -> ModuleType:
 	return httpx
 
 
-def resolve_config(opts: GitHubChecksOptions) -> ResolvedConfig:
-	"""Resolve options + env vars into a fully-specified ResolvedConfig.
+def resolve_config(
+	token: str | None,
+	repository: str | None,
+	sha: str | None,
+	name_prefix: str,
+	tail_bytes: int,
+	fail_on_api_error: bool,
+) -> ResolvedConfig:
+	"""Resolve the identity arguments + env vars into a fully-specified ResolvedConfig.
+
+	``token`` / ``repository`` / ``sha`` fall back to ``GITHUB_TOKEN`` /
+	``GITHUB_REPOSITORY`` / ``GITHUB_SHA`` when ``None``; the rest pass through.
 
 	Raises:
 		RuntimeError: when token, repository, or sha is unset, or repository
 			is not ``owner/repo``.
 
-	>>> resolve_config(GitHubChecksOptions(token="t", repository="o/r", sha="s")).repo
+	>>> resolve_config("t", "o/r", "s", "", 8192, False).repo
 	'r'
 	"""
-	token: Final = opts.token or os.environ.get("GITHUB_TOKEN") or ""
-	repository: Final = opts.repository or os.environ.get("GITHUB_REPOSITORY") or ""
-	sha: Final = opts.sha or os.environ.get("GITHUB_SHA") or ""
+	resolved_token: Final = token or os.environ.get("GITHUB_TOKEN") or ""
+	resolved_repository: Final = repository or os.environ.get("GITHUB_REPOSITORY") or ""
+	resolved_sha: Final = sha or os.environ.get("GITHUB_SHA") or ""
 	missing: Final = tuple(
 		name
 		for name, value in (
-			("GITHUB_TOKEN (or options.token)", token),
-			("GITHUB_REPOSITORY (or options.repository)", repository),
-			("GITHUB_SHA (or options.sha)", sha),
+			("GITHUB_TOKEN (or the token argument)", resolved_token),
+			("GITHUB_REPOSITORY (or the repository argument)", resolved_repository),
+			("GITHUB_SHA (or the sha argument)", resolved_sha),
 		)
 		if not value
 	)
 	if missing:
 		raise RuntimeError(f"GitHubChecks: missing required configuration: {', '.join(missing)}")
-	parts: Final = repository.split("/")
+	parts: Final = resolved_repository.split("/")
 	if len(parts) != 2 or not parts[0] or not parts[1]:
-		raise RuntimeError(f"GitHubChecks: repository must be 'owner/repo', got {repository!r}")
+		raise RuntimeError(
+			f"GitHubChecks: repository must be 'owner/repo', got {resolved_repository!r}"
+		)
 	owner, repo = parts
 	return ResolvedConfig(
-		token=token,
+		token=resolved_token,
 		owner=owner,
 		repo=repo,
-		sha=sha,
-		name_prefix=opts.name_prefix,
-		tail_bytes=opts.tail_bytes,
-		fail_on_api_error=opts.fail_on_api_error,
+		sha=resolved_sha,
+		name_prefix=name_prefix,
+		tail_bytes=tail_bytes,
+		fail_on_api_error=fail_on_api_error,
 	)
 
 
@@ -463,13 +452,33 @@ class GitHubChecks:
 	required ``checks: write`` workflow permission.
 	"""
 
-	def __init__(self, options: GitHubChecksOptions = GitHubChecksOptions()) -> None:
-		self.options: Final = options
+	def __init__(
+		self,
+		token: str | None = None,
+		repository: str | None = None,
+		sha: str | None = None,
+		name_prefix: str = "",
+		tail_bytes: int = 8192,
+		fail_on_api_error: bool = False,
+	) -> None:
+		self._token: Final = token
+		self._repository: Final = repository
+		self._sha: Final = sha
+		self._name_prefix: Final = name_prefix
+		self._tail_bytes: Final = tail_bytes
+		self._fail_on_api_error: Final = fail_on_api_error
 		self.state: EffectState | None = None
 
 	async def setup(self, task: TaskNode) -> LeafCtx:
 		httpx_mod: Final = require_httpx()  # zuban: ignore[misc] # zuban defies PEP591
-		cfg: Final = resolve_config(self.options)  # zuban: ignore[misc] # zuban defies PEP591
+		cfg: Final = resolve_config(  # zuban: ignore[misc] # zuban defies PEP591
+			self._token,
+			self._repository,
+			self._sha,
+			self._name_prefix,
+			self._tail_bytes,
+			self._fail_on_api_error,
+		)
 		self.state = EffectState(
 			http=httpx_mod.AsyncClient(timeout=5.0, headers=auth_headers(cfg)),
 			cfg=cfg,

--- a/src/camas/effect/status.py
+++ b/src/camas/effect/status.py
@@ -7,9 +7,9 @@ cursor-redrawing) and :class:`camas.effect.summary.Summary` (one post-run
 report) — suited for CI logs and any context where cursor control either
 doesn't render or shouldn't.
 
-See :class:`StatusOptions` for the mode and template fields, and the doctests
-on :func:`block_for` / :func:`fmt_started` / :func:`fmt_completed` /
-:func:`fmt_output` for the exact behavior of each.
+See the :class:`Status` constructor for the mode and template arguments, and
+the doctests on :func:`block_for` / :func:`fmt_started` / :func:`fmt_completed`
+/ :func:`fmt_output` for the exact behavior of each.
 """
 
 from __future__ import annotations
@@ -39,37 +39,25 @@ if TYPE_CHECKING:
 OutputMode: TypeAlias = Literal["quiet", "all", "errors", "stream", "github"]
 
 
-class StatusOptions(NamedTuple):
-	"""Configuration for the Status Effect.
-
-	>>> StatusOptions().output_mode
-	'errors'
-	>>> StatusOptions(output_mode="github").output_mode
-	'github'
-	>>> StatusOptions(started_fmt="").started_fmt
-	''
-	"""
-
-	output_mode: OutputMode = "errors"
-	started_fmt: str = (
-		f"{GREY}[{{timestamp:%Y-%m-%d %H:%M:%S}}.{{ms:03d}}]{RESET} "
-		f"{CAMAS_VIOLET}▶ [{{name}}] started{RESET}"
-	)
-	finished_fmt: str = (
-		f"{GREY}[{{timestamp:%Y-%m-%d %H:%M:%S}}.{{ms:03d}}]{RESET} "
-		f"{GREEN}✓ [{{name}}] success{RESET} ({{elapsed:.3f}}s)"
-	)
-	failed_fmt: str = (
-		f"{GREY}[{{timestamp:%Y-%m-%d %H:%M:%S}}.{{ms:03d}}]{RESET} "
-		f"{RED}✗ [{{name}}] error{RESET} exit={{rc}} ({{elapsed:.3f}}s)"
-	)
-	skipped_fmt: str = (
-		f"{GREY}[{{timestamp:%Y-%m-%d %H:%M:%S}}.{{ms:03d}}]{RESET} "
-		f"{GREY}⏭ [{{name}}] skipped{RESET} (prior rc={{rc}})"
-	)
-	output_fmt: str = (
-		f"{GREY}[{{timestamp:%Y-%m-%d %H:%M:%S}}.{{ms:03d}}] · [{{name}}]{RESET} {{line}}"
-	)
+STARTED_FMT: Final = (
+	f"{GREY}[{{timestamp:%Y-%m-%d %H:%M:%S}}.{{ms:03d}}]{RESET} "
+	f"{CAMAS_VIOLET}▶ [{{name}}] started{RESET}"
+)
+FINISHED_FMT: Final = (
+	f"{GREY}[{{timestamp:%Y-%m-%d %H:%M:%S}}.{{ms:03d}}]{RESET} "
+	f"{GREEN}✓ [{{name}}] success{RESET} ({{elapsed:.3f}}s)"
+)
+FAILED_FMT: Final = (
+	f"{GREY}[{{timestamp:%Y-%m-%d %H:%M:%S}}.{{ms:03d}}]{RESET} "
+	f"{RED}✗ [{{name}}] error{RESET} exit={{rc}} ({{elapsed:.3f}}s)"
+)
+SKIPPED_FMT: Final = (
+	f"{GREY}[{{timestamp:%Y-%m-%d %H:%M:%S}}.{{ms:03d}}]{RESET} "
+	f"{GREY}⏭ [{{name}}] skipped{RESET} (prior rc={{rc}})"
+)
+OUTPUT_FMT: Final = (
+	f"{GREY}[{{timestamp:%Y-%m-%d %H:%M:%S}}.{{ms:03d}}] · [{{name}}]{RESET} {{line}}"
+)
 
 
 class Idle(NamedTuple):
@@ -106,44 +94,46 @@ def cmd_str(task: Task) -> str:
 	return task.cmd if isinstance(task.cmd, str) else " ".join(task.cmd)
 
 
-def fmt_started(opts: StatusOptions, task: Task, ts: datetime) -> str | None:
+def fmt_started(started_fmt: str, task: Task, ts: datetime) -> str | None:
 	r"""Render the started-line, or ``None`` when ``started_fmt`` is empty.
 
 	>>> from datetime import datetime
 	>>> from camas import Task
 	>>> t0 = datetime(2026, 5, 21, 14, 30, 0, 123000)
-	>>> fmt_started(StatusOptions(), Task("echo hi", name="greet"), t0)
+	>>> fmt_started(STARTED_FMT, Task("echo hi", name="greet"), t0)
 	'\x1b[90m[2026-05-21 14:30:00.123]\x1b[0m \x1b[38;5;135m▶ [greet] started\x1b[0m'
-	>>> fmt_started(StatusOptions(started_fmt=""), Task("echo hi"), t0) is None
+	>>> fmt_started("", Task("echo hi"), t0) is None
 	True
-	>>> fmt_started(
-	...     StatusOptions(started_fmt="{cmd} @ {timestamp:%H:%M:%S}.{ms:03d}"),
-	...     Task(("python", "-c", "pass")), t0,
-	... )
+	>>> fmt_started("{cmd} @ {timestamp:%H:%M:%S}.{ms:03d}", Task(("python", "-c", "pass")), t0)
 	'python -c pass @ 14:30:00.123'
 	"""
-	if not opts.started_fmt:
+	if not started_fmt:
 		return None
-	return opts.started_fmt.format(
+	return started_fmt.format(
 		name=task_label(task), cmd=cmd_str(task), timestamp=ts, ms=ts.microsecond // 1000
 	)
 
 
-def fmt_completed(opts: StatusOptions, task: Task, c: Completion, ts: datetime) -> str | None:
+def fmt_completed(
+	finished_fmt: str,
+	failed_fmt: str,
+	skipped_fmt: str,
+	task: Task,
+	c: Completion,
+	ts: datetime,
+) -> str | None:
 	r"""Render the completion line, or ``None`` when the matching template is empty.
 
 	>>> from datetime import datetime
 	>>> from camas import Task
 	>>> t0 = datetime(2026, 5, 21, 14, 30, 0, 123000)
-	>>> fmt_completed(StatusOptions(), Task("a", name="lint"), Finished(0, 1.5, ()), t0)
+	>>> fmt_completed(FINISHED_FMT, FAILED_FMT, SKIPPED_FMT, Task("a", name="lint"), Finished(0, 1.5, ()), t0)
 	'\x1b[90m[2026-05-21 14:30:00.123]\x1b[0m \x1b[32m✓ [lint] success\x1b[0m (1.500s)'
-	>>> fmt_completed(StatusOptions(), Task("a", name="lint"), Finished(2, 0.5, ()), t0)
+	>>> fmt_completed(FINISHED_FMT, FAILED_FMT, SKIPPED_FMT, Task("a", name="lint"), Finished(2, 0.5, ()), t0)
 	'\x1b[90m[2026-05-21 14:30:00.123]\x1b[0m \x1b[31m✗ [lint] error\x1b[0m exit=2 (0.500s)'
-	>>> fmt_completed(StatusOptions(), Task("a", name="follow"), Skipped(2), t0)
+	>>> fmt_completed(FINISHED_FMT, FAILED_FMT, SKIPPED_FMT, Task("a", name="follow"), Skipped(2), t0)
 	'\x1b[90m[2026-05-21 14:30:00.123]\x1b[0m \x1b[90m⏭ [follow] skipped\x1b[0m (prior rc=2)'
-	>>> fmt_completed(
-	...     StatusOptions(finished_fmt=""), Task("a"), Finished(0, 1.0, ()), t0,
-	... ) is None
+	>>> fmt_completed("", FAILED_FMT, SKIPPED_FMT, Task("a"), Finished(0, 1.0, ()), t0) is None
 	True
 	"""
 	name = task_label(task)
@@ -151,35 +141,38 @@ def fmt_completed(opts: StatusOptions, task: Task, c: Completion, ts: datetime) 
 	ms = ts.microsecond // 1000
 	match c:
 		case Finished(returncode=rc, elapsed=e):
-			tmpl = opts.finished_fmt if rc == 0 else opts.failed_fmt
+			tmpl = finished_fmt if rc == 0 else failed_fmt
 			return (
 				tmpl.format(name=name, cmd=cmd, rc=rc, elapsed=e, timestamp=ts, ms=ms)
 				if tmpl
 				else None
 			)
 		case Skipped(returncode=rc):
-			tmpl = opts.skipped_fmt
-			return tmpl.format(name=name, cmd=cmd, rc=rc, timestamp=ts, ms=ms) if tmpl else None
+			return (
+				skipped_fmt.format(name=name, cmd=cmd, rc=rc, timestamp=ts, ms=ms)
+				if skipped_fmt
+				else None
+			)
 		case _:
 			assert_never(c)
 
 
-def fmt_output(opts: StatusOptions, task: Task, line: bytes, ts: datetime) -> str | None:
+def fmt_output(output_fmt: str, task: Task, line: bytes, ts: datetime) -> str | None:
 	r"""Render a stream-mode output line (ANSI-stripped, trailing newline removed).
 
 	>>> from datetime import datetime
 	>>> from camas import Task
 	>>> t0 = datetime(2026, 5, 21, 14, 30, 0, 123000)
-	>>> fmt_output(StatusOptions(), Task("a", name="lint"), b"hello\n", t0)
+	>>> fmt_output(OUTPUT_FMT, Task("a", name="lint"), b"hello\n", t0)
 	'\x1b[90m[2026-05-21 14:30:00.123] · [lint]\x1b[0m hello'
-	>>> fmt_output(StatusOptions(), Task("a", name="lint"), b"\x1b[31mred\x1b[0m\n", t0)
+	>>> fmt_output(OUTPUT_FMT, Task("a", name="lint"), b"\x1b[31mred\x1b[0m\n", t0)
 	'\x1b[90m[2026-05-21 14:30:00.123] · [lint]\x1b[0m red'
-	>>> fmt_output(StatusOptions(output_fmt=""), Task("a"), b"x\n", t0) is None
+	>>> fmt_output("", Task("a"), b"x\n", t0) is None
 	True
 	"""
-	if not opts.output_fmt:
+	if not output_fmt:
 		return None
-	return opts.output_fmt.format(
+	return output_fmt.format(
 		name=task_label(task),
 		cmd=cmd_str(task),
 		timestamp=ts,
@@ -303,13 +296,26 @@ def next_ctx_on_output(mode: OutputMode, ctx: Active, line: bytes) -> Active:
 
 
 class Status:
-	"""Line-oriented status Effect; behavior is selected by ``StatusOptions.output_mode``.
+	"""Line-oriented status Effect; behavior is selected by the ``output_mode`` argument.
 
 	See the module docstring for how it relates to ``Termtree`` and ``Summary``.
 	"""
 
-	def __init__(self, options: StatusOptions = StatusOptions()) -> None:
-		self.options: Final = options
+	def __init__(
+		self,
+		output_mode: OutputMode = "errors",
+		started_fmt: str = STARTED_FMT,
+		finished_fmt: str = FINISHED_FMT,
+		failed_fmt: str = FAILED_FMT,
+		skipped_fmt: str = SKIPPED_FMT,
+		output_fmt: str = OUTPUT_FMT,
+	) -> None:
+		self._output_mode: Final = output_mode
+		self._started_fmt: Final = started_fmt
+		self._finished_fmt: Final = finished_fmt
+		self._failed_fmt: Final = failed_fmt
+		self._skipped_fmt: Final = skipped_fmt
+		self._output_fmt: Final = output_fmt
 
 	async def setup(self, task: TaskNode) -> LeafCtx:
 		return Idle()
@@ -317,21 +323,24 @@ class Status:
 	async def on_event(
 		self, event: TaskEvent, states: Sequence[LeafState], ctx: LeafCtx
 	) -> LeafCtx:
-		opts = self.options
 		match event, ctx:
 			case StartedEvent(task=t, timestamp=ts), Idle():
-				emit_line(fmt_started(opts, t, ts))
+				emit_line(fmt_started(self._started_fmt, t, ts))
 				return Active(b"")
 			case OutputEvent(task=t, line=line, timestamp=ts), Active() as active:
-				if opts.output_mode == "stream":
-					emit_line(fmt_output(opts, t, line, ts))
-				return next_ctx_on_output(opts.output_mode, active, line)
+				if self._output_mode == "stream":
+					emit_line(fmt_output(self._output_fmt, t, line, ts))
+				return next_ctx_on_output(self._output_mode, active, line)
 			case CompletedEvent(task=t, completion=c, timestamp=ts), Active(output=buf):
-				emit_line(fmt_completed(opts, t, c, ts))
-				emit(block_for(opts.output_mode, t, c, buf))
+				emit_line(
+					fmt_completed(self._finished_fmt, self._failed_fmt, self._skipped_fmt, t, c, ts)
+				)
+				emit(block_for(self._output_mode, t, c, buf))
 				return Done()
 			case CompletedEvent(task=t, completion=c, timestamp=ts), Idle():
-				emit_line(fmt_completed(opts, t, c, ts))
+				emit_line(
+					fmt_completed(self._finished_fmt, self._failed_fmt, self._skipped_fmt, t, c, ts)
+				)
 				return Done()
 			case _:
 				return ctx

--- a/src/camas/effect/summary.py
+++ b/src/camas/effect/summary.py
@@ -51,21 +51,6 @@ class Fixed(NamedTuple):
 TermWidth: TypeAlias = Auto | Fixed
 
 
-class SummaryOptions(NamedTuple):
-	"""Configuration for the summary Effect.
-
-	>>> SummaryOptions()
-	SummaryOptions(term_width=Auto(), show_passing=False)
-	>>> SummaryOptions(term_width=Fixed(120)).term_width
-	Fixed(columns=120)
-	>>> SummaryOptions(show_passing=True).show_passing
-	True
-	"""
-
-	term_width: TermWidth = Auto()
-	show_passing: bool = False
-
-
 @dataclass
 class SummaryState:
 	"""Mutable slot holding the latest states view for the Summary effect."""
@@ -98,17 +83,18 @@ class Summary:
 	produces garbage. End-state output matches ``Termtree``'s final frame.
 	"""
 
-	def __init__(self, options: SummaryOptions = SummaryOptions()) -> None:
-		self.options: Final = options
+	def __init__(self, term_width: TermWidth = Auto(), show_passing: bool = False) -> None:
+		self._term_width: Final = term_width
+		self._show_passing: Final = show_passing
 
 	async def setup(self, task: TaskNode) -> SummaryContext:
-		match self.options.term_width:
+		match self._term_width:
 			case Auto():
 				term_width = shutil.get_terminal_size().columns
 			case Fixed(columns=columns):
 				term_width = columns
 			case _:
-				assert_never(self.options.term_width)
+				assert_never(self._term_width)
 		return SummaryContext(
 			rows=flatten_rows(task),
 			term_width=term_width,
@@ -142,5 +128,5 @@ class Summary:
 		sys.stdout.buffer.write(("\n".join(cleaned) + "\n").encode("utf-8", errors="replace"))
 		sys.stdout.flush()
 		print_failures(ctx.state.states, ctx.term_width)
-		if self.options.show_passing:
+		if self._show_passing:
 			print_passes(ctx.state.states, ctx.term_width)

--- a/src/camas/effect/termtree.py
+++ b/src/camas/effect/termtree.py
@@ -53,21 +53,6 @@ def fit_label(text: str, max_width: int) -> str:
 	return text if len(text) <= max_width else truncate_middle(text, max(max_width, 3))
 
 
-class TermtreeOptions(NamedTuple):
-	"""Configuration for the termtree Effect.
-
-	>>> TermtreeOptions()
-	TermtreeOptions(frame_interval_ms=16.667, show_passing=False)
-	>>> TermtreeOptions(frame_interval_ms=50).frame_interval_ms
-	50
-	>>> TermtreeOptions(show_passing=True).show_passing
-	True
-	"""
-
-	frame_interval_ms: float = 16.667
-	show_passing: bool = False
-
-
 CLEAR_LINE: Final = "\033[K"
 SPINNER: Final = (
 	" ▌    ",
@@ -390,8 +375,9 @@ class Termtree:
 	how fast events arrive.
 	"""
 
-	def __init__(self, options: TermtreeOptions = TermtreeOptions()) -> None:
-		self.options: Final = options
+	def __init__(self, frame_interval_ms: float = 16.667, show_passing: bool = False) -> None:
+		self._frame_interval_ms: Final = frame_interval_ms
+		self._show_passing: Final = show_passing
 
 	async def setup(self, task: TaskNode) -> TermtreeContext:
 		term_width: Final = (  # zuban: ignore[misc] # zuban defies PEP591
@@ -411,9 +397,7 @@ class Termtree:
 		sys.stdout.write("\n" * len(rows))
 		sys.stdout.flush()
 		draw(ctx)
-		ctx.state.tick_task = asyncio.create_task(
-			tick_loop(ctx, self.options.frame_interval_ms / 1000)
-		)
+		ctx.state.tick_task = asyncio.create_task(tick_loop(ctx, self._frame_interval_ms / 1000))
 		return ctx
 
 	async def on_event(
@@ -432,7 +416,7 @@ class Termtree:
 		sys.stdout.write("\n")
 		sys.stdout.flush()
 		print_failures(ctx.state.states, ctx.term_width)
-		if self.options.show_passing:
+		if self._show_passing:
 			print_passes(ctx.state.states, ctx.term_width)
 
 

--- a/src/camas/main/effects.py
+++ b/src/camas/main/effects.py
@@ -193,7 +193,7 @@ def parse_effects(
 
 	>>> [type(e).__name__ for e in parse_effects("(Summary(),)")]
 	['Summary']
-	>>> parse_effects("(Summary(options=SummaryOptions(term_width=Fixed(80))),)")[0].options.term_width
+	>>> parse_effects("(Summary(term_width=Fixed(80)),)")[0]._term_width
 	Fixed(columns=80)
 	>>> parse_effects("()")
 	()

--- a/src/camas/main/parser.py
+++ b/src/camas/main/parser.py
@@ -44,13 +44,13 @@ def default_effects_expr() -> str:
 	'(Termtree(),)'
 	>>> os.environ["GITHUB_ACTIONS"] = "true"
 	>>> default_effects_expr()
-	'(Status(StatusOptions(output_mode="github")),)'
+	'(Status(output_mode="github"),)'
 	>>> os.environ.pop("GITHUB_ACTIONS", None)
 	'true'
 	>>> _ = os.environ.update({"GITHUB_ACTIONS": _saved}) if _saved is not None else None
 	"""
 	if os.environ.get("GITHUB_ACTIONS") == "true":
-		return '(Status(StatusOptions(output_mode="github")),)'
+		return '(Status(output_mode="github"),)'
 	return "(Termtree(),)"
 
 

--- a/tests/effect/test_github_checks.py
+++ b/tests/effect/test_github_checks.py
@@ -24,7 +24,6 @@ from camas.effect.github_checks import (
 	Active,
 	Closed,
 	GitHubChecks,
-	GitHubChecksOptions,
 	PatchPayload,
 	Pending,
 	ResolvedConfig,
@@ -86,17 +85,24 @@ async def wrap_raise_none(exc: BaseException) -> None:
 	raise exc
 
 
-def test_options_defaults() -> None:
-	o = GitHubChecksOptions()
-	assert (o.token, o.repository, o.sha) == (None, None, None)
-	assert (o.name_prefix, o.tail_bytes, o.fail_on_api_error) == ("", 8192, False)
+async def test_default_construction_resolves_config_defaults(
+	monkeypatch: pytest.MonkeyPatch,
+) -> None:
+	"""Bare ``GitHubChecks()`` resolves identity from env and applies the
+	name_prefix/tail_bytes/fail_on_api_error constructor defaults."""
+	set_gh_env(monkeypatch)
+	effect = GitHubChecks()
+	await effect.setup(Task("x"))
+	assert effect.state is not None
+	assert effect.state.cfg == ResolvedConfig("t", "o", "r", "sha", "", 8192, False)
+	await effect.state.http.aclose()
 
 
 def test_resolve_config_reads_env_when_options_none(monkeypatch: pytest.MonkeyPatch) -> None:
 	monkeypatch.setenv("GITHUB_TOKEN", "env-token")
 	monkeypatch.setenv("GITHUB_REPOSITORY", "env-owner/env-repo")
 	monkeypatch.setenv("GITHUB_SHA", "env-sha")
-	cfg = resolve_config(GitHubChecksOptions())
+	cfg = resolve_config(None, None, None, "", 8192, False)
 	assert cfg == ResolvedConfig("env-token", "env-owner", "env-repo", "env-sha", "", 8192, False)
 
 
@@ -104,11 +110,7 @@ def test_resolve_config_explicit_overrides_env(monkeypatch: pytest.MonkeyPatch) 
 	monkeypatch.setenv("GITHUB_TOKEN", "env-token")
 	monkeypatch.setenv("GITHUB_REPOSITORY", "env-o/env-r")
 	monkeypatch.setenv("GITHUB_SHA", "env-sha")
-	cfg = resolve_config(
-		GitHubChecksOptions(
-			token="explicit", repository="o/r", sha="s", name_prefix="p/", tail_bytes=10
-		)
-	)
+	cfg = resolve_config("explicit", "o/r", "s", "p/", 10, False)
 	assert cfg.token == "explicit"
 	assert (cfg.owner, cfg.repo) == ("o", "r")
 	assert cfg.sha == "s"
@@ -119,19 +121,19 @@ def test_resolve_config_explicit_overrides_env(monkeypatch: pytest.MonkeyPatch) 
 def test_resolve_config_missing_token_raises(monkeypatch: pytest.MonkeyPatch) -> None:
 	clear_gh_env(monkeypatch)
 	with pytest.raises(RuntimeError, match="GITHUB_TOKEN"):
-		resolve_config(GitHubChecksOptions(repository="o/r", sha="s"))
+		resolve_config(None, "o/r", "s", "", 8192, False)
 
 
 def test_resolve_config_missing_repository_raises(monkeypatch: pytest.MonkeyPatch) -> None:
 	clear_gh_env(monkeypatch)
 	with pytest.raises(RuntimeError, match="GITHUB_REPOSITORY"):
-		resolve_config(GitHubChecksOptions(token="t", sha="s"))
+		resolve_config("t", None, "s", "", 8192, False)
 
 
 def test_resolve_config_missing_sha_raises(monkeypatch: pytest.MonkeyPatch) -> None:
 	clear_gh_env(monkeypatch)
 	with pytest.raises(RuntimeError, match="GITHUB_SHA"):
-		resolve_config(GitHubChecksOptions(token="t", repository="o/r"))
+		resolve_config("t", "o/r", None, "", 8192, False)
 
 
 @pytest.mark.parametrize("repo", ["no-slash", "o/", "/r", "o/r/extra", "/", ""])
@@ -140,7 +142,7 @@ def test_resolve_config_malformed_repository_raises(
 ) -> None:
 	clear_gh_env(monkeypatch)
 	with pytest.raises(RuntimeError):
-		resolve_config(GitHubChecksOptions(token="t", repository=repo, sha="s"))
+		resolve_config("t", repo, "s", "", 8192, False)
 
 
 def test_auth_headers_format() -> None:
@@ -417,7 +419,7 @@ async def test_on_event_started_spawns_post_task(monkeypatch: pytest.MonkeyPatch
 
 	monkeypatch.setattr("camas.effect.github_checks.post_check_run", fake_post)
 
-	effect = GitHubChecks(GitHubChecksOptions(name_prefix="pfx/"))
+	effect = GitHubChecks(name_prefix="pfx/")
 	ctx = await effect.setup(Task("x"))
 	t = Task("cmd", name="lint")
 	ctx = await effect.on_event(StartedEvent(t, 0, TS), [], ctx)
@@ -438,7 +440,7 @@ async def test_on_event_output_accumulates_and_trims_tail(
 
 	monkeypatch.setattr("camas.effect.github_checks.post_check_run", fake_post)
 
-	effect = GitHubChecks(GitHubChecksOptions(tail_bytes=5))
+	effect = GitHubChecks(tail_bytes=5)
 	ctx = await effect.setup(Task("x"))
 	t = Task("cmd", name="t")
 	ctx = await effect.on_event(StartedEvent(t, 0, TS), [], ctx)
@@ -521,7 +523,7 @@ async def test_teardown_fail_on_api_error_raises_exceptiongroup(
 	monkeypatch: pytest.MonkeyPatch,
 ) -> None:
 	set_gh_env(monkeypatch)
-	effect = GitHubChecks(GitHubChecksOptions(fail_on_api_error=True))
+	effect = GitHubChecks(fail_on_api_error=True)
 	await effect.setup(Task("x"))
 	bad = asyncio.create_task(wrap_raise_none(RuntimeError("boom")))
 	with pytest.raises(BaseExceptionGroup) as ei:

--- a/tests/effect/test_status.py
+++ b/tests/effect/test_status.py
@@ -17,7 +17,6 @@ from camas.effect.status import (
 	Done,
 	Idle,
 	Status,
-	StatusOptions,
 )
 from camas.v0.completion import Finished, Skipped
 from camas.v0.leaf_state import LeafState, Waiting
@@ -86,7 +85,7 @@ def test_all_mode_dumps_every_block(capsys: pytest.CaptureFixture[str]) -> None:
 		OutputEvent(a, 0, b"hello\n", TS),
 		CompletedEvent(a, 0, Finished(0, 0.1, ()), TS),
 	]
-	asyncio.run(drive(Status(StatusOptions(output_mode="all")), task, events))
+	asyncio.run(drive(Status(output_mode="all"), task, events))
 	out = capsys.readouterr().out
 	assert "✓ [alpha] success" in out
 	assert "hello" in out
@@ -100,7 +99,7 @@ def test_quiet_mode_drops_output(capsys: pytest.CaptureFixture[str]) -> None:
 		OutputEvent(a, 0, b"shhh\n", TS),
 		CompletedEvent(a, 0, Finished(0, 0.1, ()), TS),
 	]
-	ctxs = asyncio.run(drive(Status(StatusOptions(output_mode="quiet")), task, events))
+	ctxs = asyncio.run(drive(Status(output_mode="quiet"), task, events))
 	out = capsys.readouterr().out
 	assert "▶ [alpha] started" in out
 	assert "✓ [alpha] success" in out
@@ -119,7 +118,7 @@ def test_stream_mode_emits_lines_live_and_strips_ansi(
 		OutputEvent(a, 0, b"plain\n", TS),
 		CompletedEvent(a, 0, Finished(0, 0.1, ()), TS),
 	]
-	asyncio.run(drive(Status(StatusOptions(output_mode="stream")), task, events))
+	asyncio.run(drive(Status(output_mode="stream"), task, events))
 	out = capsys.readouterr().out
 	assert "[lint]\x1b[0m red line" in out
 	assert "[lint]\x1b[0m plain" in out
@@ -143,7 +142,7 @@ def test_stream_mode_interleaves_across_parallel_tasks(
 		CompletedEvent(a, 0, Finished(0, 0.1, ()), TS),
 		CompletedEvent(b, 1, Finished(0, 0.2, ()), TS),
 	]
-	asyncio.run(drive(Status(StatusOptions(output_mode="stream")), task, events))
+	asyncio.run(drive(Status(output_mode="stream"), task, events))
 	out = capsys.readouterr().out
 	a1 = out.index("[fast]\x1b[0m a1")
 	b1 = out.index("[slow]\x1b[0m b1")
@@ -162,7 +161,7 @@ def test_github_mode_wraps_blocks_with_workflow_commands(
 		OutputEvent(a, 0, b"PASSED 7 tests\n", TS),
 		CompletedEvent(a, 0, Finished(0, 0.4, ()), TS),
 	]
-	asyncio.run(drive(Status(StatusOptions(output_mode="github")), task, events))
+	asyncio.run(drive(Status(output_mode="github"), task, events))
 	out = capsys.readouterr().out
 	assert "✓ [test] success" in out
 	assert "::group::test\n" in out
@@ -179,7 +178,7 @@ def test_skipped_emits_skip_line_only(capsys: pytest.CaptureFixture[str]) -> Non
 		CompletedEvent(first, 0, Finished(1, 0.1, ()), TS),
 		CompletedEvent(second, 1, Skipped(1), TS),
 	]
-	asyncio.run(drive(Status(StatusOptions(output_mode="all")), task, events))
+	asyncio.run(drive(Status(output_mode="all"), task, events))
 	out = capsys.readouterr().out
 	assert "✗ [first] error" in out
 	assert "exit=1" in out
@@ -197,7 +196,7 @@ def test_empty_template_suppresses_line(capsys: pytest.CaptureFixture[str]) -> N
 	]
 	asyncio.run(
 		drive(
-			Status(StatusOptions(started_fmt="", finished_fmt="✓ {name}")),
+			Status(started_fmt="", finished_fmt="✓ {name}"),
 			task,
 			events,
 		)
@@ -219,10 +218,8 @@ def test_custom_format_string_substitutes_all_fields(
 	asyncio.run(
 		drive(
 			Status(
-				StatusOptions(
-					started_fmt="{timestamp:%H:%M:%S}.{ms:03d} START {name} [{cmd}]",
-					finished_fmt="OK {name} {elapsed:.3f}s rc={rc}",
-				)
+				started_fmt="{timestamp:%H:%M:%S}.{ms:03d} START {name} [{cmd}]",
+				finished_fmt="OK {name} {elapsed:.3f}s rc={rc}",
 			),
 			task,
 			events,
@@ -242,7 +239,7 @@ def test_missing_field_in_template_raises_keyerror() -> None:
 	with pytest.raises(KeyError):
 		asyncio.run(
 			drive(
-				Status(StatusOptions(started_fmt="{name} {elapsed:.2f}")),
+				Status(started_fmt="{name} {elapsed:.2f}"),
 				task,
 				events,
 			)
@@ -264,7 +261,7 @@ def test_block_modes_buffer_into_active_ctx(capsys: pytest.CaptureFixture[str]) 
 		OutputEvent(a, 0, b"one\n", TS),
 		OutputEvent(a, 0, b"two\n", TS),
 	]
-	ctxs = asyncio.run(drive(Status(StatusOptions(output_mode="all")), task, events))
+	ctxs = asyncio.run(drive(Status(output_mode="all"), task, events))
 	assert ctxs == (Active(b"one\ntwo\n"),)
 	out = capsys.readouterr().out
 	assert "▶ [alpha] started" in out
@@ -318,7 +315,7 @@ def test_block_appends_newline_when_output_lacks_one(
 		OutputEvent(a, 0, b"no-trailing-newline", TS),
 		CompletedEvent(a, 0, Finished(2, 0.1, ()), TS),
 	]
-	asyncio.run(drive(Status(StatusOptions(output_mode="errors")), task, events))
+	asyncio.run(drive(Status(output_mode="errors"), task, events))
 	out = capsys.readouterr().out
 	assert "no-trailing-newline\n" in out
 
@@ -331,7 +328,7 @@ def test_errors_mode_skips_block_on_pass(capsys: pytest.CaptureFixture[str]) -> 
 		OutputEvent(a, 0, b"all good\n", TS),
 		CompletedEvent(a, 0, Finished(0, 0.1, ()), TS),
 	]
-	asyncio.run(drive(Status(StatusOptions(output_mode="errors")), task, events))
+	asyncio.run(drive(Status(output_mode="errors"), task, events))
 	out = capsys.readouterr().out
 	assert "✓ [ok] success" in out
 	assert "all good" not in out
@@ -358,5 +355,5 @@ def test_discoverable_via_parse_effects() -> None:
 	effects = parse_effects("(Status(),)")
 	assert len(effects) == 1
 	assert type(effects[0]).__name__ == "Status"
-	effects2 = parse_effects("(Status(StatusOptions(output_mode='github')),)")
+	effects2 = parse_effects("(Status(output_mode='github'),)")
 	assert type(effects2[0]).__name__ == "Status"

--- a/tests/effect/test_summary.py
+++ b/tests/effect/test_summary.py
@@ -8,7 +8,7 @@ from datetime import datetime
 from typing import TYPE_CHECKING, TypeVar
 
 from camas import Parallel, Sequential, Task
-from camas.effect.summary import Fixed, Summary, SummaryOptions
+from camas.effect.summary import Fixed, Summary
 from camas.v0.completion import Finished, Skipped
 from camas.v0.leaf_state import LeafState, Waiting
 from camas.v0.task_event import CompletedEvent, StartedEvent, TaskEvent
@@ -62,7 +62,7 @@ def test_summary_renders_only_at_teardown(capsys: pytest.CaptureFixture[str]) ->
 	]
 
 	async def run_and_capture() -> tuple[str, str]:
-		effect = Summary(SummaryOptions())
+		effect = Summary()
 		from camas.core.leaf_state import next_state
 		from camas.core.traversal import flatten_leaves
 
@@ -92,7 +92,7 @@ def test_summary_failure_prints_details(capsys: pytest.CaptureFixture[str]) -> N
 		StartedEvent(a, 0, TS),
 		CompletedEvent(a, 0, Finished(1, 0.1, (b"error details\n",)), TS),
 	]
-	asyncio.run(drive(Summary(SummaryOptions()), task, events))
+	asyncio.run(drive(Summary(), task, events))
 	out = capsys.readouterr().out
 	assert "FAIL" in out
 	assert "FAILED: boom" in out
@@ -108,7 +108,7 @@ def test_summary_sequential_skipped(capsys: pytest.CaptureFixture[str]) -> None:
 		CompletedEvent(a, 0, Finished(1, 0.1, (b"failed\n",)), TS),
 		CompletedEvent(b, 1, Skipped(1), TS),
 	]
-	asyncio.run(drive(Summary(SummaryOptions()), task, events))
+	asyncio.run(drive(Summary(), task, events))
 	out = capsys.readouterr().out
 	assert "pipeline" in out
 	assert "SKIP" in out
@@ -117,7 +117,7 @@ def test_summary_sequential_skipped(capsys: pytest.CaptureFixture[str]) -> None:
 
 def test_summary_fixed_width_overrides_terminal_detection() -> None:
 	async def capture_width() -> int:
-		effect = Summary(SummaryOptions(term_width=Fixed(160)))
+		effect = Summary(term_width=Fixed(160))
 		ctx = await effect.setup(make_task("solo"))
 		return ctx.term_width
 
@@ -134,7 +134,7 @@ def test_summary_show_passing_prints_passed_output(capsys: pytest.CaptureFixture
 		CompletedEvent(a, 0, Finished(0, 0.1, (b"alpha output\n",)), TS),
 		CompletedEvent(b, 1, Finished(1, 0.2, (b"beta error\n",)), TS),
 	]
-	asyncio.run(drive(Summary(SummaryOptions(show_passing=True)), task, events))
+	asyncio.run(drive(Summary(show_passing=True), task, events))
 	out = capsys.readouterr().out
 	assert "FAILED: beta" in out
 	assert "beta error" in out
@@ -149,7 +149,7 @@ def test_summary_show_passing_defaults_to_false(capsys: pytest.CaptureFixture[st
 		StartedEvent(a, 0, TS),
 		CompletedEvent(a, 0, Finished(0, 0.1, (b"alpha output\n",)), TS),
 	]
-	asyncio.run(drive(Summary(SummaryOptions()), task, events))
+	asyncio.run(drive(Summary(), task, events))
 	out = capsys.readouterr().out
 	assert "PASSED:" not in out
 
@@ -164,7 +164,7 @@ def test_summary_creates_no_background_tasks() -> None:
 	async def count_tasks_after_teardown() -> int:
 		before: Callable[[], set[asyncio.Task[object]]] = asyncio.all_tasks
 		baseline = before()
-		await drive(Summary(SummaryOptions()), task, events)
+		await drive(Summary(), task, events)
 		return len(asyncio.all_tasks() - baseline)
 
 	assert asyncio.run(count_tasks_after_teardown()) == 0

--- a/tests/effect/test_termtree.py
+++ b/tests/effect/test_termtree.py
@@ -16,7 +16,6 @@ from camas.core.render import flatten_rows, strip_ansi
 from camas.effect.termtree import (
 	STATUS_COL_WIDTH,
 	Termtree,
-	TermtreeOptions,
 	print_failures,
 	print_passes,
 	render_frame,
@@ -145,7 +144,7 @@ def test_termtree_show_passing_prints_passed_output(
 	]
 	asyncio.run(
 		drive(
-			Termtree(TermtreeOptions(frame_interval_ms=50, show_passing=True)),
+			Termtree(frame_interval_ms=50, show_passing=True),
 			task,
 			events,
 		)
@@ -166,7 +165,7 @@ def test_termtree_show_passing_defaults_to_false(
 		StartedEvent(a, 0, TS),
 		CompletedEvent(a, 0, Finished(0, 0.1, (b"quiet\n",)), TS),
 	]
-	asyncio.run(drive(Termtree(TermtreeOptions(frame_interval_ms=50)), task, events))
+	asyncio.run(drive(Termtree(frame_interval_ms=50), task, events))
 	captured = capsys.readouterr()
 	assert "PASSED:" not in captured.out
 
@@ -184,7 +183,7 @@ def test_termtree_effect_consumes_events_and_renders(
 		CompletedEvent(a, 0, Finished(0, 0.1, (b"line from a\n",)), TS),
 		CompletedEvent(b, 1, Finished(1, 0.2, (b"boom\n",)), TS),
 	]
-	asyncio.run(drive(Termtree(TermtreeOptions(frame_interval_ms=50)), task, events))
+	asyncio.run(drive(Termtree(frame_interval_ms=50), task, events))
 	captured = capsys.readouterr()
 	assert "FAILED: b" in captured.out
 
@@ -194,7 +193,7 @@ def test_termtree_frame_tick_keeps_spinner_alive_between_events() -> None:
 	task = make_task("solo")
 
 	async def run_effect() -> bool:
-		effect = Termtree(TermtreeOptions(frame_interval_ms=20))
+		effect = Termtree(frame_interval_ms=20)
 		ctx = await effect.setup(task)
 		# Idle for long enough that several ticks fire while nothing is happening.
 		await asyncio.sleep(0.08)
@@ -223,7 +222,7 @@ def test_termtree_effect_handles_groups_and_skipped(
 		CompletedEvent(a, 0, Finished(1, 0.1, (b"failed\n",)), TS),
 		CompletedEvent(b, 1, Skipped(1), TS),
 	]
-	asyncio.run(drive(Termtree(TermtreeOptions(frame_interval_ms=50)), task, events))
+	asyncio.run(drive(Termtree(frame_interval_ms=50), task, events))
 	captured = capsys.readouterr()
 	assert "pipeline" in captured.out
 	assert "SKIP" in captured.out

--- a/tests/main/test_effects.py
+++ b/tests/main/test_effects.py
@@ -45,26 +45,23 @@ def test_parse_effects_rejects_unknown_effect() -> None:
 
 def test_parse_effects_rejects_non_effect_value() -> None:
 	with pytest.raises(ValueError, match="expected an Effect"):
-		parse_effects("(SummaryOptions(),)")
+		parse_effects("(42,)")
 
 
 def test_discover_effects_returns_builtin_set() -> None:
 	constructors, effects = discover_effects()
 	names = {n for n, _ in effects}
 	assert names == {"Summary", "Termtree", "GitHubChecks", "Status"}
-	assert "SummaryOptions" in constructors
 	assert "Auto" in constructors
 	assert "Fixed" in constructors
-	assert "GitHubChecksOptions" in constructors
 
 
-def test_parse_effects_constructs_github_checks_with_options() -> None:
-	out = parse_effects('(GitHubChecks(GitHubChecksOptions(name_prefix="pfx/")),)')
+def test_parse_effects_constructs_github_checks_with_kwarg() -> None:
+	out = parse_effects('(GitHubChecks(name_prefix="pfx/"),)')
 	assert len(out) == 1
 	from camas.effect.github_checks import GitHubChecks
 
 	assert isinstance(out[0], GitHubChecks)
-	assert out[0].options.name_prefix == "pfx/"
 
 
 def test_available_effects_merges_scope_into_builtins() -> None:
@@ -145,9 +142,9 @@ def test_reachable_classes_seen_short_circuit() -> None:
 
 
 def test_signature_fields_namedtuple_with_defaults() -> None:
-	from camas.effect.summary import SummaryOptions
+	from camas.effect.summary import Summary
 
-	fields = signature_fields(SummaryOptions)
+	fields = signature_fields(Summary)
 	names = [n for n, _, _, _ in fields]
 	assert names == ["term_width", "show_passing"]
 

--- a/tests/main/test_format.py
+++ b/tests/main/test_format.py
@@ -309,5 +309,4 @@ def test_format_signature_with_fields_and_nested() -> None:
 
 	out = "\n".join(format_signature(Summary, indent="", color=False))
 	assert "Summary(" in out
-	assert "SummaryOptions(" in out
 	assert "Auto()" in out

--- a/tests/main/test_init.py
+++ b/tests/main/test_init.py
@@ -77,7 +77,7 @@ def test_starter_runs_to_completion(tmp_path: Path) -> None:
 	"""Bare ``camas`` in a freshly scaffolded directory runs the whole default
 	tree green — the placeholder tasks must be infallible cross-platform."""
 	write_starter_tasks_py(tmp_path)
-	result = _camas("--effects=(Summary(SummaryOptions(show_passing=True)),)", cwd=tmp_path)
+	result = _camas("--effects=(Summary(show_passing=True),)", cwd=tmp_path)
 	assert result.returncode == 0, result.stderr
 	assert "hello from camas" in result.stdout
 	assert "hello, Ada!" in result.stdout

--- a/tests/main/test_mypyc.py
+++ b/tests/main/test_mypyc.py
@@ -18,25 +18,24 @@ if TYPE_CHECKING:
 
 
 def test_signature_fields_from_source_namedtuple() -> None:
-	from camas.effect.summary import SummaryOptions
+	from camas.effect.summary import Fixed
 
-	out = signature_fields_from_source(SummaryOptions)
+	out = signature_fields_from_source(Fixed)
 	assert out is not None
 	names = [n for n, _, _, _ in out]
-	assert names == ["term_width", "show_passing"]
+	assert names == ["columns"]
 
 
 def test_signature_fields_from_source_regular_class() -> None:
-	from camas.effect.summary import Summary, SummaryOptions
+	from camas.effect.summary import Auto, Summary
 
 	out = signature_fields_from_source(Summary)
 	assert out is not None
-	assert len(out) == 1
-	name, _kind, annot, default = out[0]
-	assert name == "options"
-	assert "SummaryOptions" in str(annot)
-	assert SummaryOptions.__name__ in str(annot)
-	assert default == SummaryOptions()
+	names = [n for n, _, _, _ in out]
+	assert names == ["term_width", "show_passing"]
+	defaults = {n: d for n, _, _, d in out}
+	assert defaults["term_width"] == Auto()
+	assert defaults["show_passing"] is False
 
 
 def test_signature_fields_from_source_module_not_loaded() -> None:
@@ -150,15 +149,15 @@ def test_signature_fields_falls_back_for_compiled_namedtuple(
 	source-parse path."""
 	import typing as _typing
 
-	from camas.effect.summary import SummaryOptions
+	from camas.effect.summary import Fixed
 
 	def fake_hints(_obj: object) -> dict[str, object]:
-		return {"term_width": type, "show_passing": bool}
+		return {"columns": type}
 
 	monkeypatch.setattr(_typing, "get_type_hints", fake_hints)
-	out = signature_fields(SummaryOptions)
-	annot_term = next(annot for n, _, annot, _ in out if n == "term_width")
-	assert "Auto" in str(annot_term) or "Fixed" in str(annot_term)
+	out = signature_fields(Fixed)
+	annot_cols = next(annot for n, _, annot, _ in out if n == "columns")
+	assert "int" in str(annot_cols)
 
 
 def test_signature_fields_falls_back_for_compiled_class(
@@ -175,15 +174,15 @@ def test_signature_fields_falls_back_for_compiled_class(
 		return _inspect.Signature(
 			parameters=[
 				_inspect.Parameter(
-					"options", _inspect.Parameter.POSITIONAL_OR_KEYWORD, default=None
+					"term_width", _inspect.Parameter.POSITIONAL_OR_KEYWORD, default=None
 				)
 			]
 		)
 
 	monkeypatch.setattr(_inspect, "signature", fake_signature)
 	out = signature_fields(Summary)
-	annot = next(annot for n, _, annot, _ in out if n == "options")
-	assert "SummaryOptions" in str(annot)
+	annot = next(annot for n, _, annot, _ in out if n == "term_width")
+	assert "Auto" in str(annot) or "Fixed" in str(annot)
 
 
 def test_signature_fields_namedtuple_fallback_returns_none(
@@ -251,8 +250,8 @@ def test_signature_fields_falls_back_when_inspect_signature_raises(
 
 	monkeypatch.setattr(_inspect, "signature", boom)
 	out = signature_fields(Summary)
-	annot = next(annot for n, _, annot, _ in out if n == "options")
-	assert "SummaryOptions" in str(annot)
+	annot = next(annot for n, _, annot, _ in out if n == "term_width")
+	assert "Auto" in str(annot) or "Fixed" in str(annot)
 
 
 def test_signature_fields_namedtuple_unresolvable_hints(

--- a/tests/test_config_fixture.py
+++ b/tests/test_config_fixture.py
@@ -12,7 +12,7 @@ from camas import Parallel, Sequential, Task
 from camas.main.tasks import load_tasks_from_py
 
 FIXTURE = Path(__file__).parent / "fixtures" / "config" / "tasks.py"
-SUMMARY = "--effects=(Summary(SummaryOptions(show_passing=True)),)"
+SUMMARY = "--effects=(Summary(show_passing=True),)"
 
 
 def _camas(*args: str, github: bool) -> subprocess.CompletedProcess[str]:

--- a/tests/test_demos.py
+++ b/tests/test_demos.py
@@ -10,7 +10,7 @@ import pytest
 
 from camas import Parallel, Sequential, Task
 from camas.core.execution import run
-from camas.effect.termtree import Termtree, TermtreeOptions
+from camas.effect.termtree import Termtree
 
 app = cyclopts.App()
 
@@ -57,7 +57,7 @@ def test_demo_parallel_5_tasks() -> None:
 		),
 		sleep_task(1.5, "test"),
 	)
-	assert asyncio.run(run(task, effects=(Termtree(TermtreeOptions()),))).returncode == 0
+	assert asyncio.run(run(task, effects=(Termtree(),))).returncode == 0
 
 
 @app.command
@@ -70,7 +70,7 @@ def test_demo_parallel_with_failure() -> None:
 		sleep_task(0.3, "pyright"),
 		sleep_task(1.0, "test"),
 	)
-	assert asyncio.run(run(task, effects=(Termtree(TermtreeOptions()),))).returncode == 1
+	assert asyncio.run(run(task, effects=(Termtree(),))).returncode == 1
 
 
 @app.command
@@ -87,7 +87,7 @@ def test_demo_sequential_3_steps() -> None:
 			0.3, "deploy", ("uploading artifact", "restarting service", "deployed to staging")
 		),
 	)
-	assert asyncio.run(run(task, effects=(Termtree(TermtreeOptions()),))).returncode == 0
+	assert asyncio.run(run(task, effects=(Termtree(),))).returncode == 0
 
 
 @app.command
@@ -99,7 +99,7 @@ def test_demo_sequential_fail_skips() -> None:
 		sleep_task(0.3, "deploy"),
 		sleep_task(0.3, "notify"),
 	)
-	assert asyncio.run(run(task, effects=(Termtree(TermtreeOptions()),))).returncode == 1
+	assert asyncio.run(run(task, effects=(Termtree(),))).returncode == 1
 
 
 @app.command
@@ -110,7 +110,7 @@ def test_demo_nested_parallel_in_sequential() -> None:
 		Parallel(sleep_task(0.8, "mypy"), sleep_task(0.7, "pyright")),
 		sleep_task(1.0, "test"),
 	)
-	assert asyncio.run(run(task, effects=(Termtree(TermtreeOptions()),))).returncode == 0
+	assert asyncio.run(run(task, effects=(Termtree(),))).returncode == 0
 
 
 @app.command
@@ -131,14 +131,14 @@ def test_demo_nested_sequential_in_parallel() -> None:
 		),
 		lorem_task(0.5, "lint", ("scanning", "checking imports", "no issues")),
 	)
-	assert asyncio.run(run(task, effects=(Termtree(TermtreeOptions()),))).returncode == 0
+	assert asyncio.run(run(task, effects=(Termtree(),))).returncode == 0
 
 
 @app.command
 @pytest.mark.slow
 def test_demo_matrix_python_versions() -> None:
 	task = Parallel(sleep_task(0.8, "test {PY}"), matrix={"PY": ("3.12", "3.13", "3.14")})
-	assert asyncio.run(run(task, effects=(Termtree(TermtreeOptions()),))).returncode == 0
+	assert asyncio.run(run(task, effects=(Termtree(),))).returncode == 0
 
 
 @app.command
@@ -148,7 +148,7 @@ def test_demo_matrix_2d() -> None:
 		sleep_task(0.6, "{DB}/{OPT}"),
 		matrix={"DB": ("sqlite", "postgres"), "OPT": ("debug", "release")},
 	)
-	assert asyncio.run(run(task, effects=(Termtree(TermtreeOptions()),))).returncode == 0
+	assert asyncio.run(run(task, effects=(Termtree(),))).returncode == 0
 
 
 @app.command
@@ -160,7 +160,7 @@ def test_demo_sequential_matrix_clones() -> None:
 		name="ci",
 		matrix={"PY": ("3.12", "3.13", "3.14")},
 	)
-	assert asyncio.run(run(task, effects=(Termtree(TermtreeOptions()),))).returncode == 0
+	assert asyncio.run(run(task, effects=(Termtree(),))).returncode == 0
 
 
 @app.command
@@ -185,7 +185,7 @@ def test_demo_deeply_nested_with_output() -> None:
 		),
 		lorem_task(0.2, "package", ("tarring", "artifact created")),
 	)
-	assert asyncio.run(run(task, effects=(Termtree(TermtreeOptions()),))).returncode == 0
+	assert asyncio.run(run(task, effects=(Termtree(),))).returncode == 0
 
 
 @app.command
@@ -213,7 +213,7 @@ def test_demo_deeply_nested_with_output_named() -> None:
 		lorem_task(0.2, "package", ("tarring", "artifact created")),
 		name="My App",
 	)
-	assert asyncio.run(run(task, effects=(Termtree(TermtreeOptions()),))).returncode == 0
+	assert asyncio.run(run(task, effects=(Termtree(),))).returncode == 0
 
 
 @app.command
@@ -230,7 +230,7 @@ def test_demo_matrix_full_ci_pipeline() -> None:
 		name="check",
 		matrix={"PY": ("3.13", "3.14")},
 	)
-	assert asyncio.run(run(task, effects=(Termtree(TermtreeOptions()),))).returncode == 0
+	assert asyncio.run(run(task, effects=(Termtree(),))).returncode == 0
 
 
 @app.command
@@ -245,7 +245,7 @@ def test_demo_matrix_2d_with_nesting() -> None:
 		name="ci",
 		matrix={"DB": ("sqlite", "postgres"), "OPT": ("debug", "release")},
 	)
-	assert asyncio.run(run(task, effects=(Termtree(TermtreeOptions()),))).returncode == 0
+	assert asyncio.run(run(task, effects=(Termtree(),))).returncode == 0
 
 
 if __name__ == "__main__":

--- a/tests/test_pep723_fixture.py
+++ b/tests/test_pep723_fixture.py
@@ -33,7 +33,7 @@ def test_pep723_runs_standalone() -> None:
 			str(FIXTURE),
 			"hello",
 			"--effects",
-			"(Summary(SummaryOptions(show_passing=True)),)",
+			"(Summary(show_passing=True),)",
 		],
 		capture_output=True,
 		text=True,


### PR DESCRIPTION
## What

The four single-purpose `*Options` NamedTuples (`StatusOptions`, `SummaryOptions`, `GitHubChecksOptions`, `TermtreeOptions`) wrapped a single constructor argument with no added value. Each effect now takes its option fields **directly**:

```python
# before
Status(StatusOptions(output_mode="all"))
Summary(SummaryOptions(show_passing=True))
GitHubChecks(GitHubChecksOptions(sha="…"))

# after
Status(output_mode="all")
Summary(show_passing=True)
GitHubChecks(sha="…")
```

Fields are stored as private attributes, mirroring the existing pattern.

## No feature lost

Every option (templates, modes, prefixes, widths, …) remains a constructor argument. Signature discovery is unchanged: the `--effects` mini-language, the `--help` Effects listing (still recurses into nested `Auto()`/`Fixed()`), and the **mypyc source-parse fallback** all read the flattened `__init__` and recover the same fields/defaults.

## Notable decisions

- **status**: the five default format templates became module constants (`STARTED_FMT`, …); the pure `fmt_started`/`fmt_completed`/`fmt_output` helpers take the template string(s) they use rather than an opts bundle.
- **github_checks**: `resolve_config` takes the six fields directly, so the defaults live in exactly one place (the constructor) — no two-place drift.
- **bugbear** `extend-immutable-calls` now lists `Auto` (`Summary`'s `term_width` default, the one remaining NamedTuple-in-a-default) instead of the deleted `*Options` types.

## Verification

`camas check` green across the board: `ruff format --check`, `ruff check`, **mypy / pyright / ty / zuban / pyrefly**, and pytest (`--doctest-modules`, 677 passed). Smoke-tested the real CLI flows (`Status(output_mode=…)`, nested `Summary(Fixed(90), True)`, custom `finished_fmt=`, the `--effects` listing) and the mypyc fallback recovering every flattened signature.

Rebased onto `main` (incorporates the #46 color-scheme work — `VIOLET` → `CAMAS_VIOLET`).

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)