### PR TITLE
fix(mcp): error on unexpected `camas mcp` arguments (#61)

### DIFF
--- a/src/camas/mcp/cli.py
+++ b/src/camas/mcp/cli.py
@@ -24,7 +24,7 @@ Options:
 
 
 def main(argv: list[str]) -> None:
-	"""Route ``camas mcp [-h|init|--rich|...]``; ``init`` exits with its own code.
+	"""Route ``camas mcp [-h|init|--rich]``; ``init`` and an unexpected argument exit with a code.
 
 	Raises:
 		ModuleNotFoundError: if a dependency other than the optional ``mcp`` extra is missing.
@@ -36,6 +36,15 @@ def main(argv: list[str]) -> None:
 		from .scaffold import write_mcp_json
 
 		sys.exit(write_mcp_json(argv[1:]))
+	unexpected = [arg for arg in argv if arg != "--rich"]
+	if unexpected:
+		hint = " (did you mean 'camas mcp init'?)" if "--init" in unexpected else ""
+		print(
+			f"camas mcp: unexpected argument(s): {' '.join(unexpected)}{hint}\n"
+			"Usage: camas mcp [--rich]  or  camas mcp init [--rich]  (camas mcp --help for more)",
+			file=sys.stderr,
+		)
+		sys.exit(2)
 	try:
 		from .serve import serve_stdio
 	except ModuleNotFoundError as e:

--- a/tests/mcp/test_scaffold.py
+++ b/tests/mcp/test_scaffold.py
@@ -106,3 +106,23 @@ def test_mcp_cli_help_prints_usage(capsys: pytest.CaptureFixture[str]) -> None:
 
 	main(["--help"])
 	assert "camas mcp" in capsys.readouterr().out
+
+
+def test_mcp_dash_init_errors_with_hint(capsys: pytest.CaptureFixture[str]) -> None:
+	from camas.mcp.cli import main
+
+	with pytest.raises(SystemExit) as exc:
+		main(["--init"])
+	assert exc.value.code == 2
+	err = capsys.readouterr().err
+	assert "--init" in err
+	assert "camas mcp init" in err
+
+
+def test_mcp_unexpected_arg_errors(capsys: pytest.CaptureFixture[str]) -> None:
+	from camas.mcp.cli import main
+
+	with pytest.raises(SystemExit) as exc:
+		main(["serve"])
+	assert exc.value.code == 2
+	assert "unexpected argument" in capsys.readouterr().err


### PR DESCRIPTION
## Summary

`camas mcp --init` silently fell through to the stdio MCP server — `serve_stdio` only inspects `--rich` and ignores everything else — so a user who meant `camas mcp init` got a hung server with no feedback instead of a scaffolded `.mcp.json`.

This rejects any token other than `--rich` on the serve path with a usage error (exit 2), and special-cases `--init` with a "did you mean `camas mcp init`?" hint. The check runs before the `mcp` extra is imported, so it works even when the optional dependency is absent.

```
$ camas mcp --init
camas mcp: unexpected argument(s): --init (did you mean 'camas mcp init'?)
Usage: camas mcp [--rich]  or  camas mcp init [--rich]  (camas mcp --help for more)
```

## Test plan

- `test_mcp_dash_init_errors_with_hint` — `camas mcp --init` exits 2 and the message points to `camas mcp init`.
- `test_mcp_unexpected_arg_errors` — any stray token (e.g. `serve`) exits 2.
- Existing `tests/mcp/test_scaffold.py` + `tests/mcp/test_lazy_import.py` still green (the validation runs before the serve import, so the `mcp`-extra-missing path is unaffected).

Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)