### PR TITLE
feat: `camas --under=<duration>` — time-budgeted run mode (#54)

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,34 @@ _ = Config(
 
 `Config` is discovered by type, so the binding's name never matters — `_` by convention. Defining two is an error.
 
+## Time budget (`--under`)
+
+Once camas has timed a task's leaves (the `.camas/` cache, surfaced by `camas --list`), `camas --under=<duration>` runs only the leaves whose estimate fits a wall-clock budget — the fast inner-loop subset, picked for you instead of by hand.
+
+```
+camas --under=1s            # budget the Config default task
+camas --under=500ms check   # budget a named task or expression
+```
+
+It runs the **mutating** leaves first, in sequence, then the read-only rest in parallel — so formatters never race a checker over the same files. Mark a leaf that writes the workspace with `mutates=True`:
+
+```python
+fix = Task("ruff check --fix .", mutates=True)
+fmt = Task("ruff format .", mutates=True)
+lint = Task("ruff check .")
+```
+
+```
+$ camas --under=1s --dry-run
+Time budget 1.00s — selected 6 leaf(s), excluded 2 (2 over budget, 0 untimed).
+  over budget: pyright ~4.57s, coverage ~20.98s
+fix → fmt → (mypy | ty | zuban | pyrefly)
+```
+
+Durations are `1s`, `500ms`, `2m`, `1h`, or a bare number of seconds. Leaves with no recorded timing yet are excluded (a budget can't bound them — run the task once normally to time them). The budget is per-leaf: a leaf is selected when its own estimate fits, so the parallel group's wall-clock stays near the budget.
+
+**For agents**, `camas_run` exposes the same budget as its `under` argument (omit `task` to budget the project default), and the response's `budget` field reports what was selected and excluded — a tight, time-boxed validate loop over structured MCP.
+
 ## Effects plugins
 
 Define an `Effect` in your `tasks.py` and it's discovered automatically — usable by name from `--effects` and listed under `camas --effects`. See [examples/effect-plugin/](https://github.com/JPHutchins/camas/tree/main/tests/fixtures/effect-plugin) for a typed `Tail` effect that streams per-task output as it arrives.

--- a/src/camas/__init__.py
+++ b/src/camas/__init__.py
@@ -22,6 +22,14 @@ rarely needed (the cmd or tree usually self-documents; this codebase
 uses ``help=`` only in a handful of places), but available for
 cryptic commands.
 
+``Task`` additionally accepts ``mutates=True`` to mark a leaf that
+writes the workspace (a formatter or auto-fixer). ``camas --under=<dur>``
+(e.g. ``--under=1s``, ``--under=500ms``) then runs only the leaves whose
+recorded timing fits the budget — the marked, mutating ones first in
+sequence, then the read-only rest in parallel — a fast, self-pruning
+inner-loop subset of a task. ``camas_run`` exposes the same budget as its
+``under`` argument.
+
 ``Config`` is project configuration, discovered by type: bind
 ``_ = Config(default_task=...)`` and bare ``camas`` runs that task
 (``github_task`` takes over under GitHub Actions).

--- a/src/camas/core/budget.py
+++ b/src/camas/core/budget.py
@@ -1,0 +1,115 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2026 JP Hutchins
+
+"""Time-budgeted scheduling: select the leaves of a task that fit a wall-clock budget."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, NamedTuple, TypeAlias
+
+from ..v0.task import Parallel, Sequential, Task
+from .matrix import expand_matrix
+from .timings import estimate
+from .traversal import flatten_leaves
+
+if TYPE_CHECKING:
+	from collections.abc import Mapping
+
+	from ..v0.task import TaskNode
+	from .timings import TaskLabel, TaskTiming
+
+
+class Fits(NamedTuple):
+	"""A leaf whose estimate is within budget — selected to run."""
+
+	task: Task
+	estimated_s: float
+
+
+class OverBudget(NamedTuple):
+	"""A leaf whose estimate exceeds the budget — excluded."""
+
+	task: Task
+	estimated_s: float
+
+
+class Untimed(NamedTuple):
+	"""A leaf with no recorded estimate — excluded from a strict budget."""
+
+	task: Task
+
+
+Disposition: TypeAlias = Fits | OverBudget | Untimed
+
+
+class BudgetPlan(NamedTuple):
+	"""A budget's verdict over a source task's de-duplicated leaves.
+
+	``node`` is the runnable schedule — mutating leaves in a leading ``Sequential``
+	followed by the read-only remainder as a single ``Parallel`` — or ``None`` when
+	nothing fits.
+	"""
+
+	budget_s: float
+	node: TaskNode | None
+	fits: tuple[Fits, ...]
+	over_budget: tuple[OverBudget, ...]
+	untimed: tuple[Untimed, ...]
+
+
+def classify(task: Task, budget_s: float, timings: Mapping[TaskLabel, TaskTiming]) -> Disposition:
+	"""A leaf's disposition under ``budget_s``, read from its observed estimate.
+
+	>>> from camas.core.timings import TaskTiming
+	>>> classify(Task("a"), 1.0, {"a": TaskTiming(0.5, 1)})
+	Fits(task=Task(cmd='a', name=None, env={}, cwd=None), estimated_s=0.5)
+	>>> classify(Task("a"), 1.0, {"a": TaskTiming(2.0, 1)})
+	OverBudget(task=Task(cmd='a', name=None, env={}, cwd=None), estimated_s=2.0)
+	>>> classify(Task("a"), 1.0, {})
+	Untimed(task=Task(cmd='a', name=None, env={}, cwd=None))
+	"""
+	est = estimate(task, timings)
+	if est is None:
+		return Untimed(task)
+	if est.elapsed_s <= budget_s:
+		return Fits(task, est.elapsed_s)
+	return OverBudget(task, est.elapsed_s)
+
+
+def plan_under(
+	node: TaskNode, budget_s: float, timings: Mapping[TaskLabel, TaskTiming]
+) -> BudgetPlan:
+	"""Partition ``node``'s expanded, de-duplicated leaves by ``budget_s`` and schedule
+	those that fit. Mutating leaves run sequentially first, then the read-only leaves as
+	one parallel group; leaves with no estimate are excluded (a strict budget cannot
+	bound them).
+	"""
+	leaves = tuple(dict.fromkeys(info.task for info in flatten_leaves(expand_matrix(node))))
+	dispositions = tuple(classify(leaf, budget_s, timings) for leaf in leaves)
+	fits = tuple(d for d in dispositions if isinstance(d, Fits))
+	over_budget = tuple(d for d in dispositions if isinstance(d, OverBudget))
+	untimed = tuple(d for d in dispositions if isinstance(d, Untimed))
+	return BudgetPlan(budget_s, schedule(tuple(f.task for f in fits)), fits, over_budget, untimed)
+
+
+def schedule(fitting: tuple[Task, ...]) -> TaskNode | None:
+	"""Order the fitting leaves: mutating leaves sequentially first (formatters before
+	checkers, never racing the read-only group over the same files), then the read-only
+	leaves as one parallel group. ``None`` when nothing fits.
+
+	>>> schedule(()) is None
+	True
+	>>> schedule((Task("ruff check ."),))
+	Parallel(tasks=(Task(cmd='ruff check .', name=None, env={}, cwd=None),), name=None, matrix=None, env={}, cwd=None)
+	>>> schedule((Task("ruff format .", mutates=True),))
+	Sequential(tasks=(Task(cmd='ruff format .', name=None, env={}, cwd=None, mutates=True),), name=None, matrix=None, env={}, cwd=None)
+	"""
+	mutating = tuple(t for t in fitting if t.mutates)
+	readonly = tuple(t for t in fitting if not t.mutates)
+	if not mutating and not readonly:
+		return None
+	if not mutating:
+		return Parallel(*readonly)
+	if not readonly:
+		return Sequential(*mutating)
+	return Sequential(*mutating, Parallel(*readonly))

--- a/src/camas/core/budget.py
+++ b/src/camas/core/budget.py
@@ -43,12 +43,7 @@ Disposition: TypeAlias = Fits | OverBudget | Untimed
 
 
 class BudgetPlan(NamedTuple):
-	"""A budget's verdict over a source task's de-duplicated leaves.
-
-	``node`` is the runnable schedule — mutating leaves in a leading ``Sequential``
-	followed by the read-only remainder as a single ``Parallel`` — or ``None`` when
-	nothing fits.
-	"""
+	"""A budget's partition of a task's leaves, with the runnable schedule of those that fit."""
 
 	budget_s: float
 	node: TaskNode | None
@@ -79,10 +74,8 @@ def classify(task: Task, budget_s: float, timings: Mapping[TaskLabel, TaskTiming
 def plan_under(
 	node: TaskNode, budget_s: float, timings: Mapping[TaskLabel, TaskTiming]
 ) -> BudgetPlan:
-	"""Partition ``node``'s expanded, de-duplicated leaves by ``budget_s`` and schedule
-	those that fit. Mutating leaves run sequentially first, then the read-only leaves as
-	one parallel group; leaves with no estimate are excluded (a strict budget cannot
-	bound them).
+	"""Partition ``node``'s expanded, de-duplicated leaves by ``budget_s``; untimed leaves
+	are excluded, since a budget can't bound a leaf it has never measured.
 	"""
 	leaves = tuple(dict.fromkeys(info.task for info in flatten_leaves(expand_matrix(node))))
 	dispositions = tuple(classify(leaf, budget_s, timings) for leaf in leaves)
@@ -93,9 +86,8 @@ def plan_under(
 
 
 def schedule(fitting: tuple[Task, ...]) -> TaskNode | None:
-	"""Order the fitting leaves: mutating leaves sequentially first (formatters before
-	checkers, never racing the read-only group over the same files), then the read-only
-	leaves as one parallel group. ``None`` when nothing fits.
+	"""Mutating leaves run before the read-only group, so a formatter never races a
+	checker over the same files.
 
 	>>> schedule(()) is None
 	True

--- a/src/camas/core/matrix.py
+++ b/src/camas/core/matrix.py
@@ -96,6 +96,7 @@ def specialize_task(task: Task, binding: MatrixBinding, suffix: str) -> Task:
 		env={k: substitute_in_str(v, binding) for k, v in task.env.items()} | dict(binding),
 		cwd=substitute_cwd(task.cwd, binding),
 		help=substitute_help(task.help, binding),
+		mutates=task.mutates,
 	)
 
 
@@ -325,6 +326,7 @@ def expand_matrix(
 				env={**parent_env, **task.env},
 				cwd=task.cwd if task.cwd is not None else ancestor_cwd,
 				help=task.help,
+				mutates=task.mutates,
 			)
 		case Sequential(tasks=tasks, matrix=matrix, env=env, cwd=cwd):
 			seq_env: Final = parent_env | env

--- a/src/camas/main/argv.py
+++ b/src/camas/main/argv.py
@@ -65,13 +65,14 @@ def apply_passthrough(task: TaskNode, args: tuple[str, ...]) -> Task:
 	Task(cmd="pytest -k 'a b'", name=None, env={}, cwd=None)
 	"""
 	match task:
-		case Task(cmd=cmd, name=name, env=env, cwd=cwd, help=help):
+		case Task(cmd=cmd, name=name, env=env, cwd=cwd, help=help, mutates=mutates):
 			return Task(
 				cmd=f"{cmd} {shlex.join(args)}" if isinstance(cmd, str) else cmd + args,
 				name=name,
 				env=env,
 				cwd=cwd,
 				help=help,
+				mutates=mutates,
 			)
 		case Sequential() | Parallel():
 			raise ValueError(

--- a/src/camas/main/dispatch.py
+++ b/src/camas/main/dispatch.py
@@ -10,16 +10,19 @@ import os
 import re
 import sys
 from pathlib import Path
-from typing import TYPE_CHECKING, Final, cast
+from typing import TYPE_CHECKING, Any, Final, cast
 
 if sys.version_info >= (3, 11):
 	from typing import assert_never
 else:  # pragma: no cover
 	from typing_extensions import assert_never
 
+from ..core import timings
+from ..core.budget import plan_under
 from ..core.execution import run
 from ..core.matrix import matrix_axes, override_matrix
 from ..core.render import print_tree
+from ..core.task import task_label
 from ..v0.config import Config
 from .argv import apply_passthrough, parse_axis_values, parse_matrix_kv, split_passthrough
 from .effects import default_effect_names, resolve_effects, running_under_agent
@@ -44,8 +47,11 @@ from .tasks import (
 
 if TYPE_CHECKING:
 	import io
-	from collections.abc import Mapping
+	from collections.abc import Mapping, Sequence
 
+	from ..core.budget import BudgetPlan
+	from ..core.completion import RunResult
+	from ..v0.effect import Effect
 	from ..v0.task import TaskNode
 
 
@@ -71,6 +77,60 @@ def dispatch_arg(arg: str, tasks: Mapping[str, TaskNode]) -> TaskNode:
 		print(f"error: no task named {arg!r} (known: {known})", file=sys.stderr)
 		sys.exit(2)
 	return parse_expression(arg, tasks=tasks)
+
+
+def budget_summary_lines(plan: BudgetPlan) -> list[str]:
+	"""The ``--under`` summary: how many leaves fit the budget, and what was excluded."""
+	excluded = len(plan.over_budget) + len(plan.untimed)
+	lines = [
+		f"Time budget {plan.budget_s:.2f}s — selected {len(plan.fits)} leaf(s), "
+		f"excluded {excluded} ({len(plan.over_budget)} over budget, {len(plan.untimed)} untimed)."
+	]
+	if plan.over_budget:
+		lines.append(
+			"  over budget: "
+			+ ", ".join(f"{task_label(o.task)} ~{o.estimated_s:.2f}s" for o in plan.over_budget)
+		)
+	if plan.untimed:
+		lines.append(
+			"  untimed (run the task normally once to record an estimate): "
+			+ ", ".join(task_label(u.task) for u in plan.untimed)
+		)
+	if plan.node is None:
+		lines.append("Nothing fits the budget — nothing to run.")
+	return lines
+
+
+def run_under(
+	source: TaskNode,
+	budget_s: float,
+	*,
+	camas_dir: Path | None,
+	effects: Sequence[Effect[Any]],
+	jobs: int | None,
+	dry_run: bool,
+	passthrough: tuple[str, ...],
+) -> int:
+	"""Plan and run the leaves of ``source`` that fit ``budget_s``; return the exit code."""
+	if passthrough:
+		print("error: -- passthrough args cannot be combined with --under", file=sys.stderr)
+		return 2
+	plan = plan_under(source, budget_s, timings.load(camas_dir) if camas_dir is not None else {})
+	for line in budget_summary_lines(plan):
+		print(line)
+	if plan.node is None:
+		return 0
+	if dry_run:
+		print_tree(plan.node, show_cmd=True)
+		return 0
+	return finish_run(asyncio.run(run(plan.node, effects=effects, jobs=jobs)))
+
+
+def finish_run(result: RunResult) -> int:
+	"""Print the interrupt banner for a Ctrl-C'd run and return the run's exit code."""
+	if result.interrupt_count:
+		print_interrupt_banner(result.interrupt_count)
+	return result.returncode
 
 
 def print_interrupt_banner(count: int) -> None:
@@ -278,6 +338,25 @@ def dispatch(state: TasksState, argv: list[str] | None = None) -> None:
 				except ValueError as e:
 					print(f"error: {e}", file=sys.stderr)
 					sys.exit(2)
+
+			if args.under is not None:
+				try:
+					budget_jobs: Final = resolve_jobs(args.jobs)
+				except ValueError as e:
+					print(f"error: {e}", file=sys.stderr)
+					sys.exit(2)
+				sys.exit(
+					run_under(
+						resolved,
+						args.under,
+						camas_dir=camas_dir,
+						effects=effects,
+						jobs=budget_jobs,
+						dry_run=args.dry_run,
+						passthrough=split.passthrough,
+					)
+				)
+
 			try:
 				task: Final = (
 					apply_passthrough(resolved, split.passthrough)
@@ -295,10 +374,7 @@ def dispatch(state: TasksState, argv: list[str] | None = None) -> None:
 			except ValueError as e:
 				print(f"error: {e}", file=sys.stderr)
 				sys.exit(2)
-			result: Final = asyncio.run(run(task, effects=effects, jobs=jobs))
-			if result.interrupt_count:
-				print_interrupt_banner(result.interrupt_count)
-			sys.exit(result.returncode)
+			sys.exit(finish_run(asyncio.run(run(task, effects=effects, jobs=jobs))))
 
 		case _:
 			assert_never(state)

--- a/src/camas/main/expression.py
+++ b/src/camas/main/expression.py
@@ -99,6 +99,16 @@ def eval_opt_str(node: ast.expr | None) -> str | None:
 			raise ValueError(f"expected str or None, got {ast.dump(node)}")
 
 
+def eval_opt_bool(node: ast.expr | None) -> bool:
+	match node:
+		case None:
+			return False
+		case ast.Constant(value=bool() as b):
+			return b
+		case _:
+			raise ValueError(f"expected bool literal, got {ast.dump(node)}")
+
+
 def eval_env(node: ast.expr | None) -> dict[str, str]:
 	match node:
 		case None:
@@ -205,6 +215,7 @@ def eval_node(
 						env=eval_env(kw.get("env")),
 						cwd=eval_opt_str(kw.get("cwd")),
 						help=eval_opt_str(kw.get("help")),
+						mutates=eval_opt_bool(kw.get("mutates")),
 					)
 				case "Sequential" | "Parallel":
 					ctor = Sequential if name == "Sequential" else Parallel
@@ -289,6 +300,8 @@ def to_expression(node: TaskNode) -> str:
 	'Task("ruff check .")'
 	>>> to_expression(Task("ruff", name="lint"))
 	'Task("ruff", name="lint")'
+	>>> to_expression(Task("ruff format .", mutates=True))
+	'Task("ruff format .", mutates=True)'
 	>>> to_expression(Sequential(Task("a"), Task("b")))
 	'Sequential(Task("a"), Task("b"))'
 	>>> to_expression(Parallel(Task("a"), Task("b"), name="checks"))
@@ -297,8 +310,8 @@ def to_expression(node: TaskNode) -> str:
 	'Sequential(Parallel(Task("a"), name="p"), Task("b"), name="s")'
 	"""
 	match node:
-		case Task(cmd=cmd, name=name):
-			return f"Task({quote(join_command(cmd))}{name_kwarg(name)})"
+		case Task(cmd=cmd, name=name, mutates=mutates):
+			return f"Task({quote(join_command(cmd))}{name_kwarg(name)}{mutates_kwarg(mutates)})"
 		case Sequential(tasks=tasks, name=name):
 			return f"Sequential({render_members(tasks)}{name_kwarg(name)})"
 		case Parallel(tasks=tasks, name=name):
@@ -313,6 +326,10 @@ def render_members(tasks: tuple[TaskNode, ...]) -> str:
 
 def name_kwarg(name: str | None) -> str:
 	return f", name={quote(name)}" if name is not None else ""
+
+
+def mutates_kwarg(mutates: bool) -> str:
+	return ", mutates=True" if mutates else ""
 
 
 def quote(value: str) -> str:

--- a/src/camas/main/parser.py
+++ b/src/camas/main/parser.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import argparse
 import importlib.metadata
 import os
+import re
 import sys
 from typing import TYPE_CHECKING, Any, Final
 
@@ -100,6 +101,45 @@ def positive_jobs(raw: str) -> int:
 	if n < 1:
 		raise argparse.ArgumentTypeError(f"--jobs must be >= 1, got {n}")
 	return n
+
+
+_DURATION: Final = re.compile(r"\s*(\d+(?:\.\d+)?)\s*(ms|s|m|h)?\s*")
+
+
+def parse_duration(raw: str) -> float:
+	"""Validate ``--under`` as an argparse ``type``: a positive duration in seconds.
+
+	Accepts a bare number (seconds) or a ``ms``/``s``/``m``/``h`` suffix.
+
+	Raises:
+		ArgumentTypeError: when ``raw`` is not a positive duration.
+
+	>>> parse_duration("1.5s")
+	1.5
+	>>> parse_duration("500ms")
+	0.5
+	>>> parse_duration("2m")
+	120.0
+	>>> parse_duration("3")
+	3.0
+	"""
+	m = _DURATION.fullmatch(raw)
+	if m is None:
+		raise argparse.ArgumentTypeError(
+			f"--under expects a duration like '1s', '500ms', '2m', got {raw!r}"
+		)
+	value = float(m.group(1))
+	if value <= 0:
+		raise argparse.ArgumentTypeError(f"--under must be positive, got {raw!r}")
+	match m.group(2):
+		case "ms":
+			return value / 1000.0
+		case "m":
+			return value * 60.0
+		case "h":
+			return value * 3600.0
+		case _:
+			return value
 
 
 def resolve_jobs(cli_jobs: int | None) -> int | None:
@@ -263,11 +303,33 @@ def build_parser(state: TasksState = EMPTY_STATE) -> argparse.ArgumentParser:
 		"fan-out, so --jobs can only slow a run down; reach for it only when a "
 		"wide matrix oversubscribes the machine (CPU/RAM/disk)",
 	)
+	parser.add_argument(
+		"--under",
+		type=parse_duration,
+		default=None,
+		metavar="DURATION",
+		help="run only the task's leaves whose timed estimate fits DURATION (e.g. 1s, "
+		"500ms, 2m), mutating leaves (formatters) first then the read-only rest in "
+		"parallel; untimed leaves are skipped. Operates on the named task, or the "
+		"Config default when none is given",
+	)
 	return parser
 
 
 RESERVED_FLAGS: Final = frozenset(
-	{"help", "version", "dry-run", "list", "tree", "check", "init", "effects", "matrix", "jobs"}
+	{
+		"help",
+		"version",
+		"dry-run",
+		"list",
+		"tree",
+		"check",
+		"init",
+		"effects",
+		"matrix",
+		"jobs",
+		"under",
+	}
 )
 
 

--- a/src/camas/main/tasks.py
+++ b/src/camas/main/tasks.py
@@ -47,8 +47,8 @@ def assign_key_name(node: TaskNode | Ref, key: str) -> TaskNode | Ref:
 	Ref(name='bar')
 	"""
 	match node:
-		case Task(cmd=cmd, name=None, env=env, cwd=cwd, help=help):
-			return Task(cmd=cmd, name=key, env=env, cwd=cwd, help=help)
+		case Task(cmd=cmd, name=None, env=env, cwd=cwd, help=help, mutates=mutates):
+			return Task(cmd=cmd, name=key, env=env, cwd=cwd, help=help, mutates=mutates)
 		case Sequential(tasks=tasks, name=None, matrix=matrix, env=env, cwd=cwd, help=help):
 			return Sequential(*tasks, name=key, matrix=matrix, env=env, cwd=cwd, help=help)
 		case Parallel(tasks=tasks, name=None, matrix=matrix, env=env, cwd=cwd, help=help):

--- a/src/camas/mcp/serve.py
+++ b/src/camas/mcp/serve.py
@@ -23,9 +23,11 @@ from mcp.server.lowlevel.server import NotificationOptions
 from pydantic import AnyUrl, BaseModel, ValidationError
 
 from ..core import timings
+from ..core.budget import plan_under
 from ..core.execution import run
 from ..core.matrix import override_matrix
 from ..core.render import render_tree_lines, strip_ansi
+from ..core.task import task_label
 from ..main.argv import apply_passthrough
 from ..main.format import format_load_error_hint
 from ..main.state import EMPTY_STATE, LoadErr, LoadOk, TasksState
@@ -45,6 +47,7 @@ else:  # pragma: no cover
 if TYPE_CHECKING:
 	from collections.abc import Mapping, Sequence
 
+	from ..core.budget import BudgetPlan
 	from ..core.completion import RunResult, TaskResult
 	from ..v0.task import TaskNode
 
@@ -282,9 +285,12 @@ def tools(task_names: tuple[str, ...], compat: Compat) -> Tools:
 				leaf's full output. For a tight inner loop, pass args=[…] to append flags to a
 				single-leaf task (camas's -- passthrough, e.g. args=['tests/test_x.py::test_y',
 				'-x'] to run and fail-fast on one test); composite tasks reject args, so target
-				a leaf. Compact failures-first summary by default; dry_run=true previews the
-				fully-resolved plan without executing. A non-zero result means a task failed — a
-				normal result, not a tool error.
+				a leaf. For a time-boxed inner loop, pass under=<seconds> to run only the leaves
+				whose recorded estimate fits — mutating leaves (formatters) first, then the
+				read-only rest in parallel; omit task to budget the project default. Compact
+				failures-first summary by default; dry_run=true previews the fully-resolved plan
+				without executing. A non-zero result means a task failed — a normal result, not a
+				tool error.
 			""").strip(),
 			input_schema=wire.run_input_schema(task_names),
 			output_model=wire.RunResponse,
@@ -366,53 +372,171 @@ async def run_call(session: Session, arguments: dict[str, Any]) -> types.CallToo
 	match session.project:
 		case LoadErr(source=source, exception=exception):
 			return error_result(format_load_error_hint(source, exception))
-		case LoadOk(tasks=tasks):
-			return await run_for(session, tasks, arguments)
+		case LoadOk(tasks=tasks, config=config):
+			return await run_for(session, tasks, config, arguments)
 		case _:
 			assert_never(session.project)
 
 
 async def run_for(
-	session: Session, tasks: Mapping[str, TaskNode], arguments: dict[str, Any]
+	session: Session,
+	tasks: Mapping[str, TaskNode],
+	config: Config | None,
+	arguments: dict[str, Any],
 ) -> types.CallToolResult:
 	"""Validate, resolve the node, then dry-run or execute in the server's event loop."""
 	try:
 		req = wire.RunRequest.model_validate(arguments)
 	except ValidationError as e:
 		return error_result(f"invalid camas_run arguments:\n{e}")
+	if req.under is not None:
+		return await run_budget(session, tasks, config, req, req.under)
 	try:
-		node = resolve_run_node(tasks, req)
+		name, node = resolve_run_node(tasks, req)
 	except ValueError as e:
 		return error_result(str(e))
 	if req.dry_run:
 		return success(dry_run_text(node), to_plan_response(node), session.compat)
 	result = await run(node, jobs=req.jobs, interactive=False)
-	logs = write_logs(
-		create_run_log_dir(session.camas_dir, req.task, session.reserve_run()), result
-	)
+	logs = write_logs(create_run_log_dir(session.camas_dir, name, session.reserve_run()), result)
 	timings.record_run(session.camas_dir, result)
 	resp = attach_logs(to_run_response(node, result, verbosity=req.verbosity), logs)
 	return success(
-		run_text(req.task, resp, logs), resp, session.compat, links=failing_log_links(resp, logs)
+		run_text(name, resp, logs), resp, session.compat, links=failing_log_links(resp, logs)
 	)
 
 
-def resolve_run_node(tasks: Mapping[str, TaskNode], req: wire.RunRequest) -> TaskNode:
-	"""The node to run: looked up by name, then matrix-overridden and passthrough-appended.
+def resolve_run_node(tasks: Mapping[str, TaskNode], req: wire.RunRequest) -> tuple[str, TaskNode]:
+	"""The ``(name, node)`` to run: looked up by name, then matrix-overridden and
+	passthrough-appended.
 
 	Raises:
-		ValueError: when ``req.task`` names no task, an override targets an unknown
-			matrix axis, or passthrough args are applied to a non-leaf task.
+		ValueError: when ``req.task`` is omitted (only ``under`` may omit it), names no
+			task, an override targets an unknown matrix axis, or passthrough args are
+			applied to a non-leaf task.
 	"""
-	if req.task not in tasks:
+	name = req.task
+	if name is None:
+		raise ValueError("camas_run requires 'task' (or pass 'under' to budget the default task)")
+	if name not in tasks:
 		known = ", ".join(sorted(tasks)) or "none"
-		raise ValueError(f"no task named {req.task!r} (known: {known})")
-	node = tasks[req.task]
+		raise ValueError(f"no task named {name!r} (known: {known})")
+	node = tasks[name]
 	if req.matrix_overrides:
 		node = override_matrix(node, {k: tuple(v) for k, v in req.matrix_overrides.items()})
 	if req.args:
 		node = apply_passthrough(node, tuple(req.args))
-	return node
+	return name, node
+
+
+async def run_budget(
+	session: Session,
+	tasks: Mapping[str, TaskNode],
+	config: Config | None,
+	req: wire.RunRequest,
+	budget_s: float,
+) -> types.CallToolResult:
+	"""Handle ``camas_run`` with ``under``: select the source task's leaves that fit the
+	budget, schedule mutating leaves first, then dry-run or execute the read-only group.
+	"""
+	if req.args:
+		return error_result("camas_run: 'args' (passthrough) cannot be combined with 'under'")
+	try:
+		source = budget_source(tasks, config, req.task)
+		if req.matrix_overrides:
+			source = override_matrix(source, {k: tuple(v) for k, v in req.matrix_overrides.items()})
+	except ValueError as e:
+		return error_result(str(e))
+	plan = plan_under(source, budget_s, timings.load(session.camas_dir))
+	report = to_budget_report(plan)
+	label = req.task or "default task"
+	if plan.node is None:
+		empty = wire.RunResponse(
+			returncode=0, elapsed=0.0, passed=0, failed=0, skipped=0, interrupt_count=0, leaves=()
+		)
+		text = f"{budget_headline(report)}\n\nNothing ran — no leaf fit the budget."
+		return success(text, attach_budget(empty, report), session.compat)
+	if req.dry_run:
+		resp = attach_budget(to_plan_response(plan.node), report)
+		return success(
+			f"{budget_headline(report)}\n\n{dry_run_text(plan.node)}", resp, session.compat
+		)
+	result = await run(plan.node, jobs=req.jobs, interactive=False)
+	logs = write_logs(create_run_log_dir(session.camas_dir, label, session.reserve_run()), result)
+	timings.record_run(session.camas_dir, result)
+	resp = attach_budget(
+		attach_logs(to_run_response(plan.node, result, verbosity=req.verbosity), logs), report
+	)
+	return success(
+		f"{budget_headline(report)}\n\n{run_text(label, resp, logs)}",
+		resp,
+		session.compat,
+		links=failing_log_links(resp, logs),
+	)
+
+
+def budget_source(
+	tasks: Mapping[str, TaskNode], config: Config | None, task: str | None
+) -> TaskNode:
+	"""The task a budget run filters: the named task, else the project's default task.
+
+	Raises:
+		ValueError: when ``task`` names no task, or no task is named and no
+			:class:`Config` default exists to budget.
+	"""
+	if task is not None:
+		if task not in tasks:
+			known = ", ".join(sorted(tasks)) or "none"
+			raise ValueError(f"no task named {task!r} (known: {known})")
+		return tasks[task]
+	default = config.default_task if config is not None else None
+	if default is None:
+		raise ValueError("no task given and no Config default_task to budget; name a task to run")
+	return default
+
+
+def to_budget_report(plan: BudgetPlan) -> wire.BudgetReport:
+	"""The wire ``BudgetReport`` for a plan: the selected leaves and the excluded ones."""
+	return wire.BudgetReport(
+		budget_s=plan.budget_s,
+		selected=tuple(task_label(f.task) for f in plan.fits),
+		excluded=(
+			*(
+				wire.ExcludedLeaf(
+					name=task_label(o.task), reason="over_budget", estimated_s=o.estimated_s
+				)
+				for o in plan.over_budget
+			),
+			*(wire.ExcludedLeaf(name=task_label(u.task), reason="untimed") for u in plan.untimed),
+		),
+	)
+
+
+def attach_budget(resp: wire.RunResponse, report: wire.BudgetReport) -> wire.RunResponse:
+	"""Thread the budget partition into the run response's ``budget`` field."""
+	return resp.model_copy(update={"budget": report})
+
+
+def budget_headline(report: wire.BudgetReport) -> str:
+	"""The load-bearing budget summary: leaves selected, and what was excluded and why."""
+	over = tuple(e for e in report.excluded if e.reason == "over_budget")
+	untimed = tuple(e for e in report.excluded if e.reason == "untimed")
+	lines = [
+		f"Time budget {report.budget_s:.2f}s — selected {len(report.selected)} leaf(s), "
+		f"excluded {len(report.excluded)} ({len(over)} over budget, {len(untimed)} untimed)."
+	]
+	if over:
+		lines.append("  over budget: " + ", ".join(excluded_note(e) for e in over))
+	if untimed:
+		lines.append(
+			"  untimed (run the task normally once to record an estimate): "
+			+ ", ".join(excluded_note(e) for e in untimed)
+		)
+	return "\n".join(lines)
+
+
+def excluded_note(leaf: wire.ExcludedLeaf) -> str:
+	return f"{leaf.name} ~{leaf.estimated_s:.2f}s" if leaf.estimated_s is not None else leaf.name
 
 
 def create_run_log_dir(camas_dir: Path, task: str, seq: int) -> Path:

--- a/src/camas/mcp/serve.py
+++ b/src/camas/mcp/serve.py
@@ -415,18 +415,17 @@ def resolve_run_node(tasks: Mapping[str, TaskNode], req: wire.RunRequest) -> tup
 			task, an override targets an unknown matrix axis, or passthrough args are
 			applied to a non-leaf task.
 	"""
-	name = req.task
-	if name is None:
+	if req.task is None:
 		raise ValueError("camas_run requires 'task' (or pass 'under' to budget the default task)")
-	if name not in tasks:
+	if req.task not in tasks:
 		known = ", ".join(sorted(tasks)) or "none"
-		raise ValueError(f"no task named {name!r} (known: {known})")
-	node = tasks[name]
+		raise ValueError(f"no task named {req.task!r} (known: {known})")
+	node = tasks[req.task]
 	if req.matrix_overrides:
 		node = override_matrix(node, {k: tuple(v) for k, v in req.matrix_overrides.items()})
 	if req.args:
 		node = apply_passthrough(node, tuple(req.args))
-	return name, node
+	return req.task, node
 
 
 async def run_budget(
@@ -436,9 +435,7 @@ async def run_budget(
 	req: wire.RunRequest,
 	budget_s: float,
 ) -> types.CallToolResult:
-	"""Handle ``camas_run`` with ``under``: select the source task's leaves that fit the
-	budget, schedule mutating leaves first, then dry-run or execute the read-only group.
-	"""
+	"""Handle ``camas_run`` with ``under``: budget the source task's leaves, then dry-run or execute."""
 	if req.args:
 		return error_result("camas_run: 'args' (passthrough) cannot be combined with 'under'")
 	try:

--- a/src/camas/mcp/wire.py
+++ b/src/camas/mcp/wire.py
@@ -53,6 +53,24 @@ class LeafReport(BaseModel):
 	"""Filesystem path to this leaf's full output log, when one was written."""
 
 
+class ExcludedLeaf(BaseModel):
+	"""A leaf a time budget did not run, and why."""
+
+	name: str
+	reason: Literal["over_budget", "untimed"]
+	estimated_s: float | None = None
+	"""The leaf's observed estimate; null when it has never been timed."""
+
+
+class BudgetReport(BaseModel):
+	"""How a ``camas_run`` time budget (``under``) partitioned the task's leaves."""
+
+	budget_s: float
+	selected: tuple[str, ...]
+	"""Leaves whose estimate fit the budget — the ones that were scheduled to run."""
+	excluded: tuple[ExcludedLeaf, ...]
+
+
 class RunResponse(BaseModel):
 	"""Structured result of a run — camas's ``RunResult``, faithfully on the wire."""
 
@@ -64,6 +82,8 @@ class RunResponse(BaseModel):
 	interrupt_count: int
 	leaves: tuple[LeafReport, ...]
 	truncated: bool = False
+	budget: BudgetReport | None = None
+	"""Present when the run was time-budgeted (``camas_run`` with ``under``)."""
 
 
 class TaskInfo(BaseModel):
@@ -137,7 +157,19 @@ class RunRequest(BaseModel):
 
 	model_config = ConfigDict(extra="forbid")
 
-	task: str = Field(description="Task name to run — one of the names returned by camas_list.")
+	task: str | None = Field(
+		default=None,
+		description="Task name to run — one of the names returned by camas_list. May be "
+		"omitted only with 'under', which then budgets the project's default task.",
+	)
+	under: float | None = Field(
+		default=None,
+		gt=0,
+		description="Wall-clock budget in seconds: run only the leaves whose recorded "
+		"estimate fits, mutating leaves (formatters) first then the read-only rest in "
+		"parallel. Untimed leaves are skipped. Omit 'task' to budget the default task; "
+		"the 'budget' field of the response reports what was selected and excluded.",
+	)
 	dry_run: bool = Field(
 		default=False,
 		description="Preview the fully-resolved task tree without executing anything.",
@@ -165,12 +197,17 @@ class RunRequest(BaseModel):
 def run_input_schema(task_names: tuple[str, ...]) -> dict[str, Any]:
 	"""``RunRequest``'s JSON Schema with the live task-name ``enum`` spliced into ``task``.
 
+	``task`` is ``str | None`` (a budget run may omit it), so the enum lands on the
+	string branch of the ``anyOf`` rather than the property itself.
+
 	>>> schema = run_input_schema(("lint", "test"))
-	>>> schema["properties"]["task"]["enum"]
+	>>> next(b["enum"] for b in schema["properties"]["task"]["anyOf"] if b.get("type") == "string")
 	['lint', 'test']
 	>>> schema["additionalProperties"]
 	False
 	"""
-	schema = RunRequest.model_json_schema()
-	schema["properties"]["task"]["enum"] = list(task_names)
+	schema: dict[str, Any] = RunRequest.model_json_schema()
+	for branch in schema["properties"]["task"]["anyOf"]:
+		if branch.get("type") == "string":
+			branch["enum"] = list(task_names)
 	return schema

--- a/src/camas/v0/task.py
+++ b/src/camas/v0/task.py
@@ -33,6 +33,10 @@ class Task:
 	``help`` is an optional one-line description shown in ``--list`` output and
 	``camas <task> --help`` instead of the bare command.
 
+	``mutates`` marks a leaf that writes the workspace (a formatter or auto-fixer).
+	The ``--under`` budget scheduler runs such leaves sequentially, before the
+	read-only group, so they never race a checker over the same files.
+
 	>>> Task("echo hi")
 	Task(cmd='echo hi', name=None, env={}, cwd=None)
 	>>> Task(("ruff", "check", "."), name="lint")
@@ -43,6 +47,8 @@ class Task:
 	True
 	>>> Task("ruff check .", help="Lint all sources").help
 	'Lint all sources'
+	>>> Task("ruff format .", mutates=True)
+	Task(cmd='ruff format .', name=None, env={}, cwd=None, mutates=True)
 	>>> hash(Task("a")) == hash(Task("a"))
 	True
 	>>> {Task("a", env={"K": "v"}), Task("a", env={"K": "v"})} == {Task("a", env={"K": "v"})}
@@ -54,6 +60,7 @@ class Task:
 	env: Mapping[str, str]
 	cwd: Path | None
 	help: str | None
+	mutates: bool
 
 	def __init__(
 		self,
@@ -62,6 +69,7 @@ class Task:
 		env: Mapping[str, str] = _EMPTY_ENV,
 		cwd: str | Path | None = None,
 		help: str | None = None,
+		mutates: bool = False,
 	) -> None:
 		put = object.__setattr__
 		put(self, "cmd", cmd)
@@ -69,15 +77,30 @@ class Task:
 		put(self, "env", env)
 		put(self, "cwd", Path(cwd) if isinstance(cwd, str) else cwd)
 		put(self, "help", help)
+		put(self, "mutates", mutates)
 
 	def __hash__(self) -> int:
-		return hash((self.cmd, self.name, tuple(sorted(self.env.items())), self.cwd, self.help))
+		return hash(
+			(
+				self.cmd,
+				self.name,
+				tuple(sorted(self.env.items())),
+				self.cwd,
+				self.help,
+				self.mutates,
+			)
+		)
 
 	def __repr__(self) -> str:
-		base = (
-			f"Task(cmd={self.cmd!r}, name={self.name!r}, env={dict(self.env)!r}, cwd={self.cwd!r}"
+		parts = (
+			f"cmd={self.cmd!r}",
+			f"name={self.name!r}",
+			f"env={dict(self.env)!r}",
+			f"cwd={self.cwd!r}",
+			*([f"help={self.help!r}"] if self.help is not None else []),
+			*(["mutates=True"] if self.mutates else []),
 		)
-		return f"{base}, help={self.help!r})" if self.help is not None else f"{base})"
+		return f"Task({', '.join(parts)})"
 
 
 @dataclass(frozen=True, slots=True, init=False, repr=False)

--- a/tasks.py
+++ b/tasks.py
@@ -4,10 +4,10 @@ from pathlib import Path
 
 from camas import Config, Parallel, Sequential, Task
 
-format = Task("uv run ruff format .")
+format = Task("uv run ruff format .", mutates=True)
 format_check = Task("uv run ruff format --check .")
 lint = Task("uv run ruff check .")
-lint_fix = Task("uv run ruff check --fix .")
+lint_fix = Task("uv run ruff check --fix .", mutates=True)
 fix = Sequential(lint_fix, format)
 mypy = Task("uv run mypy .")
 ty = Task("uv run ty check")

--- a/tests/core/test_budget.py
+++ b/tests/core/test_budget.py
@@ -1,0 +1,72 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2026 JP Hutchins
+
+from __future__ import annotations
+
+from camas import Parallel, Sequential, Task
+from camas.core.budget import Fits, OverBudget, Untimed, classify, plan_under, schedule
+from camas.core.timings import TaskTiming
+
+
+def test_classify_fits_over_and_untimed() -> None:
+	timings = {"fast": TaskTiming(0.5, 3), "slow": TaskTiming(9.0, 2)}
+	assert classify(Task("x", name="fast"), 1.0, timings) == Fits(Task("x", name="fast"), 0.5)
+	assert classify(Task("x", name="slow"), 1.0, timings) == OverBudget(Task("x", name="slow"), 9.0)
+	assert classify(Task("x", name="new"), 1.0, timings) == Untimed(Task("x", name="new"))
+
+
+def test_classify_boundary_is_inclusive() -> None:
+	assert isinstance(classify(Task("x", name="a"), 1.0, {"a": TaskTiming(1.0, 1)}), Fits)
+
+
+def test_schedule_orders_mutating_first_then_parallel() -> None:
+	fmt = Task("fmt", mutates=True)
+	assert schedule((Task("lint"), fmt, Task("mypy"))) == Sequential(
+		fmt, Parallel(Task("lint"), Task("mypy"))
+	)
+
+
+def test_schedule_only_readonly_is_parallel() -> None:
+	assert schedule((Task("a"), Task("b"))) == Parallel(Task("a"), Task("b"))
+
+
+def test_schedule_only_mutating_is_sequential() -> None:
+	assert schedule((Task("a", mutates=True),)) == Sequential(Task("a", mutates=True))
+
+
+def test_schedule_empty_is_none() -> None:
+	assert schedule(()) is None
+
+
+def test_plan_under_partitions_and_schedules() -> None:
+	fmt = Task("ruff format", name="fmt", mutates=True)
+	lint = Task("ruff check", name="lint")
+	test = Task("pytest", name="test")
+	source = Sequential(fmt, Parallel(lint, test))
+	timings = {"fmt": TaskTiming(0.2, 5), "lint": TaskTiming(0.4, 5), "test": TaskTiming(9.0, 5)}
+	plan = plan_under(source, 1.0, timings)
+	assert plan.node == Sequential(fmt, Parallel(lint))
+	assert [f.task for f in plan.fits] == [fmt, lint]
+	assert [o.task for o in plan.over_budget] == [test]
+	assert plan.untimed == ()
+
+
+def test_plan_under_excludes_untimed() -> None:
+	a, b = Task("a", name="a"), Task("b", name="b")
+	plan = plan_under(Parallel(a, b), 5.0, {"a": TaskTiming(0.1, 1)})
+	assert plan.node == Parallel(a)
+	assert [u.task for u in plan.untimed] == [b]
+
+
+def test_plan_under_dedups_repeated_leaves() -> None:
+	a = Task("ruff", name="lint")
+	plan = plan_under(Parallel(a, Sequential(a)), 5.0, {"lint": TaskTiming(0.1, 1)})
+	assert plan.node == Parallel(a)
+	assert len(plan.fits) == 1
+
+
+def test_plan_under_nothing_fits_is_none() -> None:
+	plan = plan_under(Task("a", name="a"), 0.1, {"a": TaskTiming(9.0, 1)})
+	assert plan.node is None
+	assert plan.fits == ()
+	assert [o.task for o in plan.over_budget] == [Task("a", name="a")]

--- a/tests/main/test_dispatch.py
+++ b/tests/main/test_dispatch.py
@@ -7,14 +7,16 @@ from typing import TYPE_CHECKING, Any
 
 import pytest
 
-from camas import Config, Parallel, Task
+from camas import Config, Parallel, Sequential, Task
+from camas.core import timings
 from camas.core.color import WHITE
 from camas.core.completion import RunResult
-from camas.main.dispatch import dispatch, print_interrupt_banner
+from camas.main.dispatch import dispatch, print_interrupt_banner, run_under
 from camas.main.state import LoadOk
 
 if TYPE_CHECKING:
 	from collections.abc import Mapping
+	from pathlib import Path
 
 	from camas.v0.effect import Effect
 	from camas.v0.task import TaskNode
@@ -205,3 +207,63 @@ def test_interrupted_run_prints_banner_and_exits_130(
 	with pytest.raises(SystemExit, match="130"):
 		dispatch(_state({}, Config(default_task=Task("true"))), [])
 	assert "Ctrl-C (3) received - exiting" in capsys.readouterr().out
+
+
+def test_dispatch_under_no_timings_runs_nothing(capsys: pytest.CaptureFixture[str]) -> None:
+	with pytest.raises(SystemExit, match="0"):
+		dispatch(_state({"check": Parallel(Task("a"), Task("b"))}), ["check", "--under", "1s"])
+	out = capsys.readouterr().out
+	assert "2 untimed" in out
+	assert "Nothing fits the budget" in out
+
+
+def test_dispatch_under_rejects_passthrough(capsys: pytest.CaptureFixture[str]) -> None:
+	with pytest.raises(SystemExit, match="2"):
+		dispatch(_state({"t": Task("pytest", name="t")}), ["t", "--under", "1s", "--", "-v"])
+	assert "passthrough args cannot be combined with --under" in capsys.readouterr().err
+
+
+def test_dispatch_under_bad_jobs_env_errors(
+	monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+	monkeypatch.setenv("CAMAS_JOBS", "nope")
+	with pytest.raises(SystemExit, match="2"):
+		dispatch(_state({"t": Task("echo", name="t")}), ["t", "--under", "1s"])
+	assert "CAMAS_JOBS" in capsys.readouterr().err
+
+
+def _camas_with_timings(tmp_path: Path, leaves: list[tuple[str, float]]) -> Path:
+	camas = tmp_path / ".camas"
+	camas.mkdir()
+	timings.record(camas, leaves)
+	return camas
+
+
+def test_run_under_dry_run_shows_plan(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+	camas = _camas_with_timings(tmp_path, [("fmt", 0.1), ("lint", 0.2), ("slow", 9.0)])
+	source = Sequential(
+		Task("echo fmt", name="fmt", mutates=True),
+		Parallel(Task("echo lint", name="lint"), Task("echo slow", name="slow")),
+	)
+	code = run_under(
+		source, 1.0, camas_dir=camas, effects=(), jobs=None, dry_run=True, passthrough=()
+	)
+	assert code == 0
+	out = capsys.readouterr().out
+	assert "selected 2 leaf(s)" in out
+	assert "over budget: slow ~9.00s" in out
+
+
+def test_run_under_executes_selected(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+	camas = _camas_with_timings(tmp_path, [("a", 0.1)])
+	source = Parallel(
+		Task(("python", "-c", "print('a')"), name="a"),
+		Task(("python", "-c", "print('b')"), name="b"),
+	)
+	code = run_under(
+		source, 1.0, camas_dir=camas, effects=(), jobs=None, dry_run=False, passthrough=()
+	)
+	assert code == 0
+	assert (
+		"untimed (run the task normally once to record an estimate): b" in capsys.readouterr().out
+	)

--- a/tests/main/test_expression.py
+++ b/tests/main/test_expression.py
@@ -151,6 +151,7 @@ def test_eval_node_threads_every_public_constructor_kwarg() -> None:
 		"env": ("env={'K': 'v'}", "env", {"K": "v"}),
 		"cwd": ("cwd='d'", "cwd", Path("d")),
 		"help": ("help='h'", "help", "h"),
+		"mutates": ("mutates=True", "mutates", True),
 		"matrix": ("matrix={'X': ('1',)}", "matrix", {"X": ("1",)}),
 	}
 	for cls, prefix, variadic in (

--- a/tests/main/test_parser.py
+++ b/tests/main/test_parser.py
@@ -3,11 +3,12 @@
 
 from __future__ import annotations
 
+import argparse
 from typing import TYPE_CHECKING
 
 import pytest
 
-from camas.main.parser import build_parser, resolve_jobs
+from camas.main.parser import build_parser, parse_duration, resolve_jobs
 
 if TYPE_CHECKING:
 	from collections.abc import Mapping
@@ -85,3 +86,27 @@ def test_build_parser_format_help_no_tasks_no_effects(monkeypatch: pytest.Monkey
 	assert "Available tasks" not in out
 	assert "Available Effects" not in out
 	assert "Try:" in out
+
+
+def test_parse_duration_units() -> None:
+	assert parse_duration("1h") == 3600.0
+	assert parse_duration("90") == 90.0
+	assert parse_duration("0.25s") == 0.25
+
+
+def test_parse_duration_rejects_garbage() -> None:
+	with pytest.raises(argparse.ArgumentTypeError, match="duration"):
+		parse_duration("soon")
+	with pytest.raises(argparse.ArgumentTypeError, match="duration"):
+		parse_duration("5x")
+
+
+def test_parse_duration_rejects_nonpositive() -> None:
+	with pytest.raises(argparse.ArgumentTypeError, match="positive"):
+		parse_duration("0")
+	with pytest.raises(argparse.ArgumentTypeError, match="positive"):
+		parse_duration("0ms")
+
+
+def test_under_flag_parses_to_seconds() -> None:
+	assert build_parser().parse_args(["check", "--under", "500ms"]).under == 0.5

--- a/tests/mcp/test_serve.py
+++ b/tests/mcp/test_serve.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import asyncio
 import os
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import pytest
 from mcp import types
@@ -37,6 +37,13 @@ def _session(
 
 PASS = Task(("python", "-c", "print('ok')"), name="lint")
 FAIL = Task(("python", "-c", "import sys; print('boom'); sys.exit(3)"), name="bad")
+
+
+def _task_enum(input_schema: dict[str, Any]) -> list[str]:
+	"""The task-name enum, spliced onto the string branch of the optional ``task`` field."""
+	branches = input_schema["properties"]["task"]["anyOf"]
+	enum: list[str] = next(b["enum"] for b in branches if b.get("type") == "string")
+	return enum
 
 
 def test_resolve_project_finds_tasks_py(tmp_path: Path) -> None:
@@ -122,7 +129,7 @@ def test_tools_default_omits_rich_fields() -> None:
 		("a", "b"), Compat(emit_structured=False)
 	)
 	assert (tool_list.title, tool_list.outputSchema, tool_list.annotations) == (None, None, None)
-	assert tool_run.inputSchema["properties"]["task"]["enum"] == ["a", "b"]
+	assert _task_enum(tool_run.inputSchema) == ["a", "b"]
 	assert (tool_run.outputSchema, tool_run.annotations) == (None, None)
 	assert (tool_check.title, tool_check.outputSchema, tool_check.annotations) == (None, None, None)
 	assert (tool_docs.title, tool_docs.outputSchema, tool_docs.annotations) == (None, None, None)
@@ -484,7 +491,7 @@ async def test_check_via_client_refreshes_catalog_and_notifies(
 	async with create_connected_server_and_client_session(serve.build_server(session)) as client:
 		first = await client.list_tools()
 		run_first = next(t for t in first.tools if t.name == "camas_run")
-		assert run_first.inputSchema["properties"]["task"]["enum"] == ["a"]
+		assert _task_enum(run_first.inputSchema) == ["a"]
 		(tmp_path / "tasks.py").write_text(
 			"from camas import Task\n"
 			"a = Task(('python', '-c', 'pass'))\n"
@@ -493,7 +500,7 @@ async def test_check_via_client_refreshes_catalog_and_notifies(
 		assert "OK" in _text(await client.call_tool("camas_check", {}))
 		after = await client.list_tools()
 		run_after = next(t for t in after.tools if t.name == "camas_run")
-		assert set(run_after.inputSchema["properties"]["task"]["enum"]) == {"a", "b"}
+		assert set(_task_enum(run_after.inputSchema)) == {"a", "b"}
 		ran = await client.call_tool("camas_run", {"task": "b"})
 		assert ran.isError is False
 		assert "PASSED" in _text(ran)
@@ -506,16 +513,130 @@ def test_resolve_run_node_unknown_task_raises() -> None:
 
 def test_resolve_run_node_applies_overrides_and_args() -> None:
 	node = Parallel(Task("test {PY}"), matrix={"PY": ("3.12", "3.13")}, name="m")
-	resolved = serve.resolve_run_node(
+	name, resolved = serve.resolve_run_node(
 		{"m": node}, wire.RunRequest(task="m", matrix_overrides={"PY": ["3.13"]})
 	)
+	assert name == "m"
 	assert isinstance(resolved, Parallel)
 	assert resolved.matrix == {"PY": ("3.13",)}
-	leaf = serve.resolve_run_node(
+	leaf_name, leaf = serve.resolve_run_node(
 		{"t": Task("pytest", name="t")}, wire.RunRequest(task="t", args=["-v"])
 	)
+	assert leaf_name == "t"
 	assert isinstance(leaf, Task)
 	assert leaf.cmd == "pytest -v"
+
+
+def test_resolve_run_node_requires_task() -> None:
+	with pytest.raises(ValueError, match="requires 'task'"):
+		serve.resolve_run_node({"lint": PASS}, wire.RunRequest())
+
+
+def _record(base: Path, leaves: list[tuple[str, float]]) -> None:
+	camas = base / ".camas"
+	camas.mkdir(exist_ok=True)
+	timings.record(camas, leaves)
+
+
+_FMT = Task(("python", "-c", "print('fmt')"), name="fmt", mutates=True)
+_LINT = Task(("python", "-c", "print('lint')"), name="lint")
+_SLOW = Task(("python", "-c", "print('slow')"), name="slow")
+
+
+async def test_run_call_under_selects_runs_and_reports(tmp_path: Path) -> None:
+	default = Sequential(_FMT, Parallel(_LINT, _SLOW), name="all")
+	_record(tmp_path, [("fmt", 0.1), ("lint", 0.2), ("slow", 9.0)])
+	session = _session({"all": default}, Config(default_task=default), tmp_path, rich=True)
+	result = await serve.run_call(session, {"under": 1.0})
+	assert result.isError is False
+	text = _text(result)
+	assert "Time budget 1.00s — selected 2 leaf(s)" in text
+	assert "over budget: slow ~9.00s" in text
+	assert "PASSED" in text
+	assert result.structuredContent is not None
+	budget = result.structuredContent["budget"]
+	assert set(budget["selected"]) == {"fmt", "lint"}
+	assert next(e for e in budget["excluded"] if e["name"] == "slow")["reason"] == "over_budget"
+
+
+async def test_run_call_under_dry_run_previews(tmp_path: Path) -> None:
+	_record(tmp_path, [("a", 0.1)])
+	a = Task(("python", "-c", "print('a')"), name="a")
+	session = _session({"p": Parallel(a, name="p")}, None, tmp_path, rich=True)
+	result = await serve.run_call(session, {"task": "p", "under": 1.0, "dry_run": True})
+	assert result.isError is False
+	assert "Dry run" in _text(result)
+	assert result.structuredContent is not None
+	assert result.structuredContent["budget"]["budget_s"] == 1.0
+
+
+async def test_run_call_under_nothing_fits(tmp_path: Path) -> None:
+	_record(tmp_path, [("a", 9.0)])
+	a = Task(("python", "-c", "print('a')"), name="a")
+	session = _session({"p": Parallel(a, name="p")}, None, tmp_path)
+	result = await serve.run_call(session, {"task": "p", "under": 0.5})
+	assert result.isError is False
+	assert "Nothing ran" in _text(result)
+
+
+async def test_run_call_under_reports_untimed(tmp_path: Path) -> None:
+	_record(tmp_path, [("a", 0.1)])
+	a = Task(("python", "-c", "print('a')"), name="a")
+	b = Task(("python", "-c", "print('b')"), name="b")
+	session = _session({"p": Parallel(a, b, name="p")}, None, tmp_path, rich=True)
+	result = await serve.run_call(session, {"task": "p", "under": 1.0})
+	assert "untimed (run the task normally once to record an estimate): b" in _text(result)
+	assert result.structuredContent is not None
+	excluded = result.structuredContent["budget"]["excluded"]
+	assert next(e for e in excluded if e["name"] == "b")["reason"] == "untimed"
+
+
+async def test_run_call_under_no_task_no_default_errors(tmp_path: Path) -> None:
+	session = _session({"lint": PASS}, None, tmp_path)
+	result = await serve.run_call(session, {"under": 1.0})
+	assert result.isError is True
+	assert "no task given and no Config default_task" in _text(result)
+
+
+async def test_run_call_under_rejects_args(tmp_path: Path) -> None:
+	session = _session({"lint": PASS}, Config(default_task=PASS), tmp_path)
+	result = await serve.run_call(session, {"under": 1.0, "args": ["-v"]})
+	assert result.isError is True
+	assert "'args'" in _text(result)
+
+
+async def test_run_call_missing_task_errors(tmp_path: Path) -> None:
+	session = _session({"lint": PASS}, None, tmp_path)
+	result = await serve.run_call(session, {})
+	assert result.isError is True
+	assert "requires 'task'" in _text(result)
+
+
+async def test_run_call_under_unknown_task_errors(tmp_path: Path) -> None:
+	session = _session({"lint": PASS}, None, tmp_path)
+	result = await serve.run_call(session, {"task": "nope", "under": 1.0})
+	assert result.isError is True
+	assert "no task named 'nope'" in _text(result)
+
+
+async def test_run_call_under_applies_matrix_override(tmp_path: Path) -> None:
+	node = Parallel(Task("echo {PY}", name="t"), matrix={"PY": ("3.12", "3.13")}, name="m")
+	session = _session({"m": node}, None, tmp_path)
+	result = await serve.run_call(
+		session, {"task": "m", "under": 1.0, "matrix_overrides": {"PY": ["3.13"]}}
+	)
+	assert result.isError is False
+	assert "Nothing ran" in _text(result)
+
+
+async def test_run_call_under_bad_matrix_override_errors(tmp_path: Path) -> None:
+	node = Parallel(Task("echo {PY}", name="t"), matrix={"PY": ("3.12",)}, name="m")
+	session = _session({"m": node}, None, tmp_path)
+	result = await serve.run_call(
+		session, {"task": "m", "under": 1.0, "matrix_overrides": {"NOPE": ["x"]}}
+	)
+	assert result.isError is True
+	assert "unknown matrix axis" in _text(result)
 
 
 def test_create_run_log_dir_namespaces_by_task_and_is_idempotent(tmp_path: Path) -> None:

--- a/tests/mcp/test_wire.py
+++ b/tests/mcp/test_wire.py
@@ -50,7 +50,10 @@ def test_run_request_rejects_bad_verbosity() -> None:
 
 def test_run_input_schema_splices_task_enum() -> None:
 	schema = run_input_schema(("lint", "test", "check"))
-	assert schema["properties"]["task"]["enum"] == ["lint", "test", "check"]
+	task_enum = next(
+		b["enum"] for b in schema["properties"]["task"]["anyOf"] if b.get("type") == "string"
+	)
+	assert task_enum == ["lint", "test", "check"]
 	assert schema["additionalProperties"] is False
 	assert schema["properties"]["verbosity"]["enum"] == ["summary", "failures", "full"]
 


### PR DESCRIPTION
Closes #54.

Run, in parallel, every leaf whose timed estimate fits a wall-clock budget — the fast inner-loop subset, picked for you instead of by hand.

## What it adds

- **`Task(mutates=True)`** — marks a leaf that writes the workspace (a formatter / auto-fixer). Threaded through every Task reconstruction site (matrix expand/specialize, passthrough, naming, expression eval/render) and round-trips through `to_expression`/`parse_expression`.
- **CLI `camas --under=<duration>`** — `1s`, `500ms`, `2m`, `1h`, or a bare number of seconds. Budgets the named task/expression, or the `Config` default when none is given.
- **MCP `camas_run` `under` argument** — same budget for agents (the primary use case, per #54). `task` becomes optional when `under` is set (budgets the project default). The response carries a structured `budget` report of what was selected and excluded.

## Scheduling

Selected leaves are run as `Sequential(*mutating, Parallel(*read_only))` — the mutating leaves first, in tree order, then the read-only rest in parallel, so a formatter never races a checker over the same files (the issue's preferred resolution). Sequential's short-circuit semantics are preserved (a failing fixer blocks the read-only group, same as a hand-written `fix` step).

```
$ camas --under=1s --dry-run
Time budget 1.00s — selected 6 leaf(s), excluded 2 (2 over budget, 0 untimed).
  over budget: pyright ~4.57s, coverage ~20.98s
lint_fix → format → (mypy | ty | zuban | pyrefly)
```

## Open-question resolutions (from the issue)

- **Packing**: a filter, not a knapsack — every leaf whose estimate fits is selected ("every task whose estimate fits the budget").
- **Budget semantics**: **per-leaf** — a leaf is selected when its own estimate ≤ budget, so the parallel group's wall-clock stays near the budget.
- **Untimed leaves**: **excluded** (strict) — a budget can't bound an un-estimated leaf; the count is reported so it's visible, and a normal run times them. *(your call)*
- **Scope**: the `Config` default task (override with a name/expression); `camas_run` mirrors it (omit `task`). *(your call)*

Leaves are de-duplicated by value before scheduling, so a leaf shared across the tree runs once.

## Tests & dogfooding

- New `tests/core/test_budget.py`; new `--under`/`parse_duration` cases in the parser & dispatch tests; new `camas_run under=` cases in the MCP tests. **100% coverage**, all five type checkers, lint, and format clean — verified by running the project's own `camas check` / `camas coverage`.
- `tasks.py` marks its `format` / `lint_fix` leaves `mutates=True`, so camas dogfoods the feature.

## Notes

- Filed #58 while working on this: the long-lived `camas mcp` server runs stale camas code after the camas package itself changes, so it couldn't load a `tasks.py` using the new `mutates=` kwarg — a self-development papercut. Verification this session went through the `camas` CLI (fresh working-tree code, same task definitions) instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)