### PR TITLE
feat: path-scoping via {paths} injection — Task.paths + scope_to_changed (#78)

### DIFF
--- a/src/camas/core/execution.py
+++ b/src/camas/core/execution.py
@@ -32,6 +32,7 @@ from ..v0.task_event import CompletedEvent, OutputEvent, StartedEvent, TaskEvent
 from .completion import RunResult, TaskResult
 from .leaf_state import KILL_PRESSES, next_state, to_interrupting
 from .matrix import expand_matrix, resolve_cmd
+from .scope import with_default_paths
 from .task import task_label
 from .traversal import flatten_leaves, subtree_leaf_indices
 
@@ -253,7 +254,7 @@ async def run(
 	if jobs is not None and jobs < 1:
 		raise ValueError(f"jobs must be >= 1, got {jobs}")
 	limiter: Final[Limiter] = asyncio.Semaphore(jobs) if jobs is not None else nullcontext()
-	expanded: Final = expand_matrix(task)
+	expanded: Final = with_default_paths(expand_matrix(task))
 	leaf_infos: Final = flatten_leaves(expanded)
 	leaves: Final = tuple(info.task for info in leaf_infos)
 	index_map: Final = {id(info.task): i for i, info in enumerate(leaf_infos)}

--- a/src/camas/core/matrix.py
+++ b/src/camas/core/matrix.py
@@ -23,6 +23,8 @@ from .task import MatrixBinding, VarBinding, task_label
 if TYPE_CHECKING:
 	from collections.abc import Mapping
 
+	from ..v0.task import PathScope
+
 
 def resolve_cmd(cmd: str | tuple[str, ...]) -> tuple[str, ...]:
 	"""Resolve a command to a tuple of argv tokens, splitting shell strings with shlex.
@@ -75,6 +77,12 @@ def substitute_help(help: str | None, binding: MatrixBinding) -> str | None:
 	return substitute_in_str(help, binding) if help is not None else None
 
 
+def substitute_paths(
+	paths: str | PathScope | None, binding: MatrixBinding
+) -> str | PathScope | None:
+	return substitute_in_str(paths, binding) if isinstance(paths, str) else paths
+
+
 def specialize_task(task: Task, binding: MatrixBinding, suffix: str) -> Task:
 	"""Specialize a leaf Task with concrete variable values from a matrix binding.
 
@@ -82,6 +90,8 @@ def specialize_task(task: Task, binding: MatrixBinding, suffix: str) -> Task:
 	Task(cmd='test 3.14', name='test 3.14 [PY=3.14]', env={'PY': '3.14'}, cwd=None)
 	>>> specialize_task(Task("go", env={"VENV": ".venv-{PY}"}), (VarBinding("PY", "3.14"),), "[PY=3.14]").env
 	{'VENV': '.venv-3.14', 'PY': '3.14'}
+	>>> specialize_task(Task("t {paths}", paths="pkg-{PY}"), (VarBinding("PY", "3.14"),), "[PY=3.14]").paths
+	'pkg-3.14'
 	"""
 	match task.cmd:
 		case str():
@@ -97,6 +107,7 @@ def specialize_task(task: Task, binding: MatrixBinding, suffix: str) -> Task:
 		cwd=substitute_cwd(task.cwd, binding),
 		help=substitute_help(task.help, binding),
 		mutates=task.mutates,
+		paths=substitute_paths(task.paths, binding),
 	)
 
 
@@ -327,6 +338,7 @@ def expand_matrix(
 				cwd=task.cwd if task.cwd is not None else ancestor_cwd,
 				help=task.help,
 				mutates=task.mutates,
+				paths=task.paths,
 			)
 		case Sequential(tasks=tasks, matrix=matrix, env=env, cwd=cwd):
 			seq_env: Final = parent_env | env

--- a/src/camas/core/scope.py
+++ b/src/camas/core/scope.py
@@ -1,0 +1,159 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2026 JP Hutchins
+
+"""Path-scoping: resolve a leaf's ``{paths}`` placeholder against the changed files.
+
+A leaf opts into scoping by putting ``{paths}`` in its command and setting ``Task.paths``
+to either a directory-prefix string (``"."``, ``"frontend"``) or a ``(changed) -> args``
+callable. On a full run (no changed set) ``{paths}`` becomes the prefix — or the callable's
+default — so the task still runs over everything; on a scoped run it becomes the changed
+files the leaf covers, and a leaf that covers none of them is dropped.
+
+:func:`with_default_paths` resolves the full-run default and is applied before every run.
+:func:`scope_to_changed` resolves and prunes against a changed set — the entry point for
+the gate (#67/#69). Detecting the changed set is the caller's job; paths match POSIX,
+relative to the same root.
+"""
+
+from __future__ import annotations
+
+import shlex
+import sys
+from pathlib import PurePosixPath
+from typing import TYPE_CHECKING, Final
+
+if sys.version_info >= (3, 11):
+	from typing import assert_never
+else:  # pragma: no cover
+	from typing_extensions import assert_never
+
+from ..v0.task import Parallel, Sequential, Task
+
+if TYPE_CHECKING:
+	from ..v0.task import PathScope, TaskNode
+
+
+PATHS_TOKEN: Final = "{paths}"
+
+
+def _within(path: str, prefix: str) -> bool:
+	"""True when POSIX ``path`` lies under ``prefix`` (segment-wise, so ``frontend`` does
+	not cover ``frontendx``); ``"."`` covers everything.
+
+	>>> _within("frontend/app.ts", "frontend"), _within("frontendx/app.ts", "frontend")
+	(True, False)
+	>>> _within("anywhere/at/all", ".")
+	True
+	"""
+	base = PurePosixPath(prefix).parts
+	return PurePosixPath(path).parts[: len(base)] == base
+
+
+def _as_scope(paths: str | PathScope) -> PathScope:
+	"""Normalize the ``paths`` field to a scope function. A prefix string covers the changed
+	files under it, falling back to the prefix itself for a full run.
+
+	>>> _as_scope(".")(())
+	('.',)
+	>>> _as_scope("src")(("src/app.py", "docs/readme.md"))
+	('src/app.py',)
+	>>> _as_scope(lambda c: tuple(p for p in c if p.endswith(".py")))(("a.py", "b.rs"))
+	('a.py',)
+	"""
+	if not isinstance(paths, str):
+		return paths
+	prefix = paths
+	return lambda changed: (
+		(prefix,) if not changed else tuple(c for c in changed if _within(c, prefix))
+	)
+
+
+def _inject(cmd: str | tuple[str, ...], parts: tuple[str, ...]) -> str | tuple[str, ...]:
+	"""Replace the ``{paths}`` placeholder in ``cmd`` with ``parts``: shell-joined into a
+	string command, spliced as tokens into a tuple command.
+
+	>>> _inject("ruff format {paths}", ("a.py", "b.py"))
+	'ruff format a.py b.py'
+	>>> _inject(("ruff", "format", "{paths}"), ("a.py", "b.py"))
+	('ruff', 'format', 'a.py', 'b.py')
+	"""
+	match cmd:
+		case str():
+			return cmd.replace(PATHS_TOKEN, shlex.join(parts))
+		case tuple():
+			return tuple(p for tok in cmd for p in (parts if tok == PATHS_TOKEN else (tok,)))
+		case _:
+			assert_never(cmd)
+
+
+def _resolve_leaf(task: Task, changed: tuple[str, ...]) -> Task | None:
+	match task.paths:
+		case None:
+			return task
+		case scope:
+			parts = _as_scope(scope)(tuple(c.replace("\\", "/") for c in changed))
+			if changed and not parts:
+				return None
+			return Task(
+				cmd=_inject(task.cmd, parts),
+				name=task.name,
+				env=task.env,
+				cwd=task.cwd,
+				help=task.help,
+				mutates=task.mutates,
+				paths=task.paths,
+			)
+
+
+def scope_to_changed(node: TaskNode, changed: tuple[str, ...]) -> TaskNode | None:
+	"""``node`` with each leaf's ``{paths}`` resolved for ``changed``, leaves covering none
+	of it pruned, and emptied groups dropped (``None`` when nothing remains).
+
+	A leaf whose command omits ``{paths}`` but sets ``paths`` runs whole when its prefix
+	changed and is skipped otherwise — the selection a file-list-averse tool (``mypy``,
+	``cargo``) needs; here the Rust check drops on a Python-only change.
+
+	>>> py = Task("ruff check {paths}", name="lint", paths=".")
+	>>> rs = Task("cargo check", name="cargo", paths="rust")
+	>>> scope_to_changed(Parallel(py, rs), ("src/app.py",))
+	Parallel(tasks=(Task(cmd='ruff check src/app.py', name='lint', env={}, cwd=None, paths='.'),), name=None, matrix=None, env={}, cwd=None)
+	>>> scope_to_changed(Parallel(py), ("README.md",)) == Parallel(Task("ruff check README.md", name="lint", paths="."))
+	True
+	>>> scope_to_changed(Parallel(Task("ruff {paths}", paths="src")), ("docs/x.md",)) is None
+	True
+	"""
+	match node:
+		case Task():
+			return _resolve_leaf(node, changed)
+		case Sequential(tasks=children, name=name, matrix=matrix, env=env, cwd=cwd, help=help):
+			kept = tuple(
+				s for s in (scope_to_changed(c, changed) for c in children) if s is not None
+			)
+			return (
+				Sequential(*kept, name=name, matrix=matrix, env=env, cwd=cwd, help=help)
+				if kept
+				else None
+			)
+		case Parallel(tasks=children, name=name, matrix=matrix, env=env, cwd=cwd, help=help):
+			kept = tuple(
+				s for s in (scope_to_changed(c, changed) for c in children) if s is not None
+			)
+			return (
+				Parallel(*kept, name=name, matrix=matrix, env=env, cwd=cwd, help=help)
+				if kept
+				else None
+			)
+		case _:
+			assert_never(node)
+
+
+def with_default_paths(node: TaskNode) -> TaskNode:
+	"""``node`` with every ``{paths}`` resolved to its full-run default. Total — the empty
+	change set never prunes — so it is safe to apply before any run.
+
+	>>> with_default_paths(Task("ruff format {paths}", paths="."))
+	Task(cmd='ruff format .', name=None, env={}, cwd=None, paths='.')
+	>>> with_default_paths(Task("mypy ."))
+	Task(cmd='mypy .', name=None, env={}, cwd=None)
+	"""
+	return scope_to_changed(node, ()) or node

--- a/src/camas/main/argv.py
+++ b/src/camas/main/argv.py
@@ -65,7 +65,7 @@ def apply_passthrough(task: TaskNode, args: tuple[str, ...]) -> Task:
 	Task(cmd="pytest -k 'a b'", name=None, env={}, cwd=None)
 	"""
 	match task:
-		case Task(cmd=cmd, name=name, env=env, cwd=cwd, help=help, mutates=mutates):
+		case Task(cmd=cmd, name=name, env=env, cwd=cwd, help=help, mutates=mutates, paths=paths):
 			return Task(
 				cmd=f"{cmd} {shlex.join(args)}" if isinstance(cmd, str) else cmd + args,
 				name=name,
@@ -73,6 +73,7 @@ def apply_passthrough(task: TaskNode, args: tuple[str, ...]) -> Task:
 				cwd=cwd,
 				help=help,
 				mutates=mutates,
+				paths=paths,
 			)
 		case Sequential() | Parallel():
 			raise ValueError(

--- a/src/camas/main/dispatch.py
+++ b/src/camas/main/dispatch.py
@@ -22,6 +22,7 @@ from ..core.budget import plan_under
 from ..core.execution import run
 from ..core.matrix import matrix_axes, override_matrix
 from ..core.render import print_tree
+from ..core.scope import with_default_paths
 from ..core.task import task_label
 from ..v0.config import Config
 from .argv import apply_passthrough, parse_axis_values, parse_matrix_kv, split_passthrough
@@ -121,7 +122,7 @@ def run_under(
 	if plan.node is None:
 		return 0
 	if dry_run:
-		print_tree(plan.node, show_cmd=True)
+		print_tree(with_default_paths(plan.node), show_cmd=True)
 		return 0
 	return finish_run(asyncio.run(run(plan.node, effects=effects, jobs=jobs)))
 
@@ -367,7 +368,7 @@ def dispatch(state: TasksState, argv: list[str] | None = None) -> None:
 				print(f"error: {e}", file=sys.stderr)
 				sys.exit(2)
 			if args.dry_run:
-				print_tree(task, show_cmd=True)
+				print_tree(with_default_paths(task), show_cmd=True)
 				sys.exit(0)
 			try:
 				jobs: Final = resolve_jobs(args.jobs)

--- a/src/camas/main/expression.py
+++ b/src/camas/main/expression.py
@@ -216,6 +216,7 @@ def eval_node(
 						cwd=eval_opt_str(kw.get("cwd")),
 						help=eval_opt_str(kw.get("help")),
 						mutates=eval_opt_bool(kw.get("mutates")),
+						paths=eval_opt_str(kw.get("paths")),
 					)
 				case "Sequential" | "Parallel":
 					ctor = Sequential if name == "Sequential" else Parallel

--- a/src/camas/main/tasks.py
+++ b/src/camas/main/tasks.py
@@ -47,8 +47,10 @@ def assign_key_name(node: TaskNode | Ref, key: str) -> TaskNode | Ref:
 	Ref(name='bar')
 	"""
 	match node:
-		case Task(cmd=cmd, name=None, env=env, cwd=cwd, help=help, mutates=mutates):
-			return Task(cmd=cmd, name=key, env=env, cwd=cwd, help=help, mutates=mutates)
+		case Task(cmd=cmd, name=None, env=env, cwd=cwd, help=help, mutates=mutates, paths=paths):
+			return Task(
+				cmd=cmd, name=key, env=env, cwd=cwd, help=help, mutates=mutates, paths=paths
+			)
 		case Sequential(tasks=tasks, name=None, matrix=matrix, env=env, cwd=cwd, help=help):
 			return Sequential(*tasks, name=key, matrix=matrix, env=env, cwd=cwd, help=help)
 		case Parallel(tasks=tasks, name=None, matrix=matrix, env=env, cwd=cwd, help=help):

--- a/src/camas/v0/task.py
+++ b/src/camas/v0/task.py
@@ -11,7 +11,12 @@ from types import MappingProxyType
 from typing import TYPE_CHECKING, TypeAlias
 
 if TYPE_CHECKING:
-	from collections.abc import Mapping
+	from collections.abc import Callable, Mapping
+
+
+PathScope: TypeAlias = "Callable[[tuple[str, ...]], tuple[str, ...]]"
+"""Maps the changed paths to the args injected at ``{paths}``: called with ``()`` for a
+full run (return the default target), with the changed set otherwise (``()`` → skip)."""
 
 
 _EMPTY_ENV: Mapping[str, str] = MappingProxyType({})
@@ -37,6 +42,10 @@ class Task:
 	The ``--under`` budget scheduler runs such leaves sequentially, before the
 	read-only group, so they never race a checker over the same files.
 
+	``paths`` opts a leaf into ``{paths}`` substitution (:mod:`camas.core.scope`): a
+	directory-prefix string (``"."``) or a ``(changed) -> tuple[str, ...]`` callable that
+	maps the changed files into the command; ``None`` leaves the command untouched.
+
 	>>> Task("echo hi")
 	Task(cmd='echo hi', name=None, env={}, cwd=None)
 	>>> Task(("ruff", "check", "."), name="lint")
@@ -49,6 +58,8 @@ class Task:
 	'Lint all sources'
 	>>> Task("ruff format .", mutates=True)
 	Task(cmd='ruff format .', name=None, env={}, cwd=None, mutates=True)
+	>>> Task("ruff format {paths}", mutates=True, paths=".")
+	Task(cmd='ruff format {paths}', name=None, env={}, cwd=None, mutates=True, paths='.')
 	>>> hash(Task("a")) == hash(Task("a"))
 	True
 	>>> {Task("a", env={"K": "v"}), Task("a", env={"K": "v"})} == {Task("a", env={"K": "v"})}
@@ -61,6 +72,7 @@ class Task:
 	cwd: Path | None
 	help: str | None
 	mutates: bool
+	paths: str | PathScope | None
 
 	def __init__(
 		self,
@@ -70,6 +82,7 @@ class Task:
 		cwd: str | Path | None = None,
 		help: str | None = None,
 		mutates: bool = False,
+		paths: str | PathScope | None = None,
 	) -> None:
 		put = object.__setattr__
 		put(self, "cmd", cmd)
@@ -78,6 +91,7 @@ class Task:
 		put(self, "cwd", Path(cwd) if isinstance(cwd, str) else cwd)
 		put(self, "help", help)
 		put(self, "mutates", mutates)
+		put(self, "paths", paths)
 
 	def __hash__(self) -> int:
 		return hash(
@@ -88,6 +102,7 @@ class Task:
 				self.cwd,
 				self.help,
 				self.mutates,
+				self.paths,
 			)
 		)
 
@@ -99,6 +114,7 @@ class Task:
 			f"cwd={self.cwd!r}",
 			*([f"help={self.help!r}"] if self.help is not None else []),
 			*(["mutates=True"] if self.mutates else []),
+			*([f"paths={self.paths!r}"] if self.paths is not None else []),
 		)
 		return f"Task({', '.join(parts)})"
 

--- a/tasks.py
+++ b/tasks.py
@@ -4,10 +4,10 @@ from pathlib import Path
 
 from camas import Config, Parallel, Sequential, Task
 
-format = Task("uv run ruff format .", mutates=True)
-format_check = Task("uv run ruff format --check .")
-lint = Task("uv run ruff check .")
-lint_fix = Task("uv run ruff check --fix .", mutates=True)
+format = Task("uv run ruff format {paths}", mutates=True, paths=".")
+format_check = Task("uv run ruff format --check {paths}", paths=".")
+lint = Task("uv run ruff check {paths}", paths=".")
+lint_fix = Task("uv run ruff check --fix {paths}", mutates=True, paths=".")
 fix = Sequential(lint_fix, format)
 mypy = Task("uv run mypy .")
 ty = Task("uv run ty check")

--- a/tests/core/test_scope.py
+++ b/tests/core/test_scope.py
@@ -1,0 +1,97 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2026 JP Hutchins
+
+from __future__ import annotations
+
+from camas import Parallel, Sequential, Task
+from camas.core.scope import scope_to_changed, with_default_paths
+
+
+def _cmd(node: object) -> str | tuple[str, ...]:
+	assert isinstance(node, Task)
+	return node.cmd
+
+
+def test_prefix_string_full_run_uses_prefix() -> None:
+	fmt = Task("ruff format {paths}", mutates=True, paths=".")
+	assert with_default_paths(fmt) == Task("ruff format .", mutates=True, paths=".")
+
+
+def test_prefix_string_scoped_run_injects_changed_files() -> None:
+	fmt = Task("ruff format {paths}", name="fmt", paths=".")
+	assert scope_to_changed(fmt, ("src/a.py", "src/b.py")) == Task(
+		"ruff format src/a.py src/b.py", name="fmt", paths="."
+	)
+
+
+def test_prefix_string_filters_to_its_subtree() -> None:
+	tsc = Task("tsc {paths}", name="tsc", paths="frontend")
+	assert scope_to_changed(tsc, ("frontend/app.ts", "backend/api.py")) == Task(
+		"tsc frontend/app.ts", name="tsc", paths="frontend"
+	)
+
+
+def test_prefix_string_skips_when_nothing_under_it() -> None:
+	tsc = Task("tsc {paths}", paths="frontend")
+	assert scope_to_changed(tsc, ("backend/api.py",)) is None
+
+
+def test_none_paths_leaf_is_untouched_and_always_runs() -> None:
+	mypy = Task("mypy .", name="mypy")
+	assert scope_to_changed(mypy, ("anything.py",)) == mypy
+	assert with_default_paths(mypy) == mypy
+
+
+def test_prefix_without_placeholder_is_run_whole_or_skip() -> None:
+	"""A leaf with ``paths`` but no ``{paths}`` runs its command unchanged when its prefix
+	changed (the selection a file-list-averse tool needs), and is skipped otherwise."""
+	mypy = Task("mypy .", name="mypy", paths="src")
+	assert scope_to_changed(mypy, ("src/app.py",)) == mypy
+	assert scope_to_changed(mypy, ("docs/readme.md",)) is None
+
+
+def test_callable_paths_full_control() -> None:
+	def py_only(changed: tuple[str, ...]) -> tuple[str, ...]:
+		return (".",) if not changed else tuple(c for c in changed if c.endswith(".py"))
+
+	lint = Task("ruff check {paths}", name="lint", paths=py_only)
+	assert _cmd(scope_to_changed(lint, ("a.py", "b.rs"))) == "ruff check a.py"
+	assert scope_to_changed(lint, ("b.rs",)) is None
+	assert _cmd(with_default_paths(lint)) == "ruff check ."
+
+
+def test_tuple_command_splices_path_tokens() -> None:
+	fmt = Task(("ruff", "format", "{paths}"), name="fmt", paths=".")
+	assert _cmd(scope_to_changed(fmt, ("a.py", "b.py"))) == ("ruff", "format", "a.py", "b.py")
+
+
+def test_full_run_default_never_prunes() -> None:
+	tree = Parallel(Task("ruff {paths}", paths="src"), Task("mypy ."))
+	assert with_default_paths(tree) == Parallel(Task("ruff src", paths="src"), Task("mypy ."))
+
+
+def test_group_pruned_when_all_leaves_skip() -> None:
+	tree = Parallel(Task("a {paths}", paths="a"), Task("b {paths}", paths="b"))
+	assert scope_to_changed(tree, ("c/x.py",)) is None
+
+
+def test_nested_structure_preserved_through_pruning() -> None:
+	lint = Task("ruff check {paths}", name="lint", paths=".")
+	tsc = Task("tsc {paths}", name="tsc", paths="frontend")
+	mypy = Task("mypy .", name="mypy")
+	tree = Sequential(Parallel(lint, tsc), mypy, name="ci")
+	assert scope_to_changed(tree, ("src/app.py",)) == Sequential(
+		Parallel(Task("ruff check src/app.py", name="lint", paths=".")),
+		mypy,
+		name="ci",
+	)
+
+
+def test_backslash_changed_paths_are_normalized() -> None:
+	fmt = Task("ruff format {paths}", name="fmt", paths=".")
+	assert _cmd(scope_to_changed(fmt, ("src\\a.py",))) == "ruff format src/a.py"
+
+
+def test_paths_with_spaces_are_shell_quoted_in_string_command() -> None:
+	fmt = Task("ruff format {paths}", name="fmt", paths=".")
+	assert _cmd(scope_to_changed(fmt, ("a b.py",))) == "ruff format 'a b.py'"

--- a/tests/main/test_expression.py
+++ b/tests/main/test_expression.py
@@ -153,6 +153,7 @@ def test_eval_node_threads_every_public_constructor_kwarg() -> None:
 		"help": ("help='h'", "help", "h"),
 		"mutates": ("mutates=True", "mutates", True),
 		"matrix": ("matrix={'X': ('1',)}", "matrix", {"X": ("1",)}),
+		"paths": ("paths='.'", "paths", "."),
 	}
 	for cls, prefix, variadic in (
 		(Task, "Task('c', ", "cmd"),


### PR DESCRIPTION
> **Targets the `epic/sa-gate` trunk, not `main`.** First PR of the #77 epic — epic work integrates on the long-lived `epic/sa-gate` branch and lands on `main` in one reviewed PR once the gate is feature-complete, so half-built behavior never reaches `main`. Retargeted from `main` accordingly.

Closes #78. First task of the SA-delegation gate epic (#77).

> Redesigned from the initial glob-selection sketch after review: scoping now **injects** the changed files into the command (`ruff format src/a.py`) instead of merely selecting a leaf and re-scanning its whole directory. That's the real speed win, and a lambda is a cleaner extensibility seam than static globs.

## What

A leaf opts into scoping with a `{paths}` placeholder and a `paths=` value:

```python
format = Task("uv run ruff format {paths}", mutates=True, paths=".")   # prefix string
lint   = Task("uv run ruff check {paths}", paths=".")
typecheck = Task("mypy .", paths="src")                                # no {paths}: run-whole-or-skip
fancy  = Task("ruff check {paths}", paths=lambda c: tuple(p for p in c if p.endswith(".py")))
```

- **prefix string** (`"."`, `"frontend"`): full run → `{paths}` becomes the prefix (so `camas format` still runs `ruff format .`); scoped run → the changed files under that prefix, and the leaf is **skipped** when none changed.
- **no `{paths}` but `paths` set**: run the command **whole** when the prefix changed, **skip** otherwise — the selection a file-list-averse tool (`mypy`, `cargo`) needs.
- **`(changed) -> tuple[str, ...]` callable**: full control (filter by extension, dedupe to directories, …). Called with `()` for the full-run default; returns `()` to skip.
- **`None`** (default): command untouched, always runs.

## `camas.core.scope`

- **`with_default_paths(node)`** — resolves every `{paths}` to its full-run default. Wired into `run()` (execution.py — the one chokepoint every CLI/MCP/budget run flows through) and the dry-run previews, so `{paths}` always resolves even without a gate.
- **`scope_to_changed(node, changed)`** — resolves and prunes against a changed set; returns `None` when nothing remains. This is the entry point the gate (#67/#69) will call. Detecting the changed set (`git diff`, a hook's `file_path`) is the caller's job.

No glob engine, no `cwd`-relevance heuristic — both gone with the redesign.

## Threading the field

`Task.paths` is now `str | PathScope | None`. Adding a field means every reconstruction site must carry it (the #25 class of bug): matrix `specialize_task`/`expand_matrix`, `--` `apply_passthrough`, TOML/scope `assign_key_name`, and the expression parser's `eval_node` (string-only there — the safe AST can't express a callable). The `eval_node` drift guard now covers `paths`.

## Dogfooding

`tasks.py` now defines its ruff leaves with `{paths}`/`paths="."`. Behaviour-neutral today (`camas format` → `ruff format .`), and the scoping seam is in place for the gate.

## Verification

`uv run camas check` green — format-check, lint, all 5 typecheckers (mypy, pyright, ty, zuban, pyrefly), full suite (965 passed). New `tests/core/test_scope.py` (13 cases) + doctests as the spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

