### PR TITLE
feat(config): configurable default effects, surfaced in --help (closes #47)

### DIFF
--- a/src/camas/main/dispatch.py
+++ b/src/camas/main/dispatch.py
@@ -20,8 +20,9 @@ else:  # pragma: no cover
 from ..core.execution import run
 from ..core.matrix import matrix_axes, override_matrix
 from ..core.render import print_tree
+from ..v0.config import Config
 from .argv import apply_passthrough, parse_axis_values, parse_matrix_kv, split_passthrough
-from .effects import parse_effects
+from .effects import default_effect_names, resolve_effects
 from .expression import parse_expression
 from .format import (
 	format_load_error_hint,
@@ -148,14 +149,20 @@ def dispatch(state: TasksState, argv: list[str] | None = None) -> None:
 				print(format_load_error_hint(err.source, err.exception))
 				sys.exit(0)
 			if args.effects == "":
-				print_available_effects({})
+				print_available_effects(
+					{},
+					default_effect_names(
+						Config(), github=os.environ.get("GITHUB_ACTIONS") == "true"
+					),
+				)
 				sys.exit(0)
 			exit_for_load_err(err)
 
 		case LoadOk(tasks=tasks, source=source, scope_effects=scope_effects, config=config):
 			args, _leftover = parser.parse_known_args(split.head)
 			in_github: Final = os.environ.get("GITHUB_ACTIONS") == "true"
-			default_node: Final = config.bare_task(github=in_github) if config is not None else None
+			effective_config: Final = config if config is not None else Config()
+			default_node: Final = effective_config.bare_task(github=in_github)
 			axis_node: Final = (
 				tasks[args.expression]
 				if isinstance(args.expression, str) and args.expression in tasks
@@ -181,7 +188,11 @@ def dispatch(state: TasksState, argv: list[str] | None = None) -> None:
 				sys.exit(write_starter_tasks_py(Path.cwd()))
 
 			if args.list:
-				print_task_summary_listing(tasks, source)
+				print_task_summary_listing(
+					tasks,
+					source,
+					default_task_name=default_node.name if default_node is not None else None,
+				)
 				sys.exit(0)
 
 			if args.tree:
@@ -194,7 +205,9 @@ def dispatch(state: TasksState, argv: list[str] | None = None) -> None:
 				sys.exit(run_typecheck_only(source))
 
 			if args.effects == "":
-				print_available_effects(scope_effects)
+				print_available_effects(
+					scope_effects, default_effect_names(effective_config, github=in_github)
+				)
 				sys.exit(0)
 
 			resolved: TaskNode
@@ -213,7 +226,9 @@ def dispatch(state: TasksState, argv: list[str] | None = None) -> None:
 				resolved = dispatch_arg(args.expression, tasks)
 
 			try:
-				effects: Final = parse_effects(args.effects, scope_effects)
+				effects: Final = resolve_effects(
+					args.effects, effective_config, github=in_github, scope_effects=scope_effects
+				)
 			except ValueError as e:
 				print(f"error: --effects: {e}", file=sys.stderr)
 				sys.exit(2)

--- a/src/camas/main/effects.py
+++ b/src/camas/main/effects.py
@@ -16,6 +16,8 @@ from .mypyc import MISSING, signature_fields_from_source
 if TYPE_CHECKING:
 	from collections.abc import Mapping
 
+	from ..v0.config import Config
+
 
 @functools.cache
 def discover_effects() -> tuple[Mapping[str, Any], tuple[tuple[str, Any], ...]]:
@@ -240,3 +242,80 @@ def expect_effect(value: Any) -> Effect[Any]:
 	if not isinstance(value, Effect):
 		raise ValueError(f"expected an Effect instance, got {type(value).__name__}")
 	return value  # pyright: ignore[reportUnknownVariableType,reportReturnType]
+
+
+def resolve_default_effects(config: Config, *, github: bool) -> tuple[Effect[Any], ...]:
+	"""The effects a bare run uses in an environment: the :class:`Config` override,
+	else the engine's built-in default — live ``Termtree`` locally, ``Status('github')``
+	(collapsed workflow groups) under GitHub Actions. An explicit ``()`` override is
+	honored as "no effects".
+	"""
+	configured = config.effects(github=github)
+	if configured is not None:
+		return configured
+	from ..effect.status import Status
+	from ..effect.termtree import Termtree
+
+	return (Status(output_mode="github"),) if github else (Termtree(),)
+
+
+def default_effect_names(config: Config, *, github: bool) -> frozenset[str]:
+	"""Class names of the effects a bare run uses in this environment — used to mark
+	the ``(default)`` entry in the Available Effects listing.
+	"""
+	return frozenset(type(e).__name__ for e in resolve_default_effects(config, github=github))
+
+
+def resolve_effects(
+	expr: str | None,
+	config: Config,
+	*,
+	github: bool,
+	scope_effects: Mapping[str, type[Effect[Any]]] = {},
+) -> tuple[Effect[Any], ...]:
+	"""The effects for a run: the parsed ``--effects`` expression (propagating its
+	``ValueError`` on a malformed expression), or the environment default when
+	``--effects`` was omitted (``expr is None``).
+	"""
+	if expr is None:
+		return resolve_default_effects(config, github=github)
+	return parse_effects(expr, scope_effects)
+
+
+def format_effect_call(effect: Effect[Any]) -> str:
+	"""Render an Effect instance as a ``--effects`` mini-language call, showing
+	only the constructor arguments whose values differ from their defaults.
+
+	>>> from camas.effect.status import Status
+	>>> from camas.effect.termtree import Termtree
+	>>> format_effect_call(Termtree())
+	'Termtree()'
+	>>> format_effect_call(Status(output_mode="github"))
+	"Status(output_mode='github')"
+	"""
+	cls = type(effect)
+	args = ", ".join(
+		f"{name}={value!r}"
+		for name, _kind, _annotation, default in signature_fields(cls)
+		if (value := getattr(effect, f"_{name}", MISSING)) is not MISSING and value != default
+	)
+	return f"{cls.__name__}({args})"
+
+
+def format_effects_expr(effects: tuple[Effect[Any], ...]) -> str:
+	"""Render an effects tuple as a ``--effects`` mini-language expression — the
+	inverse of :func:`parse_effects` for the common case.
+
+	>>> from camas.effect.status import Status
+	>>> from camas.effect.termtree import Termtree
+	>>> format_effects_expr(())
+	'()'
+	>>> format_effects_expr((Termtree(),))
+	'(Termtree(),)'
+	>>> format_effects_expr((Termtree(), Status(output_mode="github")))
+	"(Termtree(), Status(output_mode='github'))"
+	"""
+	calls = [format_effect_call(e) for e in effects]
+	if len(calls) == 1:
+		return f"({calls[0]},)"
+	return f"({', '.join(calls)})"

--- a/src/camas/main/format.py
+++ b/src/camas/main/format.py
@@ -111,8 +111,12 @@ def format_task_summary_listing(
 	tasks: Mapping[str, TaskNode],
 	source: Path | None,
 	color: bool,
+	default_task_name: str | None = None,
 ) -> str:
-	"""Build the ``Available tasks from <source>`` listing as a string."""
+	"""Build the ``Available tasks from <source>`` listing as a string.
+
+	``default_task_name`` marks the task a bare ``camas`` runs with ``(default)``.
+	"""
 	if not tasks:
 		if source is not None:
 			return f"No tasks defined in {source}."
@@ -123,7 +127,8 @@ def format_task_summary_listing(
 		)
 	names = frozenset(tasks)
 	items = sorted(tasks.items())
-	width = max(len(n) for n, _ in items)
+	marker = " (default)"
+	width = max(len(n) + (len(marker) if n == default_task_name else 0) for n, _ in items)
 	header_text = f"Available tasks from {source}:" if source is not None else "Tasks:"
 	lines = [maybe_color(header_text, CAMAS_VIOLET, color)]
 	for name, node in items:
@@ -137,15 +142,27 @@ def format_task_summary_listing(
 			if isinstance(node, Task) or node.matrix is None
 			else f"  [matrix: {' '.join(format_axis(k, v) for k, v in node.matrix.items())}]"
 		)
+		marked = name == default_task_name
+		name_cell = maybe_color(name, BOLD_CYAN, color) + (
+			maybe_color(marker, GREY, color) if marked else ""
+		)
+		pad = " " * (width + 1 - len(name) - (len(marker) if marked else 0))
 		lines.append(
-			f"  {maybe_color(name.ljust(width + 1), BOLD_CYAN, color)} {body}"
-			f"{maybe_color(annotation, GREY, color) if annotation else ''}"
+			f"  {name_cell}{pad} {body}{maybe_color(annotation, GREY, color) if annotation else ''}"
 		)
 	return "\n".join(lines)
 
 
-def print_task_summary_listing(tasks: Mapping[str, TaskNode], source: Path | None) -> None:
-	print(format_task_summary_listing(tasks, source, color=color_on()))
+def print_task_summary_listing(
+	tasks: Mapping[str, TaskNode],
+	source: Path | None,
+	default_task_name: str | None = None,
+) -> None:
+	print(
+		format_task_summary_listing(
+			tasks, source, color=color_on(), default_task_name=default_task_name
+		)
+	)
 
 
 def print_task_trees(tasks: Mapping[str, TaskNode], source: Path | None) -> None:
@@ -256,11 +273,13 @@ def format_signature(cls: Any, indent: str, color: bool) -> list[str]:
 def format_available_effects(
 	color: bool | None = None,
 	scope_effects: Mapping[str, type[Effect[Any]]] = {},
+	default_effect_names: frozenset[str] = frozenset(),
 ) -> str:
 	"""Render each discovered Effect with its full constructor signature and
 	the signatures of every parameter type it transitively references.
 
-	``scope_effects`` adds user-defined Effect classes to the listing.
+	``scope_effects`` adds user-defined Effect classes to the listing;
+	``default_effect_names`` marks the environment's default effect(s) with ``(default)``.
 	"""
 	_, effects = available_effects(scope_effects)
 	if not effects:
@@ -272,8 +291,9 @@ def format_available_effects(
 			lines.append("")
 		doc = first_line_doc(cls)
 		name_str = maybe_color(name, BOLD_CYAN, on)
-		doc_str = f"  — {maybe_color(doc, GREY, on)}" if doc else ""
-		lines.append(f"  {name_str}{doc_str}")
+		default_str = maybe_color(" (default)", GREY, on) if name in default_effect_names else ""
+		doc_str = f"  — {doc}" if doc else ""
+		lines.append(f"  {name_str}{default_str}{doc_str}")
 		lines.extend(format_signature(cls, "    ", on))
 	return "\n".join(lines)
 
@@ -283,7 +303,10 @@ def format_try_hint(color: bool) -> str:
 	rows = (
 		('camas \'("echo Hello", "echo world!")\'', "( ) → Sequential"),
 		('camas \'{"echo Hello", "echo world!"}\'', "{ } → Parallel"),
-		("camas --effects '(Summary(),)' <task>", "post-run summary instead of live tree"),
+		(
+			"camas --effects '(Summary(term_width=Fixed(60)),)' <task>",
+			"post-run summary instead of live tree",
+		),
 	)
 	width = max(len(cmd) for cmd, _ in rows)
 	header = maybe_color("Try:", CAMAS_VIOLET, color)
@@ -314,8 +337,13 @@ def format_reference(color: bool) -> str:
 
 def print_available_effects(
 	scope_effects: Mapping[str, type[Effect[Any]]] = {},
+	default_effect_names: frozenset[str] = frozenset(),
 ) -> None:
-	print(format_available_effects(scope_effects=scope_effects))
+	print(
+		format_available_effects(
+			scope_effects=scope_effects, default_effect_names=default_effect_names
+		)
+	)
 
 
 def first_line_doc(obj: Any) -> str:

--- a/src/camas/main/parser.py
+++ b/src/camas/main/parser.py
@@ -16,14 +16,19 @@ if sys.version_info >= (3, 11):
 else:  # pragma: no cover
 	from typing_extensions import assert_never
 
+from ..core.color import BOLD_CYAN
 from ..core.render import color_on
+from ..v0.config import Config
 from .check import describe_check_help
+from .color import maybe_color
+from .effects import default_effect_names, format_effects_expr, resolve_default_effects
 from .format import (
 	format_available_effects,
 	format_load_error_hint,
 	format_reference,
 	format_task_summary_listing,
 	format_try_hint,
+	task_summary,
 )
 from .state import EMPTY_STATE, LoadErr, LoadOk, TasksState
 
@@ -34,24 +39,50 @@ if TYPE_CHECKING:
 	from ..v0.task import TaskNode
 
 
-def default_effects_expr() -> str:
-	"""Default ``--effects`` for the environment: ``Status('github')`` under GitHub
-	Actions (``GITHUB_ACTIONS=true``, collapsed workflow groups), else live ``Termtree``.
+def effects_help(config: Config, *, github: bool) -> str:
+	"""``--effects`` help: names the environment's resolved default, and the other
+	environment's default when it differs (``Termtree`` locally vs. ``Status``
+	under GitHub Actions, unless the :class:`Config` overrides them).
 
-	>>> import os
-	>>> _saved = os.environ.pop("GITHUB_ACTIONS", None)
-	>>> default_effects_expr()
-	'(Termtree(),)'
-	>>> os.environ["GITHUB_ACTIONS"] = "true"
-	>>> default_effects_expr()
-	'(Status(output_mode="github"),)'
-	>>> os.environ.pop("GITHUB_ACTIONS", None)
-	'true'
-	>>> _ = os.environ.update({"GITHUB_ACTIONS": _saved}) if _saved is not None else None
+	>>> effects_help(Config(), github=False)
+	"tuple of Effect instances; pass with no value to list available Effects (default: (Termtree(),); (Status(output_mode='github'),) under GITHUB_ACTIONS=true)"
+	>>> effects_help(Config(), github=True)
+	"tuple of Effect instances; pass with no value to list available Effects (default: (Status(output_mode='github'),); (Termtree(),) off GitHub Actions)"
 	"""
-	if os.environ.get("GITHUB_ACTIONS") == "true":
-		return '(Status(output_mode="github"),)'
-	return "(Termtree(),)"
+	active = format_effects_expr(resolve_default_effects(config, github=github))
+	other = format_effects_expr(resolve_default_effects(config, github=not github))
+	where = "under GITHUB_ACTIONS=true" if not github else "off GitHub Actions"
+	default = active if active == other else f"{active}; {other} {where}"
+	return (
+		"tuple of Effect instances; pass with no value to list available Effects "
+		f"(default: {default})"
+	)
+
+
+def positional_help(config: Config, *, github: bool, color: bool = False) -> str:
+	"""Positional help: names the task a bare ``camas`` runs, when one is configured.
+	A named task is rendered in bold cyan (matching ``--list``); an anonymous one
+	falls back to its one-line summary.
+
+	>>> from camas import Task
+	>>> positional_help(Config(default_task=Task("echo hi", name="greet")), github=False)
+	"name of a defined task, or a camas expression (trailing '-- ARGS' append to a Task's command); with no argument, runs greet"
+	>>> positional_help(Config(), github=False)
+	"name of a defined task, or a camas expression (trailing '-- ARGS' append to a Task's command)"
+	"""
+	base = (
+		"name of a defined task, or a camas expression "
+		"(trailing '-- ARGS' append to a Task's command)"
+	)
+	bare = config.bare_task(github=github)
+	if bare is None:
+		return base
+	label = (
+		maybe_color(bare.name, BOLD_CYAN, color)
+		if bare.name is not None
+		else task_summary(bare, frozenset())
+	)
+	return f"{base}; with no argument, runs {label}"
 
 
 def positive_jobs(raw: str) -> int:
@@ -101,10 +132,24 @@ class CamasArgumentParser(argparse.ArgumentParser):
 
 	def format_help(self) -> str:
 		color = color_on()
+		config = (
+			self.state.config
+			if isinstance(self.state, LoadOk) and self.state.config is not None
+			else Config()
+		)
+		github = os.environ.get("GITHUB_ACTIONS") == "true"
+		bare = config.bare_task(github=github)
 		sections = [super().format_help().rstrip()]
 		match self.state:
 			case LoadOk(tasks=tasks, source=source) if tasks:
-				sections.append(format_task_summary_listing(tasks, source, color=color))
+				sections.append(
+					format_task_summary_listing(
+						tasks,
+						source,
+						color=color,
+						default_task_name=bare.name if bare is not None else None,
+					)
+				)
 			case LoadErr(source=source, exception=exc):
 				sections.append(format_load_error_hint(source, exc))
 			case LoadOk():
@@ -114,7 +159,11 @@ class CamasArgumentParser(argparse.ArgumentParser):
 		effects: Mapping[str, type[Effect[Any]]] = (
 			self.state.scope_effects if isinstance(self.state, LoadOk) else {}
 		)
-		effects_listing = format_available_effects(color=color, scope_effects=effects)
+		effects_listing = format_available_effects(
+			color=color,
+			scope_effects=effects,
+			default_effect_names=default_effect_names(config, github=github),
+		)
 		if effects_listing:
 			sections.append(effects_listing)
 		sections.append(format_try_hint(color))
@@ -139,6 +188,10 @@ def build_parser(state: TasksState = EMPTY_STATE) -> argparse.ArgumentParser:
 	True
 	"""
 	tasks_for_metavar: Mapping[str, TaskNode] = state.tasks if isinstance(state, LoadOk) else {}
+	config: Final = (
+		state.config if isinstance(state, LoadOk) and state.config is not None else Config()
+	)
+	github: Final = os.environ.get("GITHUB_ACTIONS") == "true"
 	parser: Final = CamasArgumentParser(
 		prog="camas",
 		description="A task runner with parallel execution, matrix expansion, and pluggable output effects.",
@@ -149,8 +202,7 @@ def build_parser(state: TasksState = EMPTY_STATE) -> argparse.ArgumentParser:
 		"expression",
 		nargs="?",
 		metavar=expression_metavar(tasks_for_metavar),
-		help="name of a defined task, or a camas expression "
-		"(trailing '-- ARGS' append to a Task's command)",
+		help=positional_help(config, github=github, color=color_on()),
 	)
 	parser.add_argument(
 		"--version",
@@ -185,10 +237,9 @@ def build_parser(state: TasksState = EMPTY_STATE) -> argparse.ArgumentParser:
 	parser.add_argument(
 		"--effects",
 		nargs="?",
-		default=default_effects_expr(),
+		default=None,
 		const="",
-		help="tuple of Effect instances; pass with no value to list available Effects "
-		"(default: Termtree, or Status('github') when GITHUB_ACTIONS=true)",
+		help=effects_help(config, github=github),
 	)
 	parser.add_argument(
 		"--matrix",

--- a/src/camas/main/tasks.py
+++ b/src/camas/main/tasks.py
@@ -163,6 +163,8 @@ def name_scope_config(scope: Mapping[str, object]) -> Config | None:
 	return Config(
 		default_task=promote_field(config.default_task),
 		github_task=promote_field(config.github_task),
+		default_effects=config.default_effects,
+		default_github_effects=config.default_github_effects,
 	)
 
 

--- a/src/camas/v0/config.py
+++ b/src/camas/v0/config.py
@@ -8,6 +8,9 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, NamedTuple
 
 if TYPE_CHECKING:
+	from typing import Any
+
+	from .effect import Effect
 	from .task import TaskNode
 
 
@@ -18,9 +21,21 @@ class Config(NamedTuple):
 
 	default_task: TaskNode | None = None
 	github_task: TaskNode | None = None
+	default_effects: tuple[Effect[Any], ...] | None = None
+	"""``None`` defers to the engine's default; ``()`` is an explicit no-effects."""
+	default_github_effects: tuple[Effect[Any], ...] | None = None
+	"""``None`` defers to the engine's default; ``()`` is an explicit no-effects."""
 
 	def bare_task(self, *, github: bool) -> TaskNode | None:
 		"""The task a bare ``camas`` invocation runs."""
 		if github and self.github_task is not None:
 			return self.github_task
 		return self.default_task
+
+	def effects(self, *, github: bool) -> tuple[Effect[Any], ...] | None:
+		"""The configured default effects for the environment, or ``None`` to defer
+		to the engine's built-in default.
+		"""
+		if github:
+			return self.default_github_effects
+		return self.default_effects

--- a/tests/main/test_effects.py
+++ b/tests/main/test_effects.py
@@ -14,12 +14,21 @@ from typing import TYPE_CHECKING
 
 import pytest
 
+from camas import Config
+from camas.effect.status import Status
+from camas.effect.summary import Summary
+from camas.effect.termtree import Termtree
 from camas.main.effects import (
 	available_effects,
+	default_effect_names,
 	discover_effects,
 	eval_value,
+	format_effect_call,
+	format_effects_expr,
 	parse_effects,
 	reachable_classes,
+	resolve_default_effects,
+	resolve_effects,
 	signature_fields,
 )
 from camas.main.mypyc import MISSING
@@ -207,3 +216,53 @@ def test_signature_fields_signature_raises(monkeypatch: pytest.MonkeyPatch) -> N
 
 	monkeypatch.setattr(inspect, "signature", boom)
 	assert signature_fields(Plain) == []
+
+
+def test_format_effect_call_omits_default_args() -> None:
+	assert format_effect_call(Termtree()) == "Termtree()"
+	assert format_effect_call(Termtree(show_passing=True)) == "Termtree(show_passing=True)"
+
+
+def test_format_effects_expr_singleton_keeps_trailing_comma() -> None:
+	assert format_effects_expr(()) == "()"
+	assert format_effects_expr((Termtree(),)) == "(Termtree(),)"
+	assert format_effects_expr((Termtree(), Summary())) == "(Termtree(), Summary())"
+
+
+@pytest.mark.parametrize(
+	("github", "expected"),
+	[(False, (Termtree(),)), (True, (Status(output_mode="github"),))],
+)
+def test_resolve_default_effects_builtin_when_unset(
+	github: bool, expected: tuple[object, ...]
+) -> None:
+	"""No override → the engine's environment default."""
+	out = resolve_default_effects(Config(), github=github)
+	assert [type(e).__name__ for e in out] == [type(e).__name__ for e in expected]
+
+
+def test_resolve_default_effects_honors_override() -> None:
+	override = (Summary(),)
+	assert resolve_default_effects(Config(default_effects=override), github=False) is override
+
+
+def test_resolve_default_effects_empty_override_is_no_effects() -> None:
+	"""An explicit ``()`` is honored, not treated as unset."""
+	assert resolve_default_effects(Config(default_effects=()), github=False) == ()
+
+
+def test_resolve_effects_parses_expression_over_default() -> None:
+	out = resolve_effects("(Summary(),)", Config(), github=False)
+	assert [type(e).__name__ for e in out] == ["Summary"]
+
+
+def test_resolve_effects_none_uses_config_default() -> None:
+	override = (Summary(),)
+	assert resolve_effects(None, Config(default_effects=override), github=False) is override
+
+
+@pytest.mark.parametrize(
+	("github", "expected"), [(False, frozenset({"Termtree"})), (True, frozenset({"Status"}))]
+)
+def test_default_effect_names_tracks_environment(github: bool, expected: frozenset[str]) -> None:
+	assert default_effect_names(Config(), github=github) == expected

--- a/tests/main/test_format.py
+++ b/tests/main/test_format.py
@@ -182,6 +182,35 @@ def test_format_task_summary_listing_with_color() -> None:
 	assert "\033[" in out
 
 
+def test_format_task_summary_listing_marks_default_after_name() -> None:
+	"""The bare-run default is tagged ``(default)`` immediately after its name."""
+	out = format_task_summary_listing(
+		{"all": Task("x", name="all"), "check": Task("y", name="check")},
+		None,
+		color=False,
+		default_task_name="all",
+	)
+	assert "all (default)" in out
+	assert "check (default)" not in out
+
+
+def test_format_task_summary_listing_default_marker_preserves_alignment() -> None:
+	"""The ``(default)`` marker is folded into the name column so bodies stay aligned."""
+	out = format_task_summary_listing(
+		{"all": Task("x", name="all"), "coverage": Task("y", name="coverage")},
+		None,
+		color=False,
+		default_task_name="all",
+	)
+	body_columns = {line.index("x" if " x" in line else "y") for line in out.splitlines()[1:]}
+	assert len(body_columns) == 1
+
+
+def test_format_task_summary_listing_no_marker_when_default_unset() -> None:
+	out = format_task_summary_listing({"a": Task("x", name="a")}, None, color=False)
+	assert "(default)" not in out
+
+
 def test_print_task_trees_empty(capsys: pytest.CaptureFixture[str]) -> None:
 	print_task_trees({}, None)
 	assert "No tasks file found" in capsys.readouterr().out
@@ -216,6 +245,20 @@ def test_format_available_effects_no_color() -> None:
 	out = format_available_effects(color=False)
 	assert "\033[" not in out
 	assert "Summary" in out
+
+
+def test_format_available_effects_marks_default() -> None:
+	out = format_available_effects(color=False, default_effect_names=frozenset({"Termtree"}))
+	assert "Termtree (default)" in out
+	assert "Summary (default)" not in out
+
+
+def test_format_available_effects_doc_is_not_greyed() -> None:
+	"""The one-line doc renders in the default foreground, not grey."""
+	from camas.core.color import GREY
+
+	out = format_available_effects(color=True)
+	assert f"— {GREY}" not in out
 
 
 def test_format_available_effects_empty(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -27,3 +27,21 @@ GH = Task("gh", name="gh")
 def test_bare_task_resolution(config: Config, github: bool, expected: Task | None) -> None:
 	"""``github_task`` wins under GitHub Actions, falling back to ``default_task``."""
 	assert config.bare_task(github=github) is expected
+
+
+@pytest.mark.parametrize("github", [False, True])
+def test_effects_default_is_none_deferring_to_engine(github: bool) -> None:
+	"""Unset effects return ``None`` — the signal for the engine to substitute its
+	environment default, keeping the concrete effects out of the type layer.
+	"""
+	assert Config().effects(github=github) is None
+
+
+def test_effects_returns_per_environment_override() -> None:
+	from camas.effect.summary import Summary
+
+	local = (Summary(),)
+	gh = (Summary(show_passing=True),)
+	config = Config(default_effects=local, default_github_effects=gh)
+	assert config.effects(github=False) is local
+	assert config.effects(github=True) is gh


### PR DESCRIPTION
Closes #47 — make the current default-effects behavior (live `Termtree`, or `Status('github')` under GitHub Actions) configurable via `Config`, and surface the resolved defaults in `--help`.

## Config

- `Config` gains `default_effects` / `default_github_effects`, both defaulting to `None` = *defer to the engine's built-in default*. `()` is an explicit no-effects.
- `None` keeps the concrete `Termtree`/`Status` instances out of the `camas.v0` type layer, so `test_importing_v0_does_not_load_the_engine` (the one-directional import boundary) holds with no lazy-loading gymnastics — the concrete defaults live in exactly one place, `resolve_default_effects`.
- `name_scope_config` now carries the two fields through task promotion, so an override actually reaches the run.

## Runtime

`--effects` defaults to `None`; when omitted, `resolve_effects` returns `config.effects(github=…)` and the engine substitutes the built-in when the config defers. A configured override drives a bare `camas` run (verified end-to-end with a `Summary` override).

## `--help` (now derived, not hardcoded)

- **`--effects`**: shows the environment's resolved default tuple plus the other environment's when it differs, reconstructed from the live effect instances via `format_effects_expr` (the inverse of `parse_effects`, emitting only non-default constructor args). A custom `Config` is reflected.
- **positional**: names the task a bare `camas` runs (`bare_task(github=…)`), in **bold cyan** to match `--list`.
- **listings**: the environment's default task and effect are tagged grey `(default)` (task marker sits right after the name, folded into the column width so bodies stay aligned); effect one-line docs now render in the default foreground instead of grey.

  Note: on a `tasks.py` load error the listings still mark the built-in `Termtree`/`Status` as `(default)` (computed from `Config()`), since a failed config contributes nothing and the built-in genuinely applies.

## Verification

`705 passed` (pytest + `--doctest-modules`), all five type checkers (mypy, pyright, ty, zuban, pyrefly), ruff lint + format clean. New tests cover the marker presence/position/alignment, the white doc, env-tracking of the default effect, and config-driven effects resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)