### PR TITLE
feat(mcp): `camas mcp init` creates .camas with its .gitignore (#62)

### DIFF
--- a/src/camas/mcp/scaffold.py
+++ b/src/camas/mcp/scaffold.py
@@ -11,6 +11,9 @@ import sys
 from pathlib import Path
 from typing import Any, Final, cast
 
+from ..core.timings import ensure_camas_dir
+from ..v0.config import DEFAULT_CAMAS_DIR
+
 SERVER_NAME: Final = "camas"
 
 
@@ -36,10 +39,18 @@ def write_mcp_json(argv: list[str]) -> int:
 	command, args = launcher
 	servers[SERVER_NAME] = {"type": "stdio", "command": command, "args": args}
 	mcp_json_path.write_text(json.dumps(existing, indent=2) + "\n", encoding="utf-8")
+	camas_dir: Final = Path.cwd() / DEFAULT_CAMAS_DIR
+	camas_note: Final = (
+		f"  created {camas_dir} for run logs and timing estimates; delete it to opt out.\n"
+		if not camas_dir.exists()
+		else ""
+	)
+	ensure_camas_dir(camas_dir)
 	print(
 		f"Wrote the {SERVER_NAME!r} MCP server to {mcp_json_path}\n"
-		f"  command: {command} {' '.join(args)}\n\n"
-		f"{portability_note(command)} Reload Claude Code, approve the server, "
+		f"  command: {command} {' '.join(args)}\n"
+		f"{camas_note}"
+		f"\n{portability_note(command)} Reload Claude Code, approve the server, "
 		"then ask it to call camas_list."
 	)
 	return 0

--- a/tests/mcp/test_scaffold.py
+++ b/tests/mcp/test_scaffold.py
@@ -57,6 +57,29 @@ def test_errors_when_no_portable_launcher(
 	assert "not on PATH" in err
 	assert "uv add camas" in err
 	assert not (tmp_path / ".mcp.json").exists()
+	assert not (tmp_path / ".camas").exists()
+
+
+def test_creates_camas_dir_with_gitignore(
+	tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+	monkeypatch.chdir(tmp_path)
+	monkeypatch.setattr("shutil.which", _which("camas"))
+	assert write_mcp_json([]) == 0
+	assert (tmp_path / ".camas" / ".gitignore").read_text(encoding="utf-8") == "*\n"
+	assert "created" in capsys.readouterr().out.lower()
+
+
+def test_existing_camas_dir_left_intact(
+	tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+	monkeypatch.chdir(tmp_path)
+	monkeypatch.setattr("shutil.which", _which("camas"))
+	(tmp_path / ".camas").mkdir()
+	(tmp_path / ".camas" / "timings.txt").write_text("0\n", encoding="utf-8")
+	assert write_mcp_json([]) == 0
+	assert (tmp_path / ".camas" / "timings.txt").read_text(encoding="utf-8") == "0\n"
+	assert "created" not in capsys.readouterr().out.lower()
 
 
 def test_merges_preserving_other_servers(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary

`camas mcp init` wrote `.mcp.json` but stopped there, leaving the project without the `.camas` cache directory. So the first `camas_run` had to create it lazily, and a fresh clone risked committing run logs / `timings.txt` before the catch-all `.gitignore` existed.

This creates `.camas` (with its inner `*` `.gitignore`) on the success path, reusing `core.timings.ensure_camas_dir` — the same routine `camas --init` uses — rather than a bare `mkdir`. Idempotent: an existing `.camas` is left untouched and the "created" line is suppressed.

```
$ camas mcp init
Wrote the 'camas' MCP server to /proj/.mcp.json
  command: camas mcp
  created /proj/.camas for run logs and timing estimates; delete it to opt out.

This entry is portable if your team installs camas on PATH; commit it to share. Reload Claude Code, approve the server, then ask it to call camas_list.
```

The `.camas` dir is only created on success — the no-portable-launcher error path (which returns before writing `.mcp.json`) creates nothing.

## Test plan

- `test_creates_camas_dir_with_gitignore` — `.camas/.gitignore` is `*\n` after init.
- `test_existing_camas_dir_left_intact` — a pre-existing `.camas` keeps its contents and the "created" line is omitted.
- `test_errors_when_no_portable_launcher` — extended to assert no `.camas` is created on the error path.
- Manually verified the CLI output above (fresh dir vs. re-run).

Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)