### PR TITLE
feat(gate): camas_gate MCP tool — the SA-delegation gate (#69)

### DIFF
--- a/src/camas/core/gate.py
+++ b/src/camas/core/gate.py
@@ -1,14 +1,8 @@
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: 2026 JP Hutchins
 
-"""The SA-delegation gate: scope a task to the changed paths, apply the deterministic autofix,
-run the remaining checks, and return a binary verdict — ``autofixed`` when nothing survives the
-fixers, ``needs_reasoning`` when a residual does.
-
-:func:`run_gate` is the entry point the ``camas_gate`` MCP tool drives (for a ``PostToolBatch``
-hook). It composes the existing primitives — :func:`scope_to_changed` to narrow the tree,
-:func:`plan_under` to time-box the checks, :func:`run` to execute — and classifies the result;
-the deep policy (the ``mechanical_delegatable`` tier) is deferred to its own layer.
+"""The SA-delegation gate: scope a task to the changed paths, autofix, run the remaining checks,
+and classify the residual ``autofixed`` vs ``needs_reasoning`` for a ``PostToolBatch`` hook.
 """
 
 from __future__ import annotations
@@ -43,13 +37,10 @@ class GateOutcome(NamedTuple):
 	"""A gate run's verdict and the residual that produced it."""
 
 	residual_class: ResidualClass
-	"""``autofixed`` when no residual survived the fixers; ``needs_reasoning`` otherwise."""
 	residual_node: TaskNode | None
-	"""The failing run's node — the source of the diagnostics; ``None`` when nothing failed."""
+	"""The failing run's node and result, paired — both set on ``needs_reasoning``, both ``None`` otherwise."""
 	residual_result: RunResult | None
-	"""The failing run's result; ``None`` when nothing failed."""
 	budget: BudgetPlan | None
-	"""The checks' budget partition when the run was time-boxed (``under``), else ``None``."""
 
 
 def decision_of(residual_class: ResidualClass) -> Decision:
@@ -113,33 +104,23 @@ async def run_gate(
 	jobs: int | None = None,
 	timings: Mapping[TaskLabel, TaskTiming] | None = None,
 ) -> GateOutcome:
-	"""Scope ``node`` to ``changed``, autofix, run the checks, and classify the residual.
-
-	The ``mutates=True`` leaves run first (the free deterministic fixes); if they error the code
-	is already broken — ``needs_reasoning``. The remaining read-only leaves then run over the
-	fixed workspace, time-boxed by ``under`` when given; a surviving failure is the residual that
-	needs reasoning. An empty ``changed`` gates the whole task; a leaf covering nothing is
-	dropped, and a node that scopes to nothing is a no-op ``autofixed``.
-	"""
+	"""Scope ``node`` to ``changed``, autofix, run the remaining checks, and classify the residual."""
 	scoped = scope_to_changed(node, changed)
 	if scoped is None:
 		return GateOutcome("autofixed", None, None, None)
 	mutating = filter_by_mutates(scoped, mutates=True)
-	if mutating is not None:
-		autofix = await run(mutating, jobs=jobs, interactive=False)
-		if autofix.returncode != 0:
-			return GateOutcome("needs_reasoning", mutating, autofix, None)
+	if (
+		mutating is not None
+		and (autofix := await run(mutating, jobs=jobs, interactive=False)).returncode != 0
+	):
+		return GateOutcome("needs_reasoning", mutating, autofix, None)
 	readonly = filter_by_mutates(scoped, mutates=False)
 	if readonly is None:
 		return GateOutcome("autofixed", None, None, None)
-	if under is not None:
-		plan = plan_under(readonly, under, timings or {})
-		checks_node, budget = plan.node, plan
-	else:
-		checks_node, budget = readonly, None
+	plan = plan_under(readonly, under, timings or {}) if under is not None else None
+	checks_node = plan.node if plan is not None else readonly
 	if checks_node is None:
-		return GateOutcome("autofixed", None, None, budget)
-	checks = await run(checks_node, jobs=jobs, interactive=False)
-	if checks.returncode != 0:
-		return GateOutcome("needs_reasoning", checks_node, checks, budget)
-	return GateOutcome("autofixed", None, None, budget)
+		return GateOutcome("autofixed", None, None, plan)
+	if (checks := await run(checks_node, jobs=jobs, interactive=False)).returncode != 0:
+		return GateOutcome("needs_reasoning", checks_node, checks, plan)
+	return GateOutcome("autofixed", None, None, plan)

--- a/src/camas/core/gate.py
+++ b/src/camas/core/gate.py
@@ -1,0 +1,145 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2026 JP Hutchins
+
+"""The SA-delegation gate: scope a task to the changed paths, apply the deterministic autofix,
+run the remaining checks, and return a binary verdict — ``autofixed`` when nothing survives the
+fixers, ``needs_reasoning`` when a residual does.
+
+:func:`run_gate` is the entry point the ``camas_gate`` MCP tool drives (for a ``PostToolBatch``
+hook). It composes the existing primitives — :func:`scope_to_changed` to narrow the tree,
+:func:`plan_under` to time-box the checks, :func:`run` to execute — and classifies the result;
+the deep policy (the ``mechanical_delegatable`` tier) is deferred to its own layer.
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import TYPE_CHECKING, Literal, NamedTuple, TypeAlias
+
+from ..v0.task import Parallel, Sequential, Task
+from .budget import plan_under
+from .execution import run
+from .scope import scope_to_changed
+
+if sys.version_info >= (3, 11):
+	from typing import assert_never
+else:  # pragma: no cover
+	from typing_extensions import assert_never
+
+if TYPE_CHECKING:
+	from collections.abc import Mapping
+
+	from ..v0.task import TaskNode
+	from .budget import BudgetPlan
+	from .completion import RunResult
+	from .timings import TaskLabel, TaskTiming
+
+
+ResidualClass: TypeAlias = Literal["autofixed", "needs_reasoning"]
+Decision: TypeAlias = Literal["continue", "block"]
+
+
+class GateOutcome(NamedTuple):
+	"""A gate run's verdict and the residual that produced it."""
+
+	residual_class: ResidualClass
+	"""``autofixed`` when no residual survived the fixers; ``needs_reasoning`` otherwise."""
+	residual_node: TaskNode | None
+	"""The failing run's node — the source of the diagnostics; ``None`` when nothing failed."""
+	residual_result: RunResult | None
+	"""The failing run's result; ``None`` when nothing failed."""
+	budget: BudgetPlan | None
+	"""The checks' budget partition when the run was time-boxed (``under``), else ``None``."""
+
+
+def decision_of(residual_class: ResidualClass) -> Decision:
+	"""The ``PostToolBatch`` routing for a class: a surviving residual blocks, else continue.
+
+	>>> decision_of("autofixed"), decision_of("needs_reasoning")
+	('continue', 'block')
+	"""
+	match residual_class:
+		case "autofixed":
+			return "continue"
+		case "needs_reasoning":
+			return "block"
+		case _:
+			assert_never(residual_class)
+
+
+def filter_by_mutates(node: TaskNode, *, mutates: bool) -> TaskNode | None:
+	"""``node`` with only the leaves whose ``mutates`` equals ``mutates``, emptied groups pruned.
+
+	>>> chk = Task("ruff check .", name="lint")
+	>>> filter_by_mutates(chk, mutates=True) is None
+	True
+	>>> filter_by_mutates(chk, mutates=False) is chk
+	True
+	"""
+	match node:
+		case Task():
+			return node if node.mutates == mutates else None
+		case Sequential(tasks=children, name=name, matrix=matrix, env=env, cwd=cwd, help=help):
+			kept = tuple(
+				k
+				for k in (filter_by_mutates(c, mutates=mutates) for c in children)
+				if k is not None
+			)
+			return (
+				Sequential(*kept, name=name, matrix=matrix, env=env, cwd=cwd, help=help)
+				if kept
+				else None
+			)
+		case Parallel(tasks=children, name=name, matrix=matrix, env=env, cwd=cwd, help=help):
+			kept = tuple(
+				k
+				for k in (filter_by_mutates(c, mutates=mutates) for c in children)
+				if k is not None
+			)
+			return (
+				Parallel(*kept, name=name, matrix=matrix, env=env, cwd=cwd, help=help)
+				if kept
+				else None
+			)
+		case _:
+			assert_never(node)
+
+
+async def run_gate(
+	node: TaskNode,
+	changed: tuple[str, ...],
+	*,
+	under: float | None = None,
+	jobs: int | None = None,
+	timings: Mapping[TaskLabel, TaskTiming] | None = None,
+) -> GateOutcome:
+	"""Scope ``node`` to ``changed``, autofix, run the checks, and classify the residual.
+
+	The ``mutates=True`` leaves run first (the free deterministic fixes); if they error the code
+	is already broken — ``needs_reasoning``. The remaining read-only leaves then run over the
+	fixed workspace, time-boxed by ``under`` when given; a surviving failure is the residual that
+	needs reasoning. An empty ``changed`` gates the whole task; a leaf covering nothing is
+	dropped, and a node that scopes to nothing is a no-op ``autofixed``.
+	"""
+	scoped = scope_to_changed(node, changed)
+	if scoped is None:
+		return GateOutcome("autofixed", None, None, None)
+	mutating = filter_by_mutates(scoped, mutates=True)
+	if mutating is not None:
+		autofix = await run(mutating, jobs=jobs, interactive=False)
+		if autofix.returncode != 0:
+			return GateOutcome("needs_reasoning", mutating, autofix, None)
+	readonly = filter_by_mutates(scoped, mutates=False)
+	if readonly is None:
+		return GateOutcome("autofixed", None, None, None)
+	if under is not None:
+		plan = plan_under(readonly, under, timings or {})
+		checks_node, budget = plan.node, plan
+	else:
+		checks_node, budget = readonly, None
+	if checks_node is None:
+		return GateOutcome("autofixed", None, None, budget)
+	checks = await run(checks_node, jobs=jobs, interactive=False)
+	if checks.returncode != 0:
+		return GateOutcome("needs_reasoning", checks_node, checks, budget)
+	return GateOutcome("autofixed", None, None, budget)

--- a/src/camas/mcp/result.py
+++ b/src/camas/mcp/result.py
@@ -9,6 +9,7 @@ import shlex
 import sys
 from typing import TYPE_CHECKING, Literal, NamedTuple
 
+from ..core.gate import decision_of
 from ..core.matrix import expand_matrix
 from ..core.render import strip_ansi
 from ..core.traversal import flatten_leaves
@@ -35,6 +36,7 @@ if TYPE_CHECKING:
 	from pathlib import Path
 
 	from ..core.completion import RunResult, TaskResult
+	from ..core.gate import GateOutcome
 	from ..main.state import TasksState
 	from ..v0.completion import Completion
 	from ..v0.task import Task, TaskNode
@@ -185,4 +187,21 @@ def report(task: Task, result: TaskResult, *, verbosity: Verbosity, tail: int) -
 		cwd=str(task.cwd) if task.cwd is not None else None,
 		completion=completion,
 		truncated=decoded.truncated,
+	)
+
+
+def to_gate_response(outcome: GateOutcome, budget: wire.BudgetReport | None) -> wire.GateResponse:
+	"""The wire ``GateResponse`` for a gate run: the routing decision, the residual class, and the
+	failing residual's per-leaf report (failures-only) when one survived the autofix.
+	"""
+	diagnostics = (
+		to_run_response(outcome.residual_node, outcome.residual_result, verbosity="failures")
+		if outcome.residual_node is not None and outcome.residual_result is not None
+		else None
+	)
+	return wire.GateResponse(
+		decision=decision_of(outcome.residual_class),
+		residual_class=outcome.residual_class,
+		diagnostics=diagnostics,
+		budget=budget,
 	)

--- a/src/camas/mcp/result.py
+++ b/src/camas/mcp/result.py
@@ -191,9 +191,6 @@ def report(task: Task, result: TaskResult, *, verbosity: Verbosity, tail: int) -
 
 
 def to_gate_response(outcome: GateOutcome, budget: wire.BudgetReport | None) -> wire.GateResponse:
-	"""The wire ``GateResponse`` for a gate run: the routing decision, the residual class, and the
-	failing residual's per-leaf report (failures-only) when one survived the autofix.
-	"""
 	diagnostics = (
 		to_run_response(outcome.residual_node, outcome.residual_result, verbosity="failures")
 		if outcome.residual_node is not None and outcome.residual_result is not None

--- a/src/camas/mcp/serve.py
+++ b/src/camas/mcp/serve.py
@@ -25,6 +25,7 @@ from pydantic import AnyUrl, BaseModel, ValidationError
 from ..core import timings
 from ..core.budget import plan_under
 from ..core.execution import run
+from ..core.gate import run_gate
 from ..core.matrix import override_matrix
 from ..core.render import render_tree_lines, strip_ansi
 from ..core.task import task_label
@@ -37,7 +38,7 @@ from ..v0.config import Config
 from . import wire
 from .catalog import to_list_response
 from .docs import to_docs_response
-from .result import to_check_response, to_plan_response, to_run_response
+from .result import to_check_response, to_gate_response, to_plan_response, to_run_response
 
 if sys.version_info >= (3, 11):
 	from typing import assert_never
@@ -59,6 +60,7 @@ class ToolName(Enum):
 	RUN = "camas_run"
 	CHECK = "camas_check"
 	DOCS = "camas_docs"
+	GATE = "camas_gate"
 
 
 NO_ARGS_SCHEMA: Final[dict[str, Any]] = {
@@ -72,6 +74,9 @@ RUN_ANNOTATIONS: Final = types.ToolAnnotations(
 )
 CHECK_ANNOTATIONS: Final = types.ToolAnnotations(readOnlyHint=True, openWorldHint=False)
 DOCS_ANNOTATIONS: Final = types.ToolAnnotations(readOnlyHint=True, openWorldHint=False)
+GATE_ANNOTATIONS: Final = types.ToolAnnotations(
+	readOnlyHint=False, destructiveHint=True, idempotentHint=False, openWorldHint=True
+)
 
 
 class Compat(NamedTuple):
@@ -201,6 +206,8 @@ async def call(session: Session, name: str, arguments: dict[str, Any]) -> types.
 			return check_call(session)
 		case ToolName.DOCS:
 			return docs_call(session)
+		case ToolName.GATE:
+			return await gate_call(session, arguments)
 		case _:
 			known = ", ".join(repr(tool.value) for tool in ToolName)
 			return error_result(f"unknown tool {name!r}; expected one of: {known}")
@@ -223,6 +230,7 @@ class Tools(NamedTuple):
 	execution: types.Tool
 	validation: types.Tool
 	docs: types.Tool
+	gate: types.Tool
 
 
 def tool_def(
@@ -334,6 +342,24 @@ def tools(task_names: tuple[str, ...], compat: Compat) -> Tools:
 			output_model=wire.DocsResponse,
 			title="How to author camas tasks",
 			annotations=DOCS_ANNOTATIONS,
+		),
+		gate=tool_def(
+			compat,
+			name=ToolName.GATE.value,
+			description=textwrap.dedent("""\
+				The SA-delegation gate, for a PostToolBatch hook: scope THIS project's checks to the
+				files just changed, apply the deterministic autofix (the mutates=True leaves —
+				formatters, import sorting) for free, run the remaining checks over the fixed
+				workspace, and return a binary verdict. residual_class is 'autofixed' (decision
+				'continue') when nothing survives the fixers, or 'needs_reasoning' (decision 'block')
+				when a check still fails — then diagnostics carries the failing leaves. Pass paths=[…]
+				(the changed files) to scope; omit to gate the whole task. under=<seconds> time-boxes
+				the checks; the autofix always runs. Mutates the workspace (it runs formatters).
+			""").strip(),
+			input_schema=wire.gate_input_schema(task_names),
+			output_model=wire.GateResponse,
+			title="SA-delegation gate",
+			annotations=GATE_ANNOTATIONS,
 		),
 	)
 
@@ -699,7 +725,11 @@ def docs_text(resp: wire.DocsResponse) -> str:
 
 def success(
 	text: str,
-	model: wire.ListResponse | wire.RunResponse | wire.CheckResponse | wire.DocsResponse,
+	model: wire.ListResponse
+	| wire.RunResponse
+	| wire.CheckResponse
+	| wire.DocsResponse
+	| wire.GateResponse,
 	compat: Compat,
 	*,
 	links: tuple[types.ResourceLink, ...] = (),
@@ -804,3 +834,58 @@ def slug(name: str) -> str:
 
 def decode_log(output: Sequence[bytes]) -> str:
 	return strip_ansi("".join(chunk.decode("utf-8", errors="replace") for chunk in output))
+
+
+async def gate_call(session: Session, arguments: dict[str, Any]) -> types.CallToolResult:
+	"""Handle ``camas_gate``: scope to the changed paths, autofix, run the checks, classify."""
+	match session.project:
+		case LoadErr(source=source, exception=exception):
+			return error_result(format_load_error_hint(source, exception))
+		case LoadOk(tasks=tasks, config=config):
+			return await gate_for(session, tasks, config, arguments)
+		case _:
+			assert_never(session.project)
+
+
+async def gate_for(
+	session: Session,
+	tasks: Mapping[str, TaskNode],
+	config: Config | None,
+	arguments: dict[str, Any],
+) -> types.CallToolResult:
+	"""Validate, resolve the gated task, run the gate, and build the verdict."""
+	try:
+		req = wire.GateRequest.model_validate(arguments)
+	except ValidationError as e:
+		return error_result(f"invalid camas_gate arguments:\n{e}")
+	try:
+		node = budget_source(tasks, config, req.task)
+	except ValueError as e:
+		return error_result(str(e))
+	outcome = await run_gate(
+		node,
+		tuple(req.paths),
+		under=req.under,
+		jobs=req.jobs,
+		timings=timings.load(session.camas_dir),
+	)
+	budget = to_budget_report(outcome.budget) if outcome.budget is not None else None
+	resp = to_gate_response(outcome, budget)
+	return success(gate_text(resp), resp, session.compat)
+
+
+def gate_text(resp: wire.GateResponse) -> str:
+	"""The load-bearing agent-facing summary for ``camas_gate`` — verdict, budget, residual."""
+	headline = (
+		"CONTINUE — autofixed; no residual needs reasoning"
+		if resp.decision == "continue"
+		else "BLOCK — a residual needs reasoning"
+	)
+	lines: list[str] = [f"camas_gate: {headline} (residual_class={resp.residual_class})"]
+	if resp.budget is not None:
+		lines.extend(["", budget_headline(resp.budget)])
+	if resp.diagnostics is not None:
+		lines.extend(["", "Residual (failing checks):"])
+		for leaf in resp.diagnostics.leaves:
+			lines.extend(leaf_lines(leaf, None))
+	return "\n".join(lines)

--- a/src/camas/mcp/wire.py
+++ b/src/camas/mcp/wire.py
@@ -211,3 +211,58 @@ def run_input_schema(task_names: tuple[str, ...]) -> dict[str, Any]:
 		if branch.get("type") == "string":
 			branch["enum"] = list(task_names)
 	return schema
+
+
+class GateRequest(BaseModel):
+	"""Arguments to ``camas_gate``."""
+
+	model_config = ConfigDict(extra="forbid")
+
+	paths: list[str] = Field(
+		default_factory=list,
+		description="Changed paths to scope the gate to — a FileChanged/PostToolBatch hook's "
+		"edited files. Empty gates the whole task; each leaf's {paths} is injected with the "
+		"files it covers and leaves covering nothing are dropped.",
+	)
+	task: str | None = Field(
+		default=None,
+		description="Task to gate — one of the names from camas_list. Omit to gate the project's "
+		"default task.",
+	)
+	under: float | None = Field(
+		default=None,
+		gt=0,
+		description="Wall-clock budget in seconds for the checks (the read-only leaves); the "
+		"deterministic autofix always runs. Untimed leaves are skipped.",
+	)
+	jobs: int | None = Field(
+		default=None, ge=1, description="Max concurrent leaf subprocesses; null = unbounded."
+	)
+
+
+class GateResponse(BaseModel):
+	"""The SA-delegation gate's verdict: how to route the batch, and the residual that decided it."""
+
+	decision: Literal["continue", "block"]
+	"""``block`` when a residual needs reasoning (a PostToolBatch hook surfaces it), else ``continue``."""
+	residual_class: Literal["autofixed", "needs_reasoning"]
+	diagnostics: RunResponse | None = None
+	"""The failing residual run (failures-only); null when the autofix left nothing to reason about."""
+	budget: BudgetReport | None = None
+	"""How ``under`` partitioned the checks, when a budget was given."""
+
+
+def gate_input_schema(task_names: tuple[str, ...]) -> dict[str, Any]:
+	"""``GateRequest``'s JSON Schema with the live task-name ``enum`` spliced into ``task``.
+
+	>>> schema = gate_input_schema(("lint", "test"))
+	>>> next(b["enum"] for b in schema["properties"]["task"]["anyOf"] if b.get("type") == "string")
+	['lint', 'test']
+	>>> schema["additionalProperties"]
+	False
+	"""
+	schema: dict[str, Any] = GateRequest.model_json_schema()
+	for branch in schema["properties"]["task"]["anyOf"]:
+		if branch.get("type") == "string":
+			branch["enum"] = list(task_names)
+	return schema

--- a/tests/core/test_gate.py
+++ b/tests/core/test_gate.py
@@ -1,0 +1,78 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2026 JP Hutchins
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from camas import Parallel, Sequential, Task
+from camas.core.gate import GateOutcome, decision_of, filter_by_mutates, run_gate
+from camas.core.task import task_label
+from camas.core.timings import TaskTiming
+
+if TYPE_CHECKING:
+	from camas.v0.task import TaskNode
+
+CHECK_PASS = Task(("python", "-c", "pass"), name="check")
+CHECK_FAIL = Task(("python", "-c", "raise SystemExit(1)"), name="check")
+FIX = Task(("python", "-c", "pass"), name="fmt", mutates=True)
+FIX_FAIL = Task(("python", "-c", "raise SystemExit(1)"), name="fmt", mutates=True)
+
+
+def test_filter_by_mutates_keeps_matching_group() -> None:
+	assert filter_by_mutates(Sequential(FIX, CHECK_PASS), mutates=True) == Sequential(FIX)
+
+
+def test_filter_by_mutates_prunes_emptied_group() -> None:
+	assert filter_by_mutates(Parallel(CHECK_PASS), mutates=True) is None
+
+
+async def test_gate_all_pass_is_autofixed() -> None:
+	out = await run_gate(Parallel(FIX, CHECK_PASS), ())
+	assert out.residual_class == "autofixed"
+	assert out.residual_result is None
+	assert decision_of(out.residual_class) == "continue"
+
+
+async def test_gate_failing_check_needs_reasoning() -> None:
+	out = await run_gate(Parallel(FIX, CHECK_FAIL), ())
+	assert out.residual_class == "needs_reasoning"
+	assert out.residual_result is not None
+	assert out.residual_result.returncode != 0
+	assert decision_of(out.residual_class) == "block"
+
+
+async def test_gate_failing_autofix_needs_reasoning() -> None:
+	out = await run_gate(Parallel(FIX_FAIL, CHECK_PASS), ())
+	assert out.residual_class == "needs_reasoning"
+	assert out.residual_node is not None
+
+
+async def test_gate_no_mutating_leaves_runs_checks() -> None:
+	out = await run_gate(Parallel(CHECK_PASS), ())
+	assert out.residual_class == "autofixed"
+
+
+async def test_gate_only_mutating_leaves_autofixed() -> None:
+	out = await run_gate(Parallel(FIX), ())
+	assert out.residual_class == "autofixed"
+	assert out.residual_result is None
+
+
+async def test_gate_scoped_to_nothing_is_noop() -> None:
+	node: TaskNode = Task(("cargo", "check", "{paths}"), name="rust", paths="rust")
+	assert await run_gate(node, ("src/app.py",)) == GateOutcome("autofixed", None, None, None)
+
+
+async def test_gate_budget_excludes_untimed_checks() -> None:
+	out = await run_gate(Parallel(CHECK_PASS), (), under=1.0, timings={})
+	assert out.residual_class == "autofixed"
+	assert out.budget is not None
+
+
+async def test_gate_budget_runs_fitting_check() -> None:
+	out = await run_gate(
+		Parallel(CHECK_PASS), (), under=1.0, timings={task_label(CHECK_PASS): TaskTiming(0.01, 1)}
+	)
+	assert out.residual_class == "autofixed"
+	assert out.budget is not None

--- a/tests/mcp/test_serve.py
+++ b/tests/mcp/test_serve.py
@@ -125,7 +125,7 @@ def test_task_names_empty_on_load_error(tmp_path: Path) -> None:
 
 
 def test_tools_default_omits_rich_fields() -> None:
-	tool_list, tool_run, tool_check, tool_docs = serve.tools(
+	tool_list, tool_run, tool_check, tool_docs, tool_gate = serve.tools(
 		("a", "b"), Compat(emit_structured=False)
 	)
 	assert (tool_list.title, tool_list.outputSchema, tool_list.annotations) == (None, None, None)
@@ -137,10 +137,14 @@ def test_tools_default_omits_rich_fields() -> None:
 	assert tool_docs.inputSchema == serve.NO_ARGS_SCHEMA
 	assert tool_list.inputSchema["properties"]["expand_matrix"]["type"] == "boolean"
 	assert tool_list.inputSchema["additionalProperties"] is False
+	assert (tool_gate.title, tool_gate.outputSchema, tool_gate.annotations) == (None, None, None)
+	assert _task_enum(tool_gate.inputSchema) == ["a", "b"]
 
 
 def test_tools_rich_includes_title_annotations_and_schema() -> None:
-	tool_list, tool_run, tool_check, tool_docs = serve.tools((), Compat(emit_structured=True))
+	tool_list, tool_run, tool_check, tool_docs, tool_gate = serve.tools(
+		(), Compat(emit_structured=True)
+	)
 	assert tool_list.title == "List camas tasks"
 	assert tool_list.annotations is not None
 	assert tool_list.annotations.readOnlyHint is True
@@ -157,6 +161,10 @@ def test_tools_rich_includes_title_annotations_and_schema() -> None:
 	assert tool_docs.outputSchema is not None
 	assert tool_docs.annotations is not None
 	assert tool_docs.annotations.readOnlyHint is True
+	assert tool_gate.title == "SA-delegation gate"
+	assert tool_gate.outputSchema is not None
+	assert tool_gate.annotations is not None
+	assert tool_gate.annotations.destructiveHint is True
 
 
 def test_list_call_text_lists_tasks_and_markers(tmp_path: Path) -> None:
@@ -826,6 +834,7 @@ async def test_in_memory_round_trip(tmp_path: Path) -> None:
 			"camas_run",
 			"camas_check",
 			"camas_docs",
+			"camas_gate",
 		}
 		catalog = await client.call_tool("camas_list", {})
 		assert "lint" in _text(catalog)
@@ -917,3 +926,54 @@ async def test_run_via_client_picks_up_new_task_without_check(tmp_path: Path) ->
 
 def _text(result: types.CallToolResult) -> str:
 	return "\n".join(block.text for block in result.content if isinstance(block, types.TextContent))
+
+
+GATE_FIX = Task(("python", "-c", "print('fixed')"), name="fmt", mutates=True)
+
+
+async def test_gate_call_load_error(tmp_path: Path) -> None:
+	session = Session(
+		LoadErr(source=tmp_path / "tasks.py", exception=RuntimeError("boom")), tmp_path, Compat()
+	)
+	result = await serve.call(session, "camas_gate", {})
+	assert result.isError
+
+
+async def test_gate_call_invalid_args(tmp_path: Path) -> None:
+	node = Parallel(GATE_FIX, PASS)
+	session = _session({"all": node}, Config(default_task=node), tmp_path)
+	result = await serve.call(session, "camas_gate", {"bogus": 1})
+	assert result.isError
+	assert "invalid camas_gate arguments" in _text(result)
+
+
+async def test_gate_call_no_task_no_default_errors(tmp_path: Path) -> None:
+	session = _session({"x": PASS}, None, tmp_path)
+	result = await serve.call(session, "camas_gate", {})
+	assert result.isError
+
+
+async def test_gate_call_continue_when_checks_pass(tmp_path: Path) -> None:
+	node = Parallel(GATE_FIX, PASS)
+	session = _session({"all": node}, Config(default_task=node), tmp_path)
+	result = await serve.call(session, "camas_gate", {})
+	assert not result.isError
+	assert "CONTINUE" in _text(result)
+
+
+async def test_gate_call_block_when_check_fails(tmp_path: Path) -> None:
+	node = Parallel(GATE_FIX, FAIL)
+	session = _session({"all": node}, Config(default_task=node), tmp_path)
+	result = await serve.call(session, "camas_gate", {"task": "all"})
+	text = _text(result)
+	assert not result.isError
+	assert "BLOCK" in text
+	assert "bad" in text
+
+
+async def test_gate_call_with_budget_reports_partition(tmp_path: Path) -> None:
+	node = Parallel(GATE_FIX, PASS)
+	session = _session({"all": node}, Config(default_task=node), tmp_path)
+	result = await serve.call(session, "camas_gate", {"under": 1.0})
+	assert not result.isError
+	assert "Time budget" in _text(result)


### PR DESCRIPTION
Closes #69. Targets the **`epic/sa-gate`** integration branch per the epic branching policy. Layer 3 of #77 (the gate); #68's AgentJSON folds into its diagnostics next.

## What

A `camas_gate` MCP tool — the SA-delegation gate, narrowed to the binary-classifier MVP. One call:

1. **scope** the task to the changed paths (`scope_to_changed`),
2. **autofix** — run the `mutates=True` leaves (formatters, import-sort) over the changed files, free,
3. **check** — run the remaining read-only leaves over the fixed workspace, time-boxed by `under`,
4. **classify** the residual binary and return the routing decision.

```
residual_class = autofixed       → decision continue   (nothing survived the fixers)
residual_class = needs_reasoning → decision block      (a check still fails; diagnostics carries it)
```

A failing autofix (the code won't even format/parse) is itself `needs_reasoning`. An empty `paths` gates the whole task; a node that scopes to nothing is a no-op `autofixed`.

## Composition (no new engine)

`core/gate.py` composes the primitives that already exist — `scope_to_changed` (#78), `plan_under`/`schedule` (mutates-first), `run`. The only new logic is `filter_by_mutates` (split the scoped tree into fixers vs checks) and the binary `decision_of`/classify. The MCP tool follows the existing 5-step `serve.py` pattern (`ToolName` → dispatch → `tools()` → `gate_call` → `wire.GateRequest`/`GateResponse`), and diagnostics reuse the `RunResponse` shape until #68's AgentJSON envelope lands.

## Files
- `core/gate.py` — `run_gate`, `filter_by_mutates`, `decision_of`, `GateOutcome`.
- `mcp/wire.py` — `GateRequest`/`GateResponse` + `gate_input_schema`.
- `mcp/result.py` — `to_gate_response`.
- `mcp/serve.py` — `camas_gate` wiring + `gate_call`/`gate_for`/`gate_text`.
- tests — `core/test_gate.py` (every `run_gate` branch) + serve handler tests; existing 4-tool assertions updated to 5.

## MVP boundaries (per #69)
Binary classifier only (the `mechanical_delegatable` tier is #79); cold-spawn checkers (#66 is the later speed pass); diagnostics shape upgrades with #68.

## Verified locally
- Coverage **100.00%** (987 passed); every new branch exercised.
- All five typecheckers (mypy / pyright / ty / zuban / pyrefly) clean; ruff lint + format clean.
- Tests use pytest-asyncio (`async def` + `await`), per the repo convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)