### PR TITLE
feat(mcp): camas_list expand_matrix flag; collapse matrix previews by default

### DIFF
--- a/src/camas/mcp/catalog.py
+++ b/src/camas/mcp/catalog.py
@@ -24,10 +24,13 @@ def to_list_response(
 	tasks: Mapping[str, TaskNode],
 	config: Config | None,
 	timings: Mapping[str, TaskTiming] = {},
+	*,
+	expand: bool = False,
 ) -> wire.ListResponse:
 	"""Assemble the ``camas_list`` catalog — one ``TaskInfo`` per task, sorted by
 	name, with the default and CI-default names taken from ``config`` and each task's
-	observed duration drawn from ``timings``.
+	observed duration drawn from ``timings``. ``expand`` matrix-expands each command
+	preview; otherwise it stays the unexpanded template.
 	"""
 	default = task_name(config.default_task) if config is not None else None
 	github_default = task_name(config.github_task) if config is not None else None
@@ -39,6 +42,7 @@ def to_list_response(
 				is_default=name == default,
 				is_github_default=name == github_default,
 				est=estimate(node, timings),
+				expand=expand,
 			)
 			for name, node in sorted(tasks.items())
 		),
@@ -58,12 +62,13 @@ def task_info(
 	is_default: bool,
 	is_github_default: bool,
 	est: Estimate | None,
+	expand: bool,
 ) -> wire.TaskInfo:
 	"""One ``TaskInfo``: help, a fully-typed command expression, matrix axes, and any estimate."""
 	info = wire.TaskInfo(
 		name=name,
 		help=node.help,
-		command_preview=to_expression(expand_matrix(node)),
+		command_preview=to_expression(expand_matrix(node) if expand else node),
 		matrix_axes={axis: list(values) for axis, values in matrix_axes(node).items()},
 		is_default=is_default,
 		is_github_default=is_github_default,

--- a/src/camas/mcp/serve.py
+++ b/src/camas/mcp/serve.py
@@ -189,7 +189,7 @@ async def call(session: Session, name: str, arguments: dict[str, Any]) -> types.
 	"""Dispatch a ``tools/call`` to the matching handler, or a tool error for an unknown name."""
 	match parse_tool(name):
 		case ToolName.LIST:
-			return list_call(session)
+			return list_call(session, arguments)
 		case ToolName.RUN:
 			return await run_call(session, arguments)
 		case ToolName.CHECK:
@@ -250,18 +250,20 @@ def tools(task_names: tuple[str, ...], compat: Compat) -> Tools:
 			name=ToolName.LIST.value,
 			description=textwrap.dedent("""\
 				List THIS project's camas-defined tasks: each task's name, help text, its
-				fully-resolved, matrix-expanded command expression (every leaf, recursively),
-				and any matrix axes it expands across (versions, targets, toolchains,
-				platforms — whatever the project declares). Two tasks are flagged: the default
-				(what the developer runs while working) and the github default — the exact task
-				this project's CI runs (camas is the single definition shared by local and CI),
-				so running it locally before you commit or push reproduces CI exactly. Tasks
-				whose leaves have been timed also carry an estimated duration and their slowest
-				leaf, so you can pick a quick task for the inner loop and the thorough one before
-				committing. Use this first to discover valid task names for camas_run; it is the
-				source of truth. Read-only; runs nothing.
+				command expression, and any matrix axes it expands across (versions, targets,
+				toolchains, platforms — whatever the project declares). Matrix tasks show the
+				unexpanded template by default (their axis values are listed separately, which
+				keeps discovery compact); pass expand_matrix=true to inline every resolved leaf
+				recursively. Two tasks are flagged: the default (what the developer runs while
+				working) and the github default — the exact task this project's CI runs (camas
+				is the single definition shared by local and CI), so running it locally before
+				you commit or push reproduces CI exactly. Tasks whose leaves have been timed also
+				carry an estimated duration and their slowest leaf, so you can pick a quick task
+				for the inner loop and the thorough one before committing. Use this first to
+				discover valid task names for camas_run; it is the source of truth. Read-only;
+				runs nothing.
 			""").strip(),
-			input_schema=NO_ARGS_SCHEMA,
+			input_schema=wire.ListRequest.model_json_schema(),
 			output_model=wire.ListResponse,
 			title="List camas tasks",
 			annotations=LIST_ANNOTATIONS,
@@ -328,14 +330,20 @@ def tools(task_names: tuple[str, ...], compat: Compat) -> Tools:
 	)
 
 
-def list_call(session: Session) -> types.CallToolResult:
+def list_call(session: Session, arguments: dict[str, Any]) -> types.CallToolResult:
 	"""Handle ``camas_list``: the project's task catalog, or a load error."""
+	try:
+		req = wire.ListRequest.model_validate(arguments)
+	except ValidationError as e:
+		return error_result(f"invalid camas_list arguments:\n{e}")
 	match session.project:
 		case LoadErr(source=source, exception=exception):
 			return error_result(format_load_error_hint(source, exception))
 		case LoadOk(tasks=tasks, config=config):
-			resp = to_list_response(tasks, config, timings.load(session.camas_dir))
-			return success(list_text(resp), resp, session.compat)
+			resp = to_list_response(
+				tasks, config, timings.load(session.camas_dir), expand=req.expand_matrix
+			)
+			return success(list_text(resp, expand_matrix=req.expand_matrix), resp, session.compat)
 		case _:
 			assert_never(session.project)
 
@@ -455,7 +463,7 @@ def failing_log_links(
 	)
 
 
-def list_text(resp: wire.ListResponse) -> str:
+def list_text(resp: wire.ListResponse, *, expand_matrix: bool) -> str:
 	"""The load-bearing agent-facing summary for ``camas_list``."""
 	lines = [f"{len(resp.tasks)} task(s) defined. Call camas_run with one of these names."]
 	if resp.default is not None:
@@ -478,6 +486,12 @@ def list_text(resp: wire.ListResponse) -> str:
 		timing = timing_note(t) if t.estimated_s is not None else ""
 		lines.append(f"  {t.name.ljust(width)}{marks}{help_note}{matrix}{timing}")
 		lines.append(f"      {t.command_preview}")
+	if not expand_matrix and any(t.matrix_axes for t in resp.tasks):
+		lines.append("")
+		lines.append(
+			"Matrix previews collapsed to templates; call camas_list with expand_matrix=true "
+			"for the fully-expanded per-leaf tree."
+		)
 	return "\n".join(lines)
 
 

--- a/src/camas/mcp/wire.py
+++ b/src/camas/mcp/wire.py
@@ -117,6 +117,21 @@ class DocsResponse(BaseModel):
 	"""The package ``__init__.py`` docstring: a worked, doctested authoring tutorial."""
 
 
+class ListRequest(BaseModel):
+	"""Arguments to ``camas_list``."""
+
+	model_config = ConfigDict(extra="forbid")
+
+	expand_matrix: bool = Field(
+		default=False,
+		description=(
+			"Expand matrix tasks into their full per-axis command tree. Off by default: the "
+			"preview keeps the unexpanded template and the axes are reported under matrix_axes, "
+			"which is far smaller for a matrix over many values."
+		),
+	)
+
+
 class RunRequest(BaseModel):
 	"""Arguments to ``camas_run``."""
 

--- a/tests/mcp/test_catalog.py
+++ b/tests/mcp/test_catalog.py
@@ -47,9 +47,16 @@ def test_config_without_defaults_yields_no_markers() -> None:
 	assert (resp.default, resp.github_default) == (None, None)
 
 
-def test_matrix_axes_reported_as_lists() -> None:
+def test_matrix_axes_reported_with_unexpanded_preview_by_default() -> None:
 	node = Parallel(Task("test {PY}"), matrix={"PY": ("3.13", "3.14")}, name="m")
 	resp = to_list_response({"m": node}, None)
+	assert resp.tasks[0].matrix_axes == {"PY": ["3.13", "3.14"]}
+	assert resp.tasks[0].command_preview == 'Parallel(Task("test {PY}"), name="m")'
+
+
+def test_expand_inlines_every_matrix_leaf() -> None:
+	node = Parallel(Task("test {PY}"), matrix={"PY": ("3.13", "3.14")}, name="m")
+	resp = to_list_response({"m": node}, None, expand=True)
 	assert resp.tasks[0].matrix_axes == {"PY": ["3.13", "3.14"]}
 	assert resp.tasks[0].command_preview == (
 		'Parallel(Task("test 3.13", name="test 3.13 [PY=3.13]"), '

--- a/tests/mcp/test_serve.py
+++ b/tests/mcp/test_serve.py
@@ -128,6 +128,8 @@ def test_tools_default_omits_rich_fields() -> None:
 	assert (tool_docs.title, tool_docs.outputSchema, tool_docs.annotations) == (None, None, None)
 	assert tool_check.inputSchema == serve.NO_ARGS_SCHEMA
 	assert tool_docs.inputSchema == serve.NO_ARGS_SCHEMA
+	assert tool_list.inputSchema["properties"]["expand_matrix"]["type"] == "boolean"
+	assert tool_list.inputSchema["additionalProperties"] is False
 
 
 def test_tools_rich_includes_title_annotations_and_schema() -> None:
@@ -155,27 +157,54 @@ def test_list_call_text_lists_tasks_and_markers(tmp_path: Path) -> None:
 	session = _session(
 		{"ci": ci, "lint": PASS}, Config(default_task=ci, github_task=PASS), tmp_path
 	)
-	result = serve.list_call(session)
+	result = serve.list_call(session, {})
 	assert result.isError is False
 	text = _text(result)
 	assert "default (developer's task): ci" in text
 	assert "github default" in text
 	assert "lint" in text
+	assert "expand_matrix=true" not in text
 	assert result.structuredContent is None
 
 
 def test_list_call_load_error(tmp_path: Path) -> None:
 	session = Session(LoadErr(tmp_path / "tasks.py", RuntimeError("boom")), tmp_path, Compat())
-	result = serve.list_call(session)
+	result = serve.list_call(session, {})
 	assert result.isError is True
 	assert "camas --check" in _text(result)
 
 
 def test_list_call_structured_when_rich(tmp_path: Path) -> None:
 	session = _session({"lint": PASS}, None, tmp_path, rich=True)
-	result = serve.list_call(session)
+	result = serve.list_call(session, {})
 	assert result.structuredContent is not None
 	assert result.structuredContent["tasks"][0]["name"] == "lint"
+
+
+_MATRIX = Parallel(Task("test {PY}"), matrix={"PY": ("3.13", "3.14")}, name="m")
+
+
+def test_list_call_default_collapses_matrix(tmp_path: Path) -> None:
+	result = serve.list_call(_session({"m": _MATRIX}, None, tmp_path), {})
+	text = _text(result)
+	assert "test {PY}" in text
+	assert "[PY=3.13]" not in text
+	assert "(matrix: PY=3.13/3.14)" in text
+	assert "expand_matrix=true" in text
+
+
+def test_list_call_expand_matrix_inlines_leaves(tmp_path: Path) -> None:
+	result = serve.list_call(_session({"m": _MATRIX}, None, tmp_path), {"expand_matrix": True})
+	text = _text(result)
+	assert "[PY=3.13]" in text
+	assert "[PY=3.14]" in text
+	assert "expand_matrix=true" not in text
+
+
+def test_list_call_invalid_arguments_is_tool_error(tmp_path: Path) -> None:
+	result = serve.list_call(_session({"m": _MATRIX}, None, tmp_path), {"expand_matrix": "nope"})
+	assert result.isError is True
+	assert "invalid camas_list arguments" in _text(result)
 
 
 async def test_run_call_pass(tmp_path: Path) -> None:
@@ -258,7 +287,7 @@ async def test_run_call_dry_run_records_no_timing(tmp_path: Path) -> None:
 async def test_list_reflects_recorded_timing(tmp_path: Path) -> None:
 	session = _session({"lint": PASS}, None, tmp_path)
 	await serve.run_call(session, {"task": "lint"})
-	assert "n=1" in _text(serve.list_call(session))
+	assert "n=1" in _text(serve.list_call(session, {}))
 
 
 async def test_run_call_unknown_task_is_tool_error(tmp_path: Path) -> None:
@@ -597,7 +626,7 @@ def test_list_text_renders_matrix_and_no_markers() -> None:
 		),
 		default=None,
 	)
-	text = serve.list_text(resp)
+	text = serve.list_text(resp, expand_matrix=False)
 	assert "default" not in text
 	assert "(matrix: PY=3.13/3.14)" in text
 
@@ -613,7 +642,7 @@ def test_list_text_shows_help_and_expansion_together() -> None:
 		),
 		default=None,
 	)
-	text = serve.list_text(resp)
+	text = serve.list_text(resp, expand_matrix=False)
 	assert "Lint sources" in text
 	assert 'Task("ruff check .", name="lint")' in text
 
@@ -639,7 +668,7 @@ def test_list_text_shows_timing_with_slowest_leaf() -> None:
 		),
 		default=None,
 	)
-	assert "[~32.00s, slowest test 31.90s, n=2]" in serve.list_text(resp)
+	assert "[~32.00s, slowest test 31.90s, n=2]" in serve.list_text(resp, expand_matrix=False)
 
 
 def test_list_text_omits_slowest_when_it_is_the_task_itself() -> None:
@@ -656,7 +685,7 @@ def test_list_text_omits_slowest_when_it_is_the_task_itself() -> None:
 		),
 		default=None,
 	)
-	line = serve.list_text(resp)
+	line = serve.list_text(resp, expand_matrix=False)
 	assert "[~0.20s, n=1]" in line
 	assert "slowest" not in line
 
@@ -684,6 +713,16 @@ async def test_in_memory_round_trip(tmp_path: Path) -> None:
 		assert "PASSED" in _text(run)
 		unknown = await client.call_tool("camas_run", {"task": "lint", "dry_run": True})
 		assert "fully-resolved plan" in _text(unknown)
+
+
+async def test_list_via_client_expands_matrix_on_request(tmp_path: Path) -> None:
+	session = _session({"m": _MATRIX}, None, tmp_path)
+	async with create_connected_server_and_client_session(serve.build_server(session)) as client:
+		collapsed = _text(await client.call_tool("camas_list", {}))
+		assert "[PY=3.13]" not in collapsed
+		expanded = _text(await client.call_tool("camas_list", {"expand_matrix": True}))
+		assert "[PY=3.13]" in expanded
+		assert "[PY=3.14]" in expanded
 
 
 async def test_call_unknown_tool_is_error(tmp_path: Path) -> None:

--- a/tests/mcp/test_wire.py
+++ b/tests/mcp/test_wire.py
@@ -11,6 +11,7 @@ from camas.mcp.wire import (
 	DocsResponse,
 	Finished,
 	LeafReport,
+	ListRequest,
 	ListResponse,
 	RunRequest,
 	RunResponse,
@@ -19,6 +20,15 @@ from camas.mcp.wire import (
 	TaskInfo,
 	run_input_schema,
 )
+
+
+def test_list_request_defaults_to_unexpanded() -> None:
+	assert ListRequest.model_validate({}).expand_matrix is False
+
+
+def test_list_request_rejects_unknown_field() -> None:
+	with pytest.raises(ValidationError):
+		ListRequest.model_validate({"bogus": 1})
 
 
 def test_run_request_defaults() -> None:


### PR DESCRIPTION
## What

Adds an `expand_matrix` boolean argument to the `camas_list` MCP tool (default `false`) and **flips the default to unexpanded**, as proposed in #56.

By default, a matrix task's `command_preview` now shows the **unexpanded template** with its axes reported separately under `matrix_axes`. Pass `expand_matrix=true` to get the previous fully-resolved, per-axis tree.

## Why

`camas_list` fully expanded every matrix task, repeating the whole subtree once per axis value — e.g. this project's `matrix` task dumped the entire `check` tree six times (once per Python `3.10`–`3.15`). For the common "what tasks exist so I can run one" case, the caller only needs names, help, and the axes — not every expanded leaf. The expansion is pure, repeated token cost per discovery.

## Effect on output

For the `matrix` task, the preview goes from six fully-substituted copies of the `check` subtree to a single template, with the axes still surfaced:

```
  matrix    (matrix: PY=3.14/3.13/3.12/3.11/3.10/3.15)
      Sequential(Task("uv sync"), Parallel(Task("uv run ruff format --check ."), …, name="check"))

Matrix previews collapsed to templates; call camas_list with expand_matrix=true
for the fully-expanded per-leaf tree.
```

`camas_list` with `{"expand_matrix": true}` restores the old per-axis expansion verbatim.

## Changes

- **`wire.py`** — new `ListRequest` model (`extra="forbid"`, `expand_matrix: bool = False`).
- **`catalog.py`** — `to_list_response` / `task_info` gain an `expand` kwarg; `command_preview` uses the unexpanded node unless `expand`. `matrix_axes` is still always computed on the unexpanded node.
- **`serve.py`** — the LIST tool advertises the `expand_matrix` input schema; its description no longer claims unconditional expansion; `list_call` validates `ListRequest` and threads the flag; `list_text` appends a one-line discoverability hint only when a matrix task is collapsed.

## Tests / quality

- New/updated coverage in `test_wire.py`, `test_catalog.py`, `test_serve.py`: collapse-by-default, expand-on-flag, no-hint when nothing is collapsible, invalid-args tool error, schema exposes the property, and an end-to-end client round-trip proving `expand_matrix=true` flows through dispatch + validation.
- Full gate green: `ruff format --check`, `ruff check`, `mypy --strict`, `pyright`, `ty`, `zuban`, `pyrefly` all clean; **893 passed, 100% branch coverage**.

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ni94oR7y8KpNjhcGrvF3NA
