### PR TITLE
docs(mcp): surface authoring idioms an agent kept missing (#63)

### DIFF
--- a/src/camas/__init__.py
+++ b/src/camas/__init__.py
@@ -6,7 +6,8 @@ Define your task tree in ``tasks.py``. ``camas <name>`` runs a task by
 name, ``camas --list`` enumerates them, ``camas --help`` shows
 everything (tasks + effects + hints), ``camas --effects`` lists the
 available output renderers, ``camas --tree`` prints every task's full
-expansion, and ``--AXIS VAL`` overrides a matrix axis from the CLI.
+expansion, ``camas --init`` scaffolds a commented starter ``tasks.py``
+when none exists, and ``--AXIS VAL`` overrides a matrix axis from the CLI.
 
 A leaf is *any* shell command. The doctests below all run
 ``python -c ...`` snippets only because every CI environment has
@@ -15,6 +16,12 @@ Python; in your real ``tasks.py``, write the actual command::
     Task("ruff check .")
     Task("cargo test", cwd=Path("rust"))
     Task("npm test")
+
+A module-level ``Task``/``Sequential``/``Parallel`` binding takes its
+**variable name** as the task name — ``lint = Task("ruff check .")``
+defines task ``lint`` — so ``name=`` is only for renaming or for naming a
+nested, anonymous group. (The ``[tool.camas.tasks]`` TOML form makes this
+explicit: the table key is the name.)
 
 ``Task``/``Sequential``/``Parallel`` also accept a ``help="..."``
 kwarg that overrides what ``camas --list`` prints for that task —
@@ -28,11 +35,23 @@ writes the workspace (a formatter or auto-fixer). ``camas --under=<dur>``
 recorded timing fits the budget — the marked, mutating ones first in
 sequence, then the read-only rest in parallel — a fast, self-pruning
 inner-loop subset of a task. ``camas_run`` exposes the same budget as its
-``under`` argument.
+``under`` argument. That subset is what a pre-commit / git-hook wants;
+untimed leaves are excluded, so an empty cache (a fresh clone) runs
+nothing under a budget until the task has run once unbudgeted.
+
+Two authoring idioms the engine can't enforce: ``tasks.py`` is
+real Python, so source matrix axis values from the project's single
+source of truth (e.g. read ``.python-version``) instead of hardcoding a
+list that drifts; and model independent, read-only work as ``Parallel``
+(wall-clock ``max``, not ``sum``) — a ``&&`` chain in a previous runner
+was *sequencing*, not a dependency, so reach for ``Sequential`` only for
+real ordering (a mutating step, or one that consumes a prior's output).
 
 ``Config`` is project configuration, discovered by type: bind
 ``_ = Config(default_task=...)`` and bare ``camas`` runs that task
-(``github_task`` takes over under GitHub Actions).
+(``github_task`` takes over under GitHub Actions) — so a CI step is just
+``camas`` (or ``uv run camas``), which won't go stale if you change
+``github_task``.
 
 These five are the unversioned alias for the latest API generation; to
 pin a generation, import from its namespace (``camas.v0``). See the

--- a/src/camas/main/starter.py
+++ b/src/camas/main/starter.py
@@ -37,17 +37,18 @@ greet = Parallel(
 	help="say hello to everyone at once",
 )
 
-# Sequential runs in order, short-circuiting on the first failure;
-# Parallel runs concurrently. They nest freely.
+# Sequential runs in order, short-circuiting on the first failure; Parallel
+# runs concurrently. They nest freely. The binding name is the task name
+# (this defines `ci`); pass name= only to rename or to name a nested,
+# anonymous group like the Parallel below.
 ci = Sequential(
 	hello,
 	Parallel(greet, "python --version"),
-	name="ci",
 )
 
-# Discovered by type (the binding name never matters): bare `camas` runs
-# default_task — or github_task under GitHub Actions, falling back to
-# default_task when unset.
+# Config is discovered by type, under any binding name (here `_`): bare
+# `camas` runs default_task — or github_task under GitHub Actions, falling
+# back to default_task when unset.
 _ = Config(default_task=ci)
 
 # The PEP 723 standalone flow (see the docstring): running this file directly

--- a/src/camas/mcp/serve.py
+++ b/src/camas/mcp/serve.py
@@ -169,6 +169,8 @@ def build_server(session: Session) -> Server[object]:
 			available tasks and what each one runs, camas_run to run one, camas_check to
 			validate the tasks definition after you edit it, and camas_docs for how to
 			author tasks. Call camas_list first; it is the source of truth for task names.
+			If the project has no tasks file yet, scaffold a commented starter with
+			`camas --init` before authoring one by hand.
 		""").strip(),
 	)
 
@@ -592,7 +594,8 @@ def list_text(resp: wire.ListResponse, *, expand_matrix: bool) -> str:
 	if resp.github_default is not None:
 		lines.append(
 			f"github default (exactly what CI runs; run before committing/pushing): "
-			f"{resp.github_default}"
+			f"{resp.github_default}. A bare `camas` runs it under GitHub Actions, so a CI "
+			f"step is just `camas` — naming the task there is redundant."
 		)
 	lines.append("")
 	width = max((len(t.name) for t in resp.tasks), default=0)
@@ -677,7 +680,7 @@ def check_text(resp: wire.CheckResponse) -> str:
 		case "no_tasks":
 			return (
 				"camas_check: no tasks.py or [tool.camas.tasks] found in this project. "
-				"Call camas_docs for how to author one."
+				"Run `camas --init` to scaffold a commented starter, or call camas_docs to author one."
 			)
 		case _:
 			assert_never(resp.status)


### PR DESCRIPTION
## Summary

Issue #63 reports that during a live taskipy→camas migration, an agent reading `camas_docs` authored `tasks.py` straight from the API reference and never adopted camas's *idioms* — a green `camas_check` gave no signal the shape was suboptimal. This PR surfaces those idioms where the agent already looks (docs/text only — no behavior change):

**`camas_docs` tutorial (`src/camas/__init__.py`)**
- **Finding 1** — list `camas --init` in the command rundown as the scaffold step when no `tasks.py` exists.
- **Finding 2** — state the binding-name → task-name rule explicitly: a module-level `Task`/`Sequential`/`Parallel` binding takes its variable name as the task name; `name=` is only for renaming or naming a nested anonymous group (mirrors the `[tool.camas.tasks]` key).
- **Finding 3** — signpost `--under` as the pre-commit / git-hook subset, with the empty-cache caveat (untimed leaves are excluded, so a fresh clone runs nothing until the task has run once unbudgeted).
- **Finding 4** — `tasks.py` is real Python: source matrix axis values from the project's SSOT (e.g. read `.python-version`) instead of hardcoding a drifting list.
- **Finding 6 (docs nudge)** — model independent read-only work as `Parallel` (wall-clock `max`, not `sum`); a `&&` chain in a previous runner was *sequencing*, not a dependency.

**`camas --init` starter (`src/camas/main/starter.py`)**
- **Finding 2** — drop the redundant `name="ci"` (the `ci` binding already names it) and add a teaching comment; disambiguate the adjacent `Config` comment so "binding name never matters" (about `Config`) no longer contradicts the new rule.

**MCP server surfaces (`src/camas/mcp/serve.py`)**
- **Finding 1** — server `instructions` and the `camas_check` "no tasks file" verdict now point at `camas --init`.
- **Finding 5** — `camas_list`'s summary states the github default is run by a *bare* `camas` under GitHub Actions, so the CI step is just `camas`.

### Deferred to follow-up issues
The docs/surfacing half of #63 lands here; the three capability/feature asks are tracked separately:
- **#73** — a `camas_init` MCP tool so an agent can scaffold `tasks.py` over the MCP (Finding 1's capability half).
- **#74** — a parallelism advisory in `camas_check`/`camas_list` flagging needlessly-`Sequential` read-only groups (Finding 6's advisory).
- **#75** — a helper to source a matrix axis from `.python-version` (Finding 4's optional helper).

## Test plan

- Full non-slow suite green: `928 passed` (incl. all doctests — the tutorial additions are prose, outside `>>>` blocks).
- `starter.py`: `test_starter_loads_with_config_default` / `_runs_to_completion` / `_cli_init_then_list` confirm `ci` is still named `ci` and the tree runs after dropping `name="ci"`.
- `serve.py` / `docs.py` text assertions still hold (substring checks preserved).
- ruff format + ruff check + mypy clean on all touched files.
- Prose was run through an adversarial review (slop / accuracy / voice lenses); accuracy verified against the implementation, and the flagged redundancies/qualifiers were tightened before commit.

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)
