### PR TITLE
feat(agentjson): output_kind tag + AgentJSON envelope, folded into the gate (#68)

### DIFF
--- a/src/camas/__init__.py
+++ b/src/camas/__init__.py
@@ -333,6 +333,7 @@ help: ``camas <task> --help``.
 
 import typing
 
+from .v0 import AgentFormat as AgentFormat
 from .v0 import Config as Config
 from .v0 import Effect as Effect
 from .v0 import Parallel as Parallel

--- a/src/camas/core/gate.py
+++ b/src/camas/core/gate.py
@@ -7,6 +7,8 @@ and classify the residual ``autofixed`` vs ``needs_reasoning`` for a ``PostToolB
 
 from __future__ import annotations
 
+import dataclasses
+import shlex
 import sys
 from typing import TYPE_CHECKING, Literal, NamedTuple, TypeAlias
 
@@ -96,6 +98,49 @@ def filter_by_mutates(node: TaskNode, *, mutates: bool) -> TaskNode | None:
 			assert_never(node)
 
 
+def with_agent_format(node: TaskNode) -> TaskNode:
+	"""Append each leaf's ``agent_format.args`` to its command — the agent-only structured-output
+	variant the gate runs; a human run never applies this, so ``cmd`` is otherwise untouched.
+
+	>>> from camas.v0.task import AgentFormat
+	>>> with_agent_format(Task("ruff check .", agent_format=AgentFormat("--output-format sarif", "sarif"))).cmd
+	'ruff check . --output-format sarif'
+	>>> with_agent_format(Task("ruff check .")).cmd
+	'ruff check .'
+	"""
+	match node:
+		case Task():
+			if node.agent_format is None:
+				return node
+			args = node.agent_format.args
+			cmd = (
+				f"{node.cmd} {args}"
+				if isinstance(node.cmd, str)
+				else (*node.cmd, *shlex.split(args))
+			)
+			return dataclasses.replace(node, cmd=cmd)
+		case Sequential(tasks=children, name=name, matrix=matrix, env=env, cwd=cwd, help=help):
+			return Sequential(
+				*(with_agent_format(c) for c in children),
+				name=name,
+				matrix=matrix,
+				env=env,
+				cwd=cwd,
+				help=help,
+			)
+		case Parallel(tasks=children, name=name, matrix=matrix, env=env, cwd=cwd, help=help):
+			return Parallel(
+				*(with_agent_format(c) for c in children),
+				name=name,
+				matrix=matrix,
+				env=env,
+				cwd=cwd,
+				help=help,
+			)
+		case _:
+			assert_never(node)
+
+
 async def run_gate(
 	node: TaskNode,
 	changed: tuple[str, ...],
@@ -108,6 +153,7 @@ async def run_gate(
 	scoped = scope_to_changed(node, changed)
 	if scoped is None:
 		return GateOutcome("autofixed", None, None, None)
+	scoped = with_agent_format(scoped)
 	mutating = filter_by_mutates(scoped, mutates=True)
 	if (
 		mutating is not None

--- a/src/camas/core/matrix.py
+++ b/src/camas/core/matrix.py
@@ -108,7 +108,7 @@ def specialize_task(task: Task, binding: MatrixBinding, suffix: str) -> Task:
 		help=substitute_help(task.help, binding),
 		mutates=task.mutates,
 		paths=substitute_paths(task.paths, binding),
-		output_kind=task.output_kind,
+		agent_format=task.agent_format,
 	)
 
 
@@ -340,7 +340,7 @@ def expand_matrix(
 				help=task.help,
 				mutates=task.mutates,
 				paths=task.paths,
-				output_kind=task.output_kind,
+				agent_format=task.agent_format,
 			)
 		case Sequential(tasks=tasks, matrix=matrix, env=env, cwd=cwd):
 			seq_env: Final = parent_env | env

--- a/src/camas/core/matrix.py
+++ b/src/camas/core/matrix.py
@@ -108,6 +108,7 @@ def specialize_task(task: Task, binding: MatrixBinding, suffix: str) -> Task:
 		help=substitute_help(task.help, binding),
 		mutates=task.mutates,
 		paths=substitute_paths(task.paths, binding),
+		output_kind=task.output_kind,
 	)
 
 
@@ -339,6 +340,7 @@ def expand_matrix(
 				help=task.help,
 				mutates=task.mutates,
 				paths=task.paths,
+				output_kind=task.output_kind,
 			)
 		case Sequential(tasks=tasks, matrix=matrix, env=env, cwd=cwd):
 			seq_env: Final = parent_env | env

--- a/src/camas/core/scope.py
+++ b/src/camas/core/scope.py
@@ -102,6 +102,7 @@ def _resolve_leaf(task: Task, changed: tuple[str, ...]) -> Task | None:
 				help=task.help,
 				mutates=task.mutates,
 				paths=task.paths,
+				output_kind=task.output_kind,
 			)
 
 

--- a/src/camas/core/scope.py
+++ b/src/camas/core/scope.py
@@ -102,7 +102,7 @@ def _resolve_leaf(task: Task, changed: tuple[str, ...]) -> Task | None:
 				help=task.help,
 				mutates=task.mutates,
 				paths=task.paths,
-				output_kind=task.output_kind,
+				agent_format=task.agent_format,
 			)
 
 

--- a/src/camas/main/argv.py
+++ b/src/camas/main/argv.py
@@ -65,7 +65,16 @@ def apply_passthrough(task: TaskNode, args: tuple[str, ...]) -> Task:
 	Task(cmd="pytest -k 'a b'", name=None, env={}, cwd=None)
 	"""
 	match task:
-		case Task(cmd=cmd, name=name, env=env, cwd=cwd, help=help, mutates=mutates, paths=paths):
+		case Task(
+			cmd=cmd,
+			name=name,
+			env=env,
+			cwd=cwd,
+			help=help,
+			mutates=mutates,
+			paths=paths,
+			output_kind=output_kind,
+		):
 			return Task(
 				cmd=f"{cmd} {shlex.join(args)}" if isinstance(cmd, str) else cmd + args,
 				name=name,
@@ -74,6 +83,7 @@ def apply_passthrough(task: TaskNode, args: tuple[str, ...]) -> Task:
 				help=help,
 				mutates=mutates,
 				paths=paths,
+				output_kind=output_kind,
 			)
 		case Sequential() | Parallel():
 			raise ValueError(

--- a/src/camas/main/argv.py
+++ b/src/camas/main/argv.py
@@ -73,7 +73,7 @@ def apply_passthrough(task: TaskNode, args: tuple[str, ...]) -> Task:
 			help=help,
 			mutates=mutates,
 			paths=paths,
-			output_kind=output_kind,
+			agent_format=agent_format,
 		):
 			return Task(
 				cmd=f"{cmd} {shlex.join(args)}" if isinstance(cmd, str) else cmd + args,
@@ -83,7 +83,7 @@ def apply_passthrough(task: TaskNode, args: tuple[str, ...]) -> Task:
 				help=help,
 				mutates=mutates,
 				paths=paths,
-				output_kind=output_kind,
+				agent_format=agent_format,
 			)
 		case Sequential() | Parallel():
 			raise ValueError(

--- a/src/camas/main/expression.py
+++ b/src/camas/main/expression.py
@@ -16,7 +16,7 @@ if sys.version_info >= (3, 11):
 else:  # pragma: no cover
 	from typing_extensions import assert_never
 
-from ..v0.task import OutputKind, Parallel, Sequential, Task, TaskNode
+from ..v0.task import AgentFormat, OutputKind, Parallel, Sequential, Task, TaskNode
 
 if TYPE_CHECKING:
 	from collections.abc import Mapping
@@ -109,16 +109,29 @@ def eval_opt_bool(node: ast.expr | None) -> bool:
 			raise ValueError(f"expected bool literal, got {ast.dump(node)}")
 
 
-def eval_output_kind(node: ast.expr | None) -> OutputKind:
+def _output_kind(node: ast.expr) -> OutputKind:
 	match node:
-		case None:
-			return "raw"
 		case ast.Constant(value="sarif" | "rdjson" | "lsp" | "junit" | "tap" | "raw" as kind):
 			return kind
 		case _:
 			raise ValueError(
-				f"output_kind must be one of sarif/rdjson/lsp/junit/tap/raw, got {ast.dump(node)}"
+				f"AgentFormat kind must be sarif/rdjson/lsp/junit/tap/raw, got {ast.dump(node)}"
 			)
+
+
+def eval_agent_format(node: ast.expr | None) -> AgentFormat | None:
+	match node:
+		case None:
+			return None
+		case ast.Call(func=ast.Name(id="AgentFormat"), args=call_args, keywords=call_kw):
+			kw = {k.arg: k.value for k in call_kw if k.arg is not None}
+			args_node = call_args[0] if call_args else kw.get("args")
+			kind_node = call_args[1] if len(call_args) > 1 else kw.get("kind")
+			if args_node is None or kind_node is None:
+				raise ValueError("AgentFormat requires args and kind")
+			return AgentFormat(eval_str_lit(args_node), _output_kind(kind_node))
+		case _:
+			raise ValueError(f"agent_format must be AgentFormat(args, kind), got {ast.dump(node)}")
 
 
 def eval_env(node: ast.expr | None) -> dict[str, str]:
@@ -229,7 +242,7 @@ def eval_node(
 						help=eval_opt_str(kw.get("help")),
 						mutates=eval_opt_bool(kw.get("mutates")),
 						paths=eval_opt_str(kw.get("paths")),
-						output_kind=eval_output_kind(kw.get("output_kind")),
+						agent_format=eval_agent_format(kw.get("agent_format")),
 					)
 				case "Sequential" | "Parallel":
 					ctor = Sequential if name == "Sequential" else Parallel

--- a/src/camas/main/expression.py
+++ b/src/camas/main/expression.py
@@ -16,7 +16,7 @@ if sys.version_info >= (3, 11):
 else:  # pragma: no cover
 	from typing_extensions import assert_never
 
-from ..v0.task import Parallel, Sequential, Task, TaskNode
+from ..v0.task import OutputKind, Parallel, Sequential, Task, TaskNode
 
 if TYPE_CHECKING:
 	from collections.abc import Mapping
@@ -107,6 +107,18 @@ def eval_opt_bool(node: ast.expr | None) -> bool:
 			return b
 		case _:
 			raise ValueError(f"expected bool literal, got {ast.dump(node)}")
+
+
+def eval_output_kind(node: ast.expr | None) -> OutputKind:
+	match node:
+		case None:
+			return "raw"
+		case ast.Constant(value="sarif" | "rdjson" | "lsp" | "junit" | "tap" | "raw" as kind):
+			return kind
+		case _:
+			raise ValueError(
+				f"output_kind must be one of sarif/rdjson/lsp/junit/tap/raw, got {ast.dump(node)}"
+			)
 
 
 def eval_env(node: ast.expr | None) -> dict[str, str]:
@@ -217,6 +229,7 @@ def eval_node(
 						help=eval_opt_str(kw.get("help")),
 						mutates=eval_opt_bool(kw.get("mutates")),
 						paths=eval_opt_str(kw.get("paths")),
+						output_kind=eval_output_kind(kw.get("output_kind")),
 					)
 				case "Sequential" | "Parallel":
 					ctor = Sequential if name == "Sequential" else Parallel

--- a/src/camas/main/expression.py
+++ b/src/camas/main/expression.py
@@ -130,6 +130,8 @@ def eval_agent_format(node: ast.expr | None) -> AgentFormat | None:
 			if args_node is None or kind_node is None:
 				raise ValueError("AgentFormat requires args and kind")
 			return AgentFormat(eval_str_lit(args_node), _output_kind(kind_node))
+		case ast.Tuple(elts=[args_node, kind_node]):
+			return AgentFormat(eval_str_lit(args_node), _output_kind(kind_node))
 		case _:
 			raise ValueError(f"agent_format must be AgentFormat(args, kind), got {ast.dump(node)}")
 

--- a/src/camas/main/tasks.py
+++ b/src/camas/main/tasks.py
@@ -55,7 +55,7 @@ def assign_key_name(node: TaskNode | Ref, key: str) -> TaskNode | Ref:
 			help=help,
 			mutates=mutates,
 			paths=paths,
-			output_kind=output_kind,
+			agent_format=agent_format,
 		):
 			return Task(
 				cmd=cmd,
@@ -65,7 +65,7 @@ def assign_key_name(node: TaskNode | Ref, key: str) -> TaskNode | Ref:
 				help=help,
 				mutates=mutates,
 				paths=paths,
-				output_kind=output_kind,
+				agent_format=agent_format,
 			)
 		case Sequential(tasks=tasks, name=None, matrix=matrix, env=env, cwd=cwd, help=help):
 			return Sequential(*tasks, name=key, matrix=matrix, env=env, cwd=cwd, help=help)

--- a/src/camas/main/tasks.py
+++ b/src/camas/main/tasks.py
@@ -47,9 +47,25 @@ def assign_key_name(node: TaskNode | Ref, key: str) -> TaskNode | Ref:
 	Ref(name='bar')
 	"""
 	match node:
-		case Task(cmd=cmd, name=None, env=env, cwd=cwd, help=help, mutates=mutates, paths=paths):
+		case Task(
+			cmd=cmd,
+			name=None,
+			env=env,
+			cwd=cwd,
+			help=help,
+			mutates=mutates,
+			paths=paths,
+			output_kind=output_kind,
+		):
 			return Task(
-				cmd=cmd, name=key, env=env, cwd=cwd, help=help, mutates=mutates, paths=paths
+				cmd=cmd,
+				name=key,
+				env=env,
+				cwd=cwd,
+				help=help,
+				mutates=mutates,
+				paths=paths,
+				output_kind=output_kind,
 			)
 		case Sequential(tasks=tasks, name=None, matrix=matrix, env=env, cwd=cwd, help=help):
 			return Sequential(*tasks, name=key, matrix=matrix, env=env, cwd=cwd, help=help)

--- a/src/camas/mcp/result.py
+++ b/src/camas/mcp/result.py
@@ -202,7 +202,7 @@ def to_agent_envelope(task: Task, result: TaskResult, *, tail: int = 50) -> wire
 	return wire.AgentEnvelope(
 		name=result.name,
 		exit_code=comp.returncode,
-		output_kind=task.output_kind,
+		output_kind=task.agent_format.kind if task.agent_format is not None else "raw",
 		payload="\n".join(decoded.lines),
 		truncated=decoded.truncated,
 	)

--- a/src/camas/mcp/result.py
+++ b/src/camas/mcp/result.py
@@ -190,9 +190,37 @@ def report(task: Task, result: TaskResult, *, verbosity: Verbosity, tail: int) -
 	)
 
 
+def to_agent_envelope(task: Task, result: TaskResult, *, tail: int = 50) -> wire.AgentEnvelope:
+	comp = result.completion
+	match comp:
+		case Finished(output=output) | Stopped(output=output):
+			decoded = decode(output, tail)
+		case Skipped():
+			decoded = Decoded([], truncated=False)
+		case _:
+			assert_never(comp)
+	return wire.AgentEnvelope(
+		name=result.name,
+		exit_code=comp.returncode,
+		output_kind=task.output_kind,
+		payload="\n".join(decoded.lines),
+		truncated=decoded.truncated,
+	)
+
+
+def agent_envelopes(node: TaskNode, result: RunResult) -> tuple[wire.AgentEnvelope, ...]:
+	"""The failing leaves of a finished run as AgentJSON envelopes, in DFS order."""
+	leaves = tuple(info.task for info in flatten_leaves(expand_matrix(node)))
+	return tuple(
+		to_agent_envelope(task, tr)
+		for task, tr in zip(leaves, result.results, strict=True)
+		if tr.completion.returncode != 0
+	)
+
+
 def to_gate_response(outcome: GateOutcome, budget: wire.BudgetReport | None) -> wire.GateResponse:
 	diagnostics = (
-		to_run_response(outcome.residual_node, outcome.residual_result, verbosity="failures")
+		agent_envelopes(outcome.residual_node, outcome.residual_result)
 		if outcome.residual_node is not None and outcome.residual_result is not None
 		else None
 	)

--- a/src/camas/mcp/serve.py
+++ b/src/camas/mcp/serve.py
@@ -886,6 +886,7 @@ def gate_text(resp: wire.GateResponse) -> str:
 		lines.extend(["", budget_headline(resp.budget)])
 	if resp.diagnostics is not None:
 		lines.extend(["", "Residual (failing checks):"])
-		for leaf in resp.diagnostics.leaves:
-			lines.extend(leaf_lines(leaf, None))
+		for env in resp.diagnostics:
+			lines.append(f"  {env.name} (exit {env.exit_code}, {env.output_kind})")
+			lines.extend(f"    {line}" for line in env.payload.splitlines())
 	return "\n".join(lines)

--- a/src/camas/mcp/wire.py
+++ b/src/camas/mcp/wire.py
@@ -240,14 +240,26 @@ class GateRequest(BaseModel):
 	)
 
 
+class AgentEnvelope(BaseModel):
+	"""One task's agent-facing result: its exit code and the tool's output tagged by the
+	standard it is in (``output_kind``) and passed through verbatim — camas never parses it.
+	"""
+
+	name: str
+	exit_code: int
+	output_kind: Literal["sarif", "rdjson", "lsp", "junit", "tap", "raw"]
+	payload: str
+	truncated: bool = False
+
+
 class GateResponse(BaseModel):
 	"""The SA-delegation gate's verdict: how to route the batch, and the residual that decided it."""
 
 	decision: Literal["continue", "block"]
 	"""``block`` when a residual needs reasoning (a PostToolBatch hook surfaces it), else ``continue``."""
 	residual_class: Literal["autofixed", "needs_reasoning"]
-	diagnostics: RunResponse | None = None
-	"""The failing residual run (failures-only); null when the autofix left nothing to reason about."""
+	diagnostics: tuple[AgentEnvelope, ...] | None = None
+	"""The failing leaves as AgentJSON envelopes (failures-only); null when nothing survived the fixers."""
 	budget: BudgetReport | None = None
 	"""How ``under`` partitioned the checks, when a budget was given."""
 

--- a/src/camas/v0/__init__.py
+++ b/src/camas/v0/__init__.py
@@ -6,6 +6,7 @@ import typing
 
 from .config import Config as Config
 from .effect import Effect as Effect
+from .task import AgentFormat as AgentFormat
 from .task import Parallel as Parallel
 from .task import Sequential as Sequential
 from .task import Task as Task

--- a/src/camas/v0/task.py
+++ b/src/camas/v0/task.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from pathlib import Path
 from types import MappingProxyType
-from typing import TYPE_CHECKING, Literal, TypeAlias
+from typing import TYPE_CHECKING, Literal, NamedTuple, TypeAlias
 
 if TYPE_CHECKING:
 	from collections.abc import Callable, Mapping
@@ -22,6 +22,19 @@ full run (return the default target), with the changed set otherwise (``()`` →
 OutputKind: TypeAlias = Literal["sarif", "rdjson", "lsp", "junit", "tap", "raw"]
 """The standard a leaf's command emits its diagnostics in — the agent-facing format camas
 tags and passes through verbatim, never parsing. ``raw`` (the default) is plain text."""
+
+
+class AgentFormat(NamedTuple):
+	"""A leaf's agent-only structured-output variant: ``args`` (a producing flag the user
+	supplies — camas never infers it) appended to the command, and the ``kind`` of diagnostics
+	it makes the tool emit. Applied only when an agent runs; a human run leaves the command as-is.
+
+	>>> AgentFormat("--output-format sarif", "sarif")
+	AgentFormat(args='--output-format sarif', kind='sarif')
+	"""
+
+	args: str
+	kind: OutputKind
 
 
 _EMPTY_ENV: Mapping[str, str] = MappingProxyType({})
@@ -51,8 +64,8 @@ class Task:
 	directory-prefix string (``"."``) or a ``(changed) -> tuple[str, ...]`` callable that
 	maps the changed files into the command; ``None`` leaves the command untouched.
 
-	``output_kind`` tags the diagnostic standard the command emits (``sarif``, ``lsp``, …);
-	the gate and the ``AgentJSON`` envelope carry the output under that tag, verbatim.
+	``agent_format`` is the agent-only structured-output variant (:class:`AgentFormat`): the gate
+	appends its ``args`` and tags the diagnostics ``kind``; a human run leaves the command as-is.
 
 	>>> Task("echo hi")
 	Task(cmd='echo hi', name=None, env={}, cwd=None)
@@ -68,8 +81,8 @@ class Task:
 	Task(cmd='ruff format .', name=None, env={}, cwd=None, mutates=True)
 	>>> Task("ruff format {paths}", mutates=True, paths=".")
 	Task(cmd='ruff format {paths}', name=None, env={}, cwd=None, mutates=True, paths='.')
-	>>> Task("ruff check . --output-format sarif", output_kind="sarif")
-	Task(cmd='ruff check . --output-format sarif', name=None, env={}, cwd=None, output_kind='sarif')
+	>>> Task("ruff check .", agent_format=AgentFormat("--output-format sarif", "sarif"))
+	Task(cmd='ruff check .', name=None, env={}, cwd=None, agent_format=AgentFormat(args='--output-format sarif', kind='sarif'))
 	>>> hash(Task("a")) == hash(Task("a"))
 	True
 	>>> {Task("a", env={"K": "v"}), Task("a", env={"K": "v"})} == {Task("a", env={"K": "v"})}
@@ -83,7 +96,7 @@ class Task:
 	help: str | None
 	mutates: bool
 	paths: str | PathScope | None
-	output_kind: OutputKind
+	agent_format: AgentFormat | None
 
 	def __init__(
 		self,
@@ -94,7 +107,7 @@ class Task:
 		help: str | None = None,
 		mutates: bool = False,
 		paths: str | PathScope | None = None,
-		output_kind: OutputKind = "raw",
+		agent_format: AgentFormat | None = None,
 	) -> None:
 		put = object.__setattr__
 		put(self, "cmd", cmd)
@@ -104,7 +117,7 @@ class Task:
 		put(self, "help", help)
 		put(self, "mutates", mutates)
 		put(self, "paths", paths)
-		put(self, "output_kind", output_kind)
+		put(self, "agent_format", agent_format)
 
 	def __hash__(self) -> int:
 		return hash(
@@ -116,7 +129,7 @@ class Task:
 				self.help,
 				self.mutates,
 				self.paths,
-				self.output_kind,
+				self.agent_format,
 			)
 		)
 
@@ -129,7 +142,7 @@ class Task:
 			*([f"help={self.help!r}"] if self.help is not None else []),
 			*(["mutates=True"] if self.mutates else []),
 			*([f"paths={self.paths!r}"] if self.paths is not None else []),
-			*([f"output_kind={self.output_kind!r}"] if self.output_kind != "raw" else []),
+			*([f"agent_format={self.agent_format!r}"] if self.agent_format is not None else []),
 		)
 		return f"Task({', '.join(parts)})"
 

--- a/src/camas/v0/task.py
+++ b/src/camas/v0/task.py
@@ -66,6 +66,7 @@ class Task:
 
 	``agent_format`` is the agent-only structured-output variant (:class:`AgentFormat`): the gate
 	appends its ``args`` and tags the diagnostics ``kind``; a human run leaves the command as-is.
+	A bare ``(args, kind)`` tuple is coerced to an :class:`AgentFormat`.
 
 	>>> Task("echo hi")
 	Task(cmd='echo hi', name=None, env={}, cwd=None)
@@ -83,6 +84,8 @@ class Task:
 	Task(cmd='ruff format {paths}', name=None, env={}, cwd=None, mutates=True, paths='.')
 	>>> Task("ruff check .", agent_format=AgentFormat("--output-format sarif", "sarif"))
 	Task(cmd='ruff check .', name=None, env={}, cwd=None, agent_format=AgentFormat(args='--output-format sarif', kind='sarif'))
+	>>> Task("ruff check .", agent_format=("--output-format sarif", "sarif")).agent_format
+	AgentFormat(args='--output-format sarif', kind='sarif')
 	>>> hash(Task("a")) == hash(Task("a"))
 	True
 	>>> {Task("a", env={"K": "v"}), Task("a", env={"K": "v"})} == {Task("a", env={"K": "v"})}
@@ -107,7 +110,7 @@ class Task:
 		help: str | None = None,
 		mutates: bool = False,
 		paths: str | PathScope | None = None,
-		agent_format: AgentFormat | None = None,
+		agent_format: AgentFormat | tuple[str, OutputKind] | None = None,
 	) -> None:
 		put = object.__setattr__
 		put(self, "cmd", cmd)
@@ -117,7 +120,13 @@ class Task:
 		put(self, "help", help)
 		put(self, "mutates", mutates)
 		put(self, "paths", paths)
-		put(self, "agent_format", agent_format)
+		put(
+			self,
+			"agent_format",
+			agent_format
+			if agent_format is None or isinstance(agent_format, AgentFormat)
+			else AgentFormat(*agent_format),
+		)
 
 	def __hash__(self) -> int:
 		return hash(

--- a/src/camas/v0/task.py
+++ b/src/camas/v0/task.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from pathlib import Path
 from types import MappingProxyType
-from typing import TYPE_CHECKING, TypeAlias
+from typing import TYPE_CHECKING, Literal, TypeAlias
 
 if TYPE_CHECKING:
 	from collections.abc import Callable, Mapping
@@ -17,6 +17,11 @@ if TYPE_CHECKING:
 PathScope: TypeAlias = "Callable[[tuple[str, ...]], tuple[str, ...]]"
 """Maps the changed paths to the args injected at ``{paths}``: called with ``()`` for a
 full run (return the default target), with the changed set otherwise (``()`` → skip)."""
+
+
+OutputKind: TypeAlias = Literal["sarif", "rdjson", "lsp", "junit", "tap", "raw"]
+"""The standard a leaf's command emits its diagnostics in — the agent-facing format camas
+tags and passes through verbatim, never parsing. ``raw`` (the default) is plain text."""
 
 
 _EMPTY_ENV: Mapping[str, str] = MappingProxyType({})
@@ -46,6 +51,9 @@ class Task:
 	directory-prefix string (``"."``) or a ``(changed) -> tuple[str, ...]`` callable that
 	maps the changed files into the command; ``None`` leaves the command untouched.
 
+	``output_kind`` tags the diagnostic standard the command emits (``sarif``, ``lsp``, …);
+	the gate and the ``AgentJSON`` envelope carry the output under that tag, verbatim.
+
 	>>> Task("echo hi")
 	Task(cmd='echo hi', name=None, env={}, cwd=None)
 	>>> Task(("ruff", "check", "."), name="lint")
@@ -60,6 +68,8 @@ class Task:
 	Task(cmd='ruff format .', name=None, env={}, cwd=None, mutates=True)
 	>>> Task("ruff format {paths}", mutates=True, paths=".")
 	Task(cmd='ruff format {paths}', name=None, env={}, cwd=None, mutates=True, paths='.')
+	>>> Task("ruff check . --output-format sarif", output_kind="sarif")
+	Task(cmd='ruff check . --output-format sarif', name=None, env={}, cwd=None, output_kind='sarif')
 	>>> hash(Task("a")) == hash(Task("a"))
 	True
 	>>> {Task("a", env={"K": "v"}), Task("a", env={"K": "v"})} == {Task("a", env={"K": "v"})}
@@ -73,6 +83,7 @@ class Task:
 	help: str | None
 	mutates: bool
 	paths: str | PathScope | None
+	output_kind: OutputKind
 
 	def __init__(
 		self,
@@ -83,6 +94,7 @@ class Task:
 		help: str | None = None,
 		mutates: bool = False,
 		paths: str | PathScope | None = None,
+		output_kind: OutputKind = "raw",
 	) -> None:
 		put = object.__setattr__
 		put(self, "cmd", cmd)
@@ -92,6 +104,7 @@ class Task:
 		put(self, "help", help)
 		put(self, "mutates", mutates)
 		put(self, "paths", paths)
+		put(self, "output_kind", output_kind)
 
 	def __hash__(self) -> int:
 		return hash(
@@ -103,6 +116,7 @@ class Task:
 				self.help,
 				self.mutates,
 				self.paths,
+				self.output_kind,
 			)
 		)
 
@@ -115,6 +129,7 @@ class Task:
 			*([f"help={self.help!r}"] if self.help is not None else []),
 			*(["mutates=True"] if self.mutates else []),
 			*([f"paths={self.paths!r}"] if self.paths is not None else []),
+			*([f"output_kind={self.output_kind!r}"] if self.output_kind != "raw" else []),
 		)
 		return f"Task({', '.join(parts)})"
 

--- a/tests/core/test_gate.py
+++ b/tests/core/test_gate.py
@@ -5,8 +5,14 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from camas import Parallel, Sequential, Task
-from camas.core.gate import GateOutcome, decision_of, filter_by_mutates, run_gate
+from camas import AgentFormat, Parallel, Sequential, Task
+from camas.core.gate import (
+	GateOutcome,
+	decision_of,
+	filter_by_mutates,
+	run_gate,
+	with_agent_format,
+)
 from camas.core.task import task_label
 from camas.core.timings import TaskTiming
 
@@ -76,3 +82,32 @@ async def test_gate_budget_runs_fitting_check() -> None:
 	)
 	assert out.residual_class == "autofixed"
 	assert out.budget is not None
+
+
+def test_with_agent_format_appends_to_tuple_command() -> None:
+	t = Task(("ruff", "check", "."), agent_format=AgentFormat("--output-format sarif", "sarif"))
+	result = with_agent_format(t)
+	assert isinstance(result, Task)
+	assert result.cmd == ("ruff", "check", ".", "--output-format", "sarif")
+
+
+def test_with_agent_format_recurses_groups_and_leaves_plain_untouched() -> None:
+	fmt = Task("ruff check .", name="lint", agent_format=AgentFormat("--out sarif", "sarif"))
+	plain = Task("mypy .", name="types")
+	out = with_agent_format(Sequential(fmt, plain))
+	assert isinstance(out, Sequential)
+	first, second = out.tasks
+	assert isinstance(first, Task)
+	assert isinstance(second, Task)
+	assert first.cmd == "ruff check . --out sarif"
+	assert second.cmd == "mypy ."
+
+
+async def test_gate_tags_residual_with_agent_format_kind() -> None:
+	chk = Task(
+		("python", "-c", "import sys; sys.exit(1)"),
+		name="lint",
+		agent_format=AgentFormat("--quiet", "sarif"),
+	)
+	out = await run_gate(Parallel(chk), ())
+	assert out.residual_class == "needs_reasoning"

--- a/tests/main/test_expression.py
+++ b/tests/main/test_expression.py
@@ -154,6 +154,7 @@ def test_eval_node_threads_every_public_constructor_kwarg() -> None:
 		"mutates": ("mutates=True", "mutates", True),
 		"matrix": ("matrix={'X': ('1',)}", "matrix", {"X": ("1",)}),
 		"paths": ("paths='.'", "paths", "."),
+		"output_kind": ("output_kind='sarif'", "output_kind", "sarif"),
 	}
 	for cls, prefix, variadic in (
 		(Task, "Task('c', ", "cmd"),
@@ -166,6 +167,11 @@ def test_eval_node_threads_every_public_constructor_kwarg() -> None:
 
 
 # Parser-side fluent syntax: strings inside literals and the README one-liner.
+
+
+def test_eval_node_rejects_unknown_output_kind() -> None:
+	with pytest.raises(SystemExit, match="2"):
+		parse_expression("Task('c', output_kind='bogus')")
 
 
 def test_parse_top_level_tuple_with_bare_strings() -> None:

--- a/tests/main/test_expression.py
+++ b/tests/main/test_expression.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 import pytest
 
-from camas import Parallel, Sequential, Task
+from camas import AgentFormat, Parallel, Sequential, Task
 from camas.main.expression import parse_expression
 from camas.v0.task import Group
 
@@ -154,7 +154,11 @@ def test_eval_node_threads_every_public_constructor_kwarg() -> None:
 		"mutates": ("mutates=True", "mutates", True),
 		"matrix": ("matrix={'X': ('1',)}", "matrix", {"X": ("1",)}),
 		"paths": ("paths='.'", "paths", "."),
-		"output_kind": ("output_kind='sarif'", "output_kind", "sarif"),
+		"agent_format": (
+			"agent_format=AgentFormat('--x', 'sarif')",
+			"agent_format",
+			AgentFormat("--x", "sarif"),
+		),
 	}
 	for cls, prefix, variadic in (
 		(Task, "Task('c', ", "cmd"),
@@ -169,9 +173,19 @@ def test_eval_node_threads_every_public_constructor_kwarg() -> None:
 # Parser-side fluent syntax: strings inside literals and the README one-liner.
 
 
-def test_eval_node_rejects_unknown_output_kind() -> None:
+def test_eval_node_rejects_unknown_agent_format_kind() -> None:
 	with pytest.raises(SystemExit, match="2"):
-		parse_expression("Task('c', output_kind='bogus')")
+		parse_expression("Task('c', agent_format=AgentFormat('--x', 'bogus'))")
+
+
+def test_eval_node_rejects_incomplete_agent_format() -> None:
+	with pytest.raises(SystemExit, match="2"):
+		parse_expression("Task('c', agent_format=AgentFormat('--x'))")
+
+
+def test_eval_node_rejects_non_agent_format_value() -> None:
+	with pytest.raises(SystemExit, match="2"):
+		parse_expression("Task('c', agent_format='sarif')")
 
 
 def test_parse_top_level_tuple_with_bare_strings() -> None:

--- a/tests/main/test_expression.py
+++ b/tests/main/test_expression.py
@@ -188,6 +188,12 @@ def test_eval_node_rejects_non_agent_format_value() -> None:
 		parse_expression("Task('c', agent_format='sarif')")
 
 
+def test_eval_node_accepts_agent_format_tuple_shorthand() -> None:
+	node = parse_expression("Task('c', agent_format=('--x', 'sarif'))")
+	assert isinstance(node, Task)
+	assert node.agent_format == AgentFormat("--x", "sarif")
+
+
 def test_parse_top_level_tuple_with_bare_strings() -> None:
 	assert parse_expression('("a", "b", "c")') == Sequential(Task("a"), Task("b"), Task("c"))
 

--- a/tests/mcp/test_result.py
+++ b/tests/mcp/test_result.py
@@ -9,8 +9,8 @@ from camas import Parallel, Sequential, Task
 from camas.core.completion import RunResult, TaskResult
 from camas.core.execution import run
 from camas.mcp import wire
-from camas.mcp.result import to_run_response
-from camas.v0.completion import Stopped
+from camas.mcp.result import agent_envelopes, to_agent_envelope, to_run_response
+from camas.v0.completion import Finished, Skipped, Stopped
 
 if TYPE_CHECKING:
 	from camas.mcp.result import Verbosity
@@ -85,3 +85,34 @@ def test_stopped_leaf_maps_to_wire_stopped() -> None:
 	assert isinstance(comp, wire.Stopped)
 	assert comp.output == ["bye"]
 	assert (resp.passed, resp.failed, resp.skipped, resp.interrupt_count) == (0, 1, 0, 1)
+
+
+def test_agent_envelope_finished_carries_verbatim_payload() -> None:
+	task = Task("ruff check . --output-format sarif", name="lint", output_kind="sarif")
+	env = to_agent_envelope(task, TaskResult("lint", Finished(1, 0.1, (b"E1\n", b"E2\n"))))
+	assert (env.name, env.exit_code, env.output_kind) == ("lint", 1, "sarif")
+	assert env.payload == "E1\nE2"
+	assert env.truncated is False
+
+
+def test_agent_envelope_skipped_has_empty_payload() -> None:
+	env = to_agent_envelope(Task("x", name="x"), TaskResult("x", Skipped(1, "dep")))
+	assert env.exit_code == 1
+	assert env.payload == ""
+
+
+def test_agent_envelope_stopped_carries_partial_output() -> None:
+	env = to_agent_envelope(
+		Task("x", name="x"), TaskResult("x", Stopped(130, 0.1, (b"partial\n",)))
+	)
+	assert env.exit_code == 130
+	assert env.payload == "partial"
+
+
+async def test_agent_envelopes_are_failures_only() -> None:
+	node = Parallel(
+		Task(("python", "-c", "pass"), name="ok"),
+		Task(("python", "-c", "raise SystemExit(1)"), name="bad"),
+	)
+	envelopes = agent_envelopes(node, await run(node, interactive=False))
+	assert tuple(e.name for e in envelopes) == ("bad",)

--- a/tests/mcp/test_result.py
+++ b/tests/mcp/test_result.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from camas import Parallel, Sequential, Task
+from camas import AgentFormat, Parallel, Sequential, Task
 from camas.core.completion import RunResult, TaskResult
 from camas.core.execution import run
 from camas.mcp import wire
@@ -88,7 +88,9 @@ def test_stopped_leaf_maps_to_wire_stopped() -> None:
 
 
 def test_agent_envelope_finished_carries_verbatim_payload() -> None:
-	task = Task("ruff check . --output-format sarif", name="lint", output_kind="sarif")
+	task = Task(
+		"ruff check .", name="lint", agent_format=AgentFormat("--output-format sarif", "sarif")
+	)
 	env = to_agent_envelope(task, TaskResult("lint", Finished(1, 0.1, (b"E1\n", b"E2\n"))))
 	assert (env.name, env.exit_code, env.output_kind) == ("lint", 1, "sarif")
 	assert env.payload == "E1\nE2"

--- a/tests/test_v0.py
+++ b/tests/test_v0.py
@@ -19,7 +19,7 @@ from camas.v0.leaf_state import Completed, LeafState, Running, Waiting
 from camas.v0.task import Group, Parallel, Sequential, Task, TaskNode
 from camas.v0.task_event import CompletedEvent, OutputEvent, StartedEvent, TaskEvent
 
-HEADLINE: Final = frozenset({"Config", "Effect", "Parallel", "Sequential", "Task"})
+HEADLINE: Final = frozenset({"AgentFormat", "Config", "Effect", "Parallel", "Sequential", "Task"})
 """The unversioned definers re-exported by both ``camas`` and ``camas.v0``."""
 
 PUBLIC_API: Final = (


### PR DESCRIPTION
Closes #68. Targets **`epic/sa-gate`** per the epic branching policy. Layer 4 of #77 — folds into the gate's diagnostics (#69).

## What

Tag a leaf with the diagnostic standard its command emits — **without changing the human-facing command**. The producing flag lives in an agent-only field and is applied only when the gate runs:

```python
Task("ruff check .", agent_format=AgentFormat(args="--output-format sarif", kind="sarif"))
```
- **Human** (`camas check` / `camas run` / CI): runs `ruff check .` → normal terminal output.
- **Agent** (the gate): runs `ruff check . --output-format sarif`, tags the envelope `sarif`.

camas never knows the tool — you supply the flag; no per-tool registry (reviewdog's model). `output_kind` is the standard tag; the payload is passed through verbatim, never parsed or translated.

> **Design note:** an earlier cut baked `--output-format sarif` into `cmd` itself, which would make a human `camas check` emit SARIF in their terminal. `cmd` is the SSOT for human *and* agent runs, so the agent-only format had to come off it. Hence `agent_format`, applied solely by the gate.

## Changes
- `v0/task.py` — `Task.agent_format: AgentFormat | None` (`AgentFormat(args, kind)`, a NamedTuple); `AgentFormat` exported from the public API (`from camas import AgentFormat`). Threaded through all five reconstruction sites; the `eval_node` drift guard covers it (`eval_agent_format` validates the kind, positional + keyword forms).
- `core/gate.py` — `with_agent_format` appends `agent_format.args` to the leaves the gate runs (via `dataclasses.replace`); `run_gate` applies it after scoping. No human run path calls it.
- `mcp` — `AgentEnvelope {name, exit_code, output_kind, payload}` (failures-only); `to_gate_response` emits envelopes; `output_kind` derives from `agent_format.kind` (else `raw`).

## Verified
- 100% coverage (999 passed); all five typecheckers; ruff lint + format clean. Tests use pytest-asyncio (`async def`/`await`).
- Adversarial review confirmed the human-`cmd`-untouched invariant and found no slop. Two **pre-existing** gaps it surfaced are filed separately and are *not* #68 regressions: #85 (`to_expression` round-trip incompleteness) and #86 (`specialize_node` group `env`/`matrix`).

## Scope
The standalone `camas run` AgentJSON *effect* (the issue's other delivery vehicle) reuses this same envelope and is a clean fast-follow. Reference flag recipes stay in docs/examples per the issue, surfaced via `camas_docs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
