### PR TITLE
fix(mcp): report missing mcp extra cleanly

### DIFF
--- a/src/camas/mcp/cli.py
+++ b/src/camas/mcp/cli.py
@@ -24,7 +24,11 @@ Options:
 
 
 def main(argv: list[str]) -> None:
-	"""Route ``camas mcp [-h|init|--rich|...]``; ``init`` exits with its own code."""
+	"""Route ``camas mcp [-h|init|--rich|...]``; ``init`` exits with its own code.
+
+	Raises:
+		ModuleNotFoundError: if a dependency other than the optional ``mcp`` extra is missing.
+	"""
 	if "-h" in argv or "--help" in argv:
 		print(HELP)
 		return
@@ -32,6 +36,12 @@ def main(argv: list[str]) -> None:
 		from .scaffold import write_mcp_json
 
 		sys.exit(write_mcp_json(argv[1:]))
-	from .serve import serve_stdio
+	try:
+		from .serve import serve_stdio
+	except ModuleNotFoundError as e:
+		if e.name != "mcp":
+			raise
+		print("camas mcp: requires feature camas[mcp]", file=sys.stderr)
+		sys.exit(2)
 
 	serve_stdio(argv)

--- a/tests/mcp/test_lazy_import.py
+++ b/tests/mcp/test_lazy_import.py
@@ -6,11 +6,13 @@ from __future__ import annotations
 import subprocess
 import sys
 from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+import pytest
 
 if TYPE_CHECKING:
+	from collections.abc import Mapping, Sequence
 	from pathlib import Path
-
-	import pytest
 
 
 def test_entrypoint_mcp_branch_invokes_serve(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -22,6 +24,64 @@ def test_entrypoint_mcp_branch_invokes_serve(monkeypatch: pytest.MonkeyPatch) ->
 	monkeypatch.setattr("sys.argv", ["camas", "mcp", "--rich"])
 	main()
 	assert calls == [["--rich"]]
+
+
+def test_entrypoint_mcp_branch_missing_extra_exits_with_feature_hint(
+	monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+	from camas.main import main
+
+	original_import = __import__
+
+	def fake_import(
+		name: str,
+		globals: Mapping[str, object] | None = None,
+		locals: Mapping[str, object] | None = None,
+		fromlist: Sequence[str] = (),
+		level: int = 0,
+	) -> object:
+		if name == "mcp":
+			raise ModuleNotFoundError("No module named 'mcp'", name="mcp")
+		return original_import(name, globals, locals, fromlist, level)
+
+	for module in ("camas.mcp.serve", "mcp"):
+		monkeypatch.delitem(sys.modules, module, raising=False)
+	monkeypatch.setattr("sys.argv", ["camas", "mcp"])
+	with patch("builtins.__import__", fake_import), pytest.raises(SystemExit) as exc:
+		main()
+
+	assert exc.value.code == 2
+	err = capsys.readouterr().err
+	assert "camas mcp: requires feature camas[mcp]" in err
+	assert "pip" not in err
+	assert "uv" not in err
+
+
+def test_entrypoint_mcp_branch_reraises_non_mcp_missing_import(
+	monkeypatch: pytest.MonkeyPatch,
+) -> None:
+	from camas.main import main
+
+	original_import = __import__
+
+	def fake_import(
+		name: str,
+		globals: Mapping[str, object] | None = None,
+		locals: Mapping[str, object] | None = None,
+		fromlist: Sequence[str] = (),
+		level: int = 0,
+	) -> object:
+		if name == "pydantic":
+			raise ModuleNotFoundError("No module named 'pydantic'", name="pydantic")
+		return original_import(name, globals, locals, fromlist, level)
+
+	for module in ("camas.mcp.serve", "pydantic"):
+		monkeypatch.delitem(sys.modules, module, raising=False)
+	monkeypatch.setattr("sys.argv", ["camas", "mcp"])
+	with patch("builtins.__import__", fake_import), pytest.raises(ModuleNotFoundError) as exc:
+		main()
+
+	assert exc.value.name == "pydantic"
 
 
 def test_camas_list_does_not_import_mcp_stack(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Fixes #60.

`camas mcp` currently reaches the server import path before the optional `mcp` dependency is installed. When users install `camas` without the `mcp` extra, the command fails with a bare `ModuleNotFoundError`, which can surface to MCP clients as an opaque connection close.

## Changes

- Catch the missing optional `mcp` dependency at the `camas mcp` serve boundary and exit with a concise extra-focused message: `camas mcp: requires feature camas[mcp]`.
- Re-raise other `ModuleNotFoundError` cases so unrelated import bugs are not hidden.
- Add a regression test that simulates a cold `camas.mcp.serve` import without `mcp` installed.

## Verification

```bash
uv run pytest tests/mcp/test_lazy_import.py -q
uv run pytest tests/mcp/test_lazy_import.py tests/mcp/test_scaffold.py::test_entrypoint_mcp_init_routes_to_scaffold tests/mcp/test_scaffold.py::test_mcp_cli_help_prints_usage -q
uv run ruff check src/camas/mcp/cli.py tests/mcp/test_lazy_import.py
uv run ruff format --check src/camas/mcp/cli.py tests/mcp/test_lazy_import.py
uv run pyright src/camas/mcp/cli.py tests/mcp/test_lazy_import.py
uv run mypy src/camas/mcp/cli.py tests/mcp/test_lazy_import.py
git diff --check
```
