### PR TITLE
feat(cli): --paths scopes a run to changed paths (#67)

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,33 @@ Durations are `1s`, `500ms`, `2m`, `1h`, or a bare number of seconds. Leaves wit
 
 **For agents**, `camas_run` exposes the same budget as its `under` argument (omit `task` to budget the project default), and the response's `budget` field reports what was selected and excluded — a tight, time-boxed validate loop over structured MCP.
 
+## Path scoping (`--paths`)
+
+`camas --paths <path>…` scopes a run to changed paths instead of the whole tree. A leaf opts in by writing the `{paths}` placeholder in its command and declaring its scope with `paths=` — a directory prefix, or a `(changed) -> paths` callable:
+
+```python
+py = Task("ruff format {paths}", mutates=True, paths="src")
+web = Task("prettier --write {paths}", mutates=True, paths="web")
+fix = Sequential(py, web)
+```
+
+Without the flag, every `{paths}` resolves to its full-run default (`ruff format src`). With it, each leaf runs only over the changed files it covers, and a leaf that covers none is dropped — `--paths` is repeatable, or comma-separated:
+
+```
+camas fix --paths web/app.ts          # prettier only
+camas fix --paths src/a.py,src/b.py   # ruff only
+```
+
+This is the entry point for a Claude Code `FileChanged` hook — point it at your fixing task and it fixes only what changed, zero model tokens:
+
+```jsonc
+// .claude/settings.json
+{ "hooks": { "FileChanged": [
+  { "hooks": [{ "type": "command", "command": "camas fix --paths ${file_path}" }] } ] } }
+```
+
+When no leaf covers any changed path, the run is a no-op (exits 0).
+
 ## Effects plugins
 
 Define an `Effect` in your `tasks.py` and it's discovered automatically — usable by name from `--effects` and listed under `camas --effects`. See [examples/effect-plugin/](https://github.com/JPHutchins/camas/tree/main/tests/fixtures/effect-plugin) for a typed `Tail` effect that streams per-task output as it arrives.

--- a/src/camas/main/dispatch.py
+++ b/src/camas/main/dispatch.py
@@ -22,7 +22,7 @@ from ..core.budget import plan_under
 from ..core.execution import run
 from ..core.matrix import matrix_axes, override_matrix
 from ..core.render import print_tree
-from ..core.scope import with_default_paths
+from ..core.scope import scope_to_changed, with_default_paths
 from ..core.task import task_label
 from ..v0.config import Config
 from .argv import apply_passthrough, parse_axis_values, parse_matrix_kv, split_passthrough
@@ -339,6 +339,17 @@ def dispatch(state: TasksState, argv: list[str] | None = None) -> None:
 				except ValueError as e:
 					print(f"error: {e}", file=sys.stderr)
 					sys.exit(2)
+
+			if args.paths is not None:
+				changed = tuple(p for raw in args.paths for p in parse_axis_values(raw))
+				scoped = scope_to_changed(resolved, changed) if changed else None
+				if scoped is None:
+					print(
+						f"No task leaf covers {', '.join(changed) or '(no paths given)'}"
+						" — nothing to run."
+					)
+					sys.exit(0)
+				resolved = scoped
 
 			if args.under is not None:
 				try:

--- a/src/camas/main/parser.py
+++ b/src/camas/main/parser.py
@@ -230,6 +230,8 @@ def build_parser(state: TasksState = EMPTY_STATE) -> argparse.ArgumentParser:
 	True
 	>>> "task | expression" in build_parser(LoadOk({"all": Task("x")}, None, {})).format_usage()
 	True
+	>>> build_parser().parse_args(["fix", "--paths", "a.py", "--paths", "b.py"]).paths
+	['a.py', 'b.py']
 	"""
 	tasks_for_metavar: Mapping[str, TaskNode] = state.tasks if isinstance(state, LoadOk) else {}
 	config: Final = (
@@ -313,6 +315,15 @@ def build_parser(state: TasksState = EMPTY_STATE) -> argparse.ArgumentParser:
 		"parallel; untimed leaves are skipped. Operates on the named task, or the "
 		"Config default when none is given",
 	)
+	parser.add_argument(
+		"--paths",
+		action="append",
+		default=None,
+		metavar="PATH[,PATH...]",
+		help="scope the run to these changed paths (repeatable): inject them into each "
+		"leaf's {paths} and drop leaves that match none. The entry point a FileChanged "
+		"hook drives, e.g. camas fix --paths ${file_path}",
+	)
 	return parser
 
 
@@ -329,6 +340,7 @@ RESERVED_FLAGS: Final = frozenset(
 		"matrix",
 		"jobs",
 		"under",
+		"paths",
 	}
 )
 

--- a/tests/main/test_dispatch.py
+++ b/tests/main/test_dispatch.py
@@ -267,3 +267,26 @@ def test_run_under_executes_selected(tmp_path: Path, capsys: pytest.CaptureFixtu
 	assert (
 		"untimed (run the task normally once to record an estimate): b" in capsys.readouterr().out
 	)
+
+
+def test_dispatch_paths_scopes_to_changed(capsys: pytest.CaptureFixture[str]) -> None:
+	task = Task("ruff check {paths}", name="lint", paths=".")
+	with pytest.raises(SystemExit, match="0"):
+		dispatch(_state({"lint": task}), ["--dry-run", "lint", "--paths", "src/app.py"])
+	assert "ruff check src/app.py" in capsys.readouterr().out
+
+
+def test_dispatch_paths_no_match_skips(capsys: pytest.CaptureFixture[str]) -> None:
+	task = Task("cargo check {paths}", name="rust", paths="rust")
+	with pytest.raises(SystemExit, match="0"):
+		dispatch(_state({"rust": task}), ["rust", "--paths", "src/app.py"])
+	out = capsys.readouterr().out
+	assert "src/app.py" in out
+	assert "nothing to run" in out
+
+
+def test_dispatch_paths_empty_skips(capsys: pytest.CaptureFixture[str]) -> None:
+	task = Task("ruff check {paths}", name="lint", paths=".")
+	with pytest.raises(SystemExit, match="0"):
+		dispatch(_state({"lint": task}), ["lint", "--paths", ""])
+	assert "(no paths given)" in capsys.readouterr().out


### PR DESCRIPTION
Closes #67. Targets the **`epic/sa-gate`** integration branch (not `main`) per the epic branching policy.

## What

Wires the existing `scope_to_changed` primitive (#78) to a `--paths` meta-flag, mirroring `--under`: resolve the node → inject the changed paths into each leaf's `{paths}` and prune leaves that cover none → run.

```
camas fix   --paths src/app.py        # reformat just the changed file
camas check --paths src/a.py,src/b.py # scoped checks (repeatable / comma-separated)
```

The FileChanged-hook entrypoint #67 asked for is then just `camas fix --paths ${file_path}` — deterministic autofix, zero model tokens, reusing the user's own fixing task as SSOT for *what* to fix. No new filtering machinery, no subcommand (which would collide with user task names like the repo's own `fix`).

When no leaf covers any changed path — or no paths are given — the run is a no-op (exit 0), the right behavior for a side-effect-only hook.

## Changes
- `main/parser.py` — `--paths PATH[,PATH...]` (repeatable), reserved against matrix-axis shadowing, parsing doctest.
- `main/dispatch.py` — apply `scope_to_changed` to the resolved node alongside `--under`; no-op + exit 0 when nothing remains.
- `tests/main/test_dispatch.py` — scoped-run, no-match-skip, empty-paths-skip.
- `README.md` — new "Path scoping (`--paths`)" section + the FileChanged hook wiring.

## Verified locally
- Coverage **100.00%** (968 passed), the new branches fully exercised.
- All five typecheckers (mypy / pyright / ty / zuban / pyrefly) clean; ruff lint + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)