### PR TITLE
fix(termtree): size rows by display width so wide glyphs can't wrap the live repaint (#64)

### DIFF
--- a/src/camas/core/render.py
+++ b/src/camas/core/render.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import os
 import re
 import sys
+import unicodedata
 from typing import TYPE_CHECKING, Final, NamedTuple, TypeAlias
 
 if sys.version_info >= (3, 11):
@@ -45,6 +46,47 @@ def strip_ansi(text: str) -> str:
 	'green\ttext'
 	"""
 	return ANSI_ESCAPE.sub("", text)
+
+
+def char_cols(ch: str) -> int:
+	"""Terminal columns one character occupies: 2 for East-Asian wide/fullwidth, else 1."""
+	return 2 if unicodedata.east_asian_width(ch) in ("W", "F") else 1
+
+
+def visual_width(text: str) -> int:
+	r"""Terminal columns ``text`` occupies — wide glyphs (CJK, most emoji) count as 2, not 1.
+
+	``len`` counts code points; a row sized by ``len`` that contains wide glyphs renders
+	wider than computed and wraps, desyncing the live repaint's cursor math (issue #64).
+
+	>>> visual_width("abc")
+	3
+	>>> visual_width("你好")
+	4
+	"""
+	return sum(char_cols(ch) for ch in text)
+
+
+def take_cols(text: str, cols: int, *, from_end: bool = False) -> str:
+	"""The longest prefix (or suffix, ``from_end``) of ``text`` fitting ``cols`` columns.
+
+	Never splits a wide glyph, so the result's :func:`visual_width` is ``<= cols``.
+
+	>>> take_cols("hello", 3)
+	'hel'
+	>>> take_cols("hello", 3, from_end=True)
+	'llo'
+	>>> take_cols("你好世", 3)
+	'你'
+	"""
+	used = 0
+	kept: list[str] = []
+	for ch in reversed(text) if from_end else text:
+		if used + (w := char_cols(ch)) > cols:
+			break
+		kept.append(ch)
+		used += w
+	return "".join(reversed(kept)) if from_end else "".join(kept)
 
 
 def color_on() -> bool:

--- a/src/camas/core/render.py
+++ b/src/camas/core/render.py
@@ -78,6 +78,8 @@ def take_cols(text: str, cols: int, *, from_end: bool = False) -> str:
 	'llo'
 	>>> take_cols("你好世", 3)
 	'你'
+	>>> take_cols("ok", 9)
+	'ok'
 	"""
 	used = 0
 	kept: list[str] = []

--- a/src/camas/effect/termtree.py
+++ b/src/camas/effect/termtree.py
@@ -26,7 +26,15 @@ from ..core.color import (
 	YELLOW,
 )
 from ..core.leaf_state import KILL_PRESSES, LeafInfo
-from ..core.render import DisplayRow, GroupHeader, flatten_rows, render_tree_prefix, strip_ansi
+from ..core.render import (
+	DisplayRow,
+	GroupHeader,
+	flatten_rows,
+	render_tree_prefix,
+	strip_ansi,
+	take_cols,
+	visual_width,
+)
 from ..core.task import task_label
 from ..core.traversal import flatten_leaves
 from ..v0.completion import Finished, Skipped, Stopped
@@ -36,24 +44,29 @@ from ..v0.task_event import TaskEvent
 
 
 def truncate_middle(text: str, max_width: int) -> str:
-	"""Middle-truncate with '...' to ``max_width`` (result length ``min(len(text), max_width)``).
+	"""Middle-truncate with '...' so the result's :func:`visual_width` is ``<= max_width``.
+
+	Budgets terminal columns, not code points, so a wide glyph (CJK, emoji) can't push the
+	result past ``max_width`` and wrap the row (issue #64).
 
 	>>> truncate_middle("hello world!", 9)
 	'hel...ld!'
 	>>> truncate_middle("built", 2)
 	'..'
+	>>> truncate_middle("你好世界你好", 7)
+	'你...好'
 	"""
-	if len(text) <= max_width:
+	if visual_width(text) <= max_width:
 		return text
 	if max_width < 3:
 		return "..."[: max(max_width, 0)]
-	side: Final = (max_width - 3) // 2
-	return text[:side] + "..." + text[len(text) - (max_width - 3 - side) :]
+	left: Final = (max_width - 3) // 2
+	return take_cols(text, left) + "..." + take_cols(text, max_width - 3 - left, from_end=True)
 
 
 def fit_label(text: str, max_width: int) -> str:
 	"""Return ``text`` unchanged if it fits; otherwise middle-truncate to ``max_width``."""
-	return text if len(text) <= max_width else truncate_middle(text, max(max_width, 3))
+	return text if visual_width(text) <= max_width else truncate_middle(text, max(max_width, 3))
 
 
 CLEAR_LINE: Final = "\033[K"
@@ -244,10 +257,10 @@ def render_lines(
 					f"\r{GREY}{truncate_middle(f'{prefix}{label}', term_width - 1)}{CLEAR_LINE}{RESET}"
 				)
 			case LeafInfo(task=task):
-				name = fit_label(task_label(task), max(display_width - len(prefix), 0))
+				name = fit_label(task_label(task), max(display_width - visual_width(prefix), 0))
 				state = states[leaf_idx]
 				leaf_idx += 1
-				gap = max(display_width - len(prefix) - len(name), 0)
+				gap = max(display_width - visual_width(prefix) - visual_width(name), 0)
 				header = f"{GREY}{prefix}{RESET}{BOLD}{name}{RESET}"
 				match state:
 					case Completed(completion=completion):
@@ -261,7 +274,7 @@ def render_lines(
 									if gap > 2 and stream_line
 									else ""
 								)
-								padding = " " * max(gap - len(stream), 0)
+								padding = " " * max(gap - visual_width(stream), 0)
 								lines.append(
 									f"\r{header}{GREY}{stream}{RESET}{padding} {CYAN}|{color}{status}{CYAN}|{RESET} {elapsed:7.3f}s{CLEAR_LINE}"
 								)
@@ -277,7 +290,7 @@ def render_lines(
 									if gap > 2 and stream_line
 									else ""
 								)
-								padding = " " * max(gap - len(stream), 0)
+								padding = " " * max(gap - visual_width(stream), 0)
 								lines.append(
 									f"\r{header}{GREY}{stream}{RESET}{padding} {CYAN}|{DARK_RED} STOP {CYAN}|{RESET} {elapsed:7.3f}s{CLEAR_LINE}"
 								)
@@ -290,7 +303,7 @@ def render_lines(
 							if gap > 2 and stream_line
 							else ""
 						)
-						padding = " " * max(gap - len(stream), 0)
+						padding = " " * max(gap - visual_width(stream), 0)
 						lines.append(
 							f"\r{header}{GREY}{stream}{RESET}{padding} {CYAN}|{CAMAS_VIOLET}{spin}{CYAN}|{RESET} {elapsed:7.3f}s{CLEAR_LINE}"
 						)
@@ -302,7 +315,7 @@ def render_lines(
 							if gap > 2 and stream_line
 							else ""
 						)
-						padding = " " * max(gap - len(stream), 0)
+						padding = " " * max(gap - visual_width(stream), 0)
 						lines.append(
 							f"\r{header}{GREY}{stream}{RESET}{padding} {CYAN}|{interrupt_status(presses)}{CYAN}|{RESET} {elapsed:7.3f}s{CLEAR_LINE}"
 						)

--- a/tests/effect/test_termtree.py
+++ b/tests/effect/test_termtree.py
@@ -13,7 +13,7 @@ import pytest
 
 from camas import Parallel, Sequential, Task
 from camas.core.leaf_state import KILL_PRESSES
-from camas.core.render import flatten_rows, strip_ansi
+from camas.core.render import flatten_rows, strip_ansi, visual_width
 from camas.effect.termtree import (
 	STATUS_COL_WIDTH,
 	Termtree,
@@ -419,6 +419,54 @@ def test_render_lines_never_exceed_term_width_for_long_matrix_names(
 		assert visible_width(line) < term_width, (
 			f"line {visible_width(line)} chars exceeds term_width {term_width}: {line!r}"
 		)
+
+
+@pytest.mark.parametrize("term_width", [60, 72, 80, 94, 100, 120])
+def test_render_lines_never_wrap_on_wide_char_output(term_width: int) -> None:
+	"""Regression for #64: a leaf whose output holds wide glyphs (CJK, emoji) must not
+	render a line wider than the terminal. ``len`` undercounts a wide glyph (1 vs 2
+	columns), so a row sized by ``len`` wraps to a second physical row — and the live
+	repaint, which moves the cursor up by the *logical* line count, then never overwrites
+	the top row, stacking a copy of the group header every frame.
+
+	This mirrors the issue's tree (a mutating ``format`` then parallel read-only checks),
+	with ``pydoclint``'s real ``🎉 No violations 🎉`` output. Measured against display
+	width, not ``len`` — the existing :func:`visible_width` helper counts code points and
+	would not catch the wrap.
+	"""
+	fmt = Task(("python", "-c", "pass"), name="format")
+	ruff = Task(("python", "-c", "pass"), name="ruff check .")
+	doclint = Task(("python", "-c", "pass"), name="pydoclint src/pkg")
+	typecheck = Task(("python", "-c", "pass"), name="typecheck")
+	tree = Sequential(fmt, Parallel(ruff, doclint, typecheck))
+	rows = flatten_rows(tree)
+	states: tuple[LeafState, ...] = (
+		Completed(fmt, Finished(0, 0.03, (b"70 files left unchanged\n",))),
+		Completed(ruff, Finished(0, 0.03, (b"All checks passed!\n",))),
+		Completed(doclint, Finished(0, 0.38, ("\U0001f389 No violations \U0001f389\n".encode(),))),
+		Completed(typecheck, Finished(0, 0.53, (b"Success: no issues found\n",))),
+	)
+	display_width = term_width - STATUS_COL_WIDTH - 1
+	lines = render_lines(rows, states, term_width, display_width, TS, 0.0)
+	for line in lines:
+		assert visual_width(strip_ansi(line)) <= term_width, (
+			f"line is {visual_width(strip_ansi(line))} display cols, term_width {term_width}: "
+			f"{strip_ansi(line)!r}"
+		)
+
+
+@pytest.mark.parametrize("term_width", [40, 60, 80])
+def test_render_lines_never_wrap_on_wide_char_name(term_width: int) -> None:
+	"""Regression for #64 on the name column: a wide-glyph task name must middle-truncate
+	by display width, not code points, so the leaf row never overflows."""
+	task = Task(("python", "-c", "pass"), name="构建 数据库 发布 " * 6)
+	tree = Parallel(task)
+	rows = flatten_rows(tree)
+	states: tuple[LeafState, ...] = (Completed(task, Finished(0, 0.1, (b"ok\n",))),)
+	display_width = term_width - STATUS_COL_WIDTH - 1
+	lines = render_lines(rows, states, term_width, display_width, TS, 0.0)
+	for line in lines:
+		assert visual_width(strip_ansi(line)) <= term_width
 
 
 def test_strip_ansi_removes_color_codes() -> None:

--- a/tests/effect/test_truncate_middle.py
+++ b/tests/effect/test_truncate_middle.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import pytest
 
+from camas.core.render import visual_width
 from camas.effect.termtree import truncate_middle
 
 
@@ -48,3 +49,18 @@ def test_small_max_width_never_exceeds(text: str, max_width: int, expected: str)
 	result = truncate_middle(text, max_width)
 	assert result == expected
 	assert len(result) <= max(max_width, 0)
+
+
+@pytest.mark.parametrize(
+	("text", "max_width"),
+	[
+		("你好世界你好世界", 7),  # CJK, wide
+		("\U0001f389" * 10, 7),  # 🎉, wide
+		("a你b好c世d界e", 6),  # mixed narrow/wide
+		("界", 1),  # a lone wide glyph cannot fit one column
+	],
+)
+def test_wide_chars_budget_display_width_not_code_points(text: str, max_width: int) -> None:
+	"""Regression for #64: the result's terminal-column width never exceeds ``max_width``,
+	even when wide glyphs make ``len`` smaller than the rendered width."""
+	assert visual_width(truncate_middle(text, max_width)) <= max_width


### PR DESCRIPTION
## Summary

Fixes #64 (the stacked `format → (…)` group-header lines) and adds regression coverage.

**Root cause** — `termtree` sized every row with `len()` (code points), but a terminal lays rows out by *display columns*. A leaf whose output carries wide glyphs — `pydoclint`'s `🎉 No violations 🎉`, CJK, most emoji — renders wider than computed and **wraps** to a second physical row. `render_frame` then repositions the cursor for the next frame with `\033[{prev_visible-1}F` (CPL — counts *physical* rows) while `prev_visible` counts *logical* lines, so after a wrap the cursor lands one row too low and never overwrites the top row. One copy of the group header is left behind per repaint frame → the reported stack.

It's **not** a budgeting regression (the `--under` commit never touched the render code) and it's width-dependent — it only fires when a wide-char row lands at the wrap column — which is why it didn't reproduce for everyone.

Demonstrated against the real render path at `term_width=100`: the `pydoclint … 🎉 … | PASS |` row is `len()==99` but **101 display columns** (each 🎉 is East-Asian-Wide → 2 cols), so it wrapped; the `result` row at the same `len()` did not.

## Fix

- `core/render.py`: add `char_cols` / `visual_width` / `take_cols` — width by terminal columns (East-Asian wide + fullwidth = 2), slicing that never splits a wide glyph.
- `effect/termtree.py`: budget the row math by display columns instead of `len()` — `truncate_middle`, `fit_label`, and the name / gap / stream-padding in `render_lines`. A computed row width now equals what the terminal draws, so **logical lines == physical rows** and the repaint reposition can't desync.

No behavior change for ASCII (display width == `len`), so the existing `truncate_middle` tests/doctests are unchanged.

## Regression tests

- `test_render_lines_never_wrap_on_wide_char_output` — the issue's tree (mutating `format` then parallel read-only checks) with `pydoclint`'s `🎉 No violations 🎉`, asserting **no line exceeds the terminal's display width** across widths 60–120. This fails on the pre-fix code (the 101-vs-100 overflow above) and passes after.
- `test_render_lines_never_wrap_on_wide_char_name` — same invariant for a wide-glyph task *name* (the `fit_label` path).
- `test_wide_chars_budget_display_width_not_code_points` — `truncate_middle` keeps its result within `max_width` *display columns* for CJK / emoji / mixed input.
- New `visual_width` / `take_cols` doctests.

Measured by **display** width on purpose: the existing `len()`-based `visible_width` helper counts code points and cannot see the overflow.

## Test plan

- Full non-slow suite green: `943 passed`.
- ruff format + ruff check + mypy clean on all touched files.
- Verified by reconstructing the issue's tree: 0 over-width lines across `term_width` 60–120 after the fix (the same scenario produced wraps before).

> Verification note: changes to camas's own rendering were verified with `uv run pytest` rather than the camas MCP, because the long-lived MCP server serves stale camas-package code during self-dev (#58) — the MCP would have run the pre-fix renderer.

Closes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)