### PR TITLE
feat(plugin): ship the camas Claude Code plugin via a repo marketplace (#80)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
     {
       "name": "camas",
       "source": "./agent/claude/plugin",
-      "description": "The camas SA-delegation gate: deterministic autofix + residual-only surfacing."
+      "description": "The camas gate \u2014 deterministic autofix on every change, plus residual-only surfacing after each batch."
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,13 @@
+{
+  "name": "camas",
+  "owner": {
+    "name": "JP Hutchins"
+  },
+  "plugins": [
+    {
+      "name": "camas",
+      "source": "./agent/claude/plugin",
+      "description": "The camas SA-delegation gate: deterministic autofix + residual-only surfacing."
+    }
+  ]
+}

--- a/agent/claude/plugin/.claude-plugin/plugin.json
+++ b/agent/claude/plugin/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "camas",
-  "description": "Static-analysis delegation gate: after each batch of edits, camas applies its deterministic fixes for free and surfaces only the residual that needs reasoning.",
+  "description": "The camas gate: applies the deterministic fixes for free after each change, and surfaces only the residual that needs reasoning.",
   "version": "0.1.0"
 }

--- a/agent/claude/plugin/.claude-plugin/plugin.json
+++ b/agent/claude/plugin/.claude-plugin/plugin.json
@@ -1,0 +1,5 @@
+{
+  "name": "camas",
+  "description": "Static-analysis delegation gate: after each batch of edits, camas applies its deterministic fixes for free and surfaces only the residual that needs reasoning.",
+  "version": "0.1.0"
+}

--- a/agent/claude/plugin/.mcp.json
+++ b/agent/claude/plugin/.mcp.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "camas": {
+      "type": "stdio",
+      "command": "camas",
+      "args": [
+        "mcp"
+      ]
+    }
+  }
+}

--- a/agent/claude/plugin/agents/camas-fixer.md
+++ b/agent/claude/plugin/agents/camas-fixer.md
@@ -1,0 +1,16 @@
+---
+name: camas-fixer
+description: Applies the mechanical, no-behavior-change fixes the camas gate identifies, then re-gates. Invoked when camas_gate returns a residual safe for a cheap model.
+model: haiku
+tools: Read, Edit, Bash, mcp__camas__camas_gate
+---
+
+You apply only mechanical, behavior-preserving fixes (formatting, import order, trivial
+annotations) for diagnostics the camas gate marks delegatable, then call `camas_gate` again
+to confirm the residual is gone. Never change program behavior, and never mask a diagnostic
+(no `# type: ignore`, no disabling a check). Anything needing intent, hand back to the main
+agent unchanged.
+
+The delegatable tier is camas issue #79, not yet shipped; until then the gate is binary
+(autofixed | needs_reasoning), so re-run the gate and surface the residual rather than apply
+a curated mechanical payload.

--- a/agent/claude/plugin/agents/camas-fixer.md
+++ b/agent/claude/plugin/agents/camas-fixer.md
@@ -1,16 +1,11 @@
 ---
 name: camas-fixer
-description: Applies the mechanical, no-behavior-change fixes the camas gate identifies, then re-gates. Invoked when camas_gate returns a residual safe for a cheap model.
+description: Applies the mechanical, behavior-preserving fixes the camas gate marks delegatable, then re-gates. Invoked when camas_gate returns a residual safe for a cheap model.
 model: haiku
 tools: Read, Edit, Bash, mcp__camas__camas_gate
 ---
 
-You apply only mechanical, behavior-preserving fixes (formatting, import order, trivial
-annotations) for diagnostics the camas gate marks delegatable, then call `camas_gate` again
-to confirm the residual is gone. Never change program behavior, and never mask a diagnostic
-(no `# type: ignore`, no disabling a check). Anything needing intent, hand back to the main
-agent unchanged.
-
-The delegatable tier is camas issue #79, not yet shipped; until then the gate is binary
-(autofixed | needs_reasoning), so re-run the gate and surface the residual rather than apply
-a curated mechanical payload.
+Apply only mechanical, behavior-preserving fixes for the diagnostics the camas gate marks
+delegatable, then call `camas_gate` again to confirm the residual is gone. Never change
+behavior, and never mask a diagnostic — do not suppress, disable, or loosen a check. Anything
+that needs understanding intent, hand back to the main agent unchanged.

--- a/agent/claude/plugin/hooks/hooks.json
+++ b/agent/claude/plugin/hooks/hooks.json
@@ -1,0 +1,17 @@
+{
+  "hooks": {
+    "PostToolBatch": [
+      {
+        "matcher": "Edit|Write|MultiEdit|NotebookEdit",
+        "hooks": [
+          {
+            "type": "mcp_tool",
+            "server": "camas",
+            "tool": "camas_gate",
+            "input": {}
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/agent/claude/plugin/hooks/hooks.json
+++ b/agent/claude/plugin/hooks/hooks.json
@@ -1,5 +1,15 @@
 {
   "hooks": {
+    "FileChanged": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "camas fix --paths ${file_path}"
+          }
+        ]
+      }
+    ],
     "PostToolBatch": [
       {
         "matcher": "Edit|Write|MultiEdit|NotebookEdit",

--- a/agent/claude/plugin/skills/gate/SKILL.md
+++ b/agent/claude/plugin/skills/gate/SKILL.md
@@ -1,17 +1,20 @@
 ---
 name: gate
-description: How the camas static-analysis gate works — when it runs, how to read a needs_reasoning residual, and the no-masking rule.
+description: How the camas gate works — when it runs, how to read a needs_reasoning residual, and the no-masking rule.
 ---
 
-The camas SA-delegation gate runs after each batch of edits (a `PostToolBatch` hook calls the
-`camas_gate` MCP tool). The gate applies camas's deterministic autofix (formatters, import
-sorting) for free, runs the project's checks over the fixed workspace, and classifies the
-residual: `autofixed` (nothing left) or `needs_reasoning` (a check still fails).
+The camas gate keeps the workspace green as you edit, in two layers:
 
-When the gate surfaces a `needs_reasoning` residual, fix the underlying problem — do not mask
-it. No `# type: ignore`, no `# noqa`, no disabling or loosening a check to make the gate pass.
-A green gate must mean the code is actually correct.
+- On every file change, a `FileChanged` hook runs camas's deterministic fixers (`camas fix`)
+  scoped to that file — zero model tokens. Define a `fix` task (your mutating,
+  behavior-preserving leaves) for it to run.
+- After each batch of edits, a `PostToolBatch` hook calls the `camas_gate` tool: it applies
+  the deterministic fixes for free, runs the project's checks over the fixed workspace, and
+  classifies the residual — `autofixed` (nothing left) or `needs_reasoning` (a check still fails).
 
-The gate runs the project's default camas task. To scope or time-box it, edit the hook's
-`input` in `hooks/hooks.json` (a faster `task`, or an `under` budget), or point it at a check
-task whose leaves declare `agent_format` so diagnostics arrive in a structured standard.
+When the gate surfaces a `needs_reasoning` residual, fix the underlying problem — never mask
+it: do not suppress, disable, or loosen a check to make the gate pass. A green gate must mean
+the work is actually correct.
+
+The gate runs the project's default camas task; scope or time-box it by editing the hook's
+`input` in `hooks/hooks.json`.

--- a/agent/claude/plugin/skills/gate/SKILL.md
+++ b/agent/claude/plugin/skills/gate/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: gate
+description: How the camas static-analysis gate works — when it runs, how to read a needs_reasoning residual, and the no-masking rule.
+---
+
+The camas SA-delegation gate runs after each batch of edits (a `PostToolBatch` hook calls the
+`camas_gate` MCP tool). The gate applies camas's deterministic autofix (formatters, import
+sorting) for free, runs the project's checks over the fixed workspace, and classifies the
+residual: `autofixed` (nothing left) or `needs_reasoning` (a check still fails).
+
+When the gate surfaces a `needs_reasoning` residual, fix the underlying problem — do not mask
+it. No `# type: ignore`, no `# noqa`, no disabling or loosening a check to make the gate pass.
+A green gate must mean the code is actually correct.
+
+The gate runs the project's default camas task. To scope or time-box it, edit the hook's
+`input` in `hooks/hooks.json` (a faster `task`, or an `under` budget), or point it at a check
+task whose leaves declare `agent_format` so diagnostics arrive in a structured standard.

--- a/tests/plugin/test_gate_e2e.py
+++ b/tests/plugin/test_gate_e2e.py
@@ -1,0 +1,69 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2026 JP Hutchins
+
+"""End-to-end gate "sandbox": a real tasks.py in a tmp project, driven through the
+``camas_gate`` MCP tool (what the plugin's PostToolBatch hook calls), exercising the
+autofix-then-check-then-classify loop against files on disk. tmp_path is auto-removed."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from mcp import types
+
+from camas.main.tasks import load_tasks_from_py
+from camas.mcp import serve
+from camas.mcp.serve import Compat, Session
+
+if TYPE_CHECKING:
+	from pathlib import Path
+
+	import pytest
+
+# A fix leaf that deletes the literal "TODO" from sample.py, and a check that fails while a
+# marker is still present. Same fix in both; the check's marker decides autofixed vs residual.
+_FIX = (
+	"fix = Task(\n"
+	'\t("python", "-c", "import pathlib; p = pathlib.Path(\'sample.py\'); '
+	"p.write_text(p.read_text().replace('TODO', ''))\"),\n"
+	'\tname="fix",\n\tmutates=True,\n)\n'
+)
+
+
+def _tasks_py(marker: str) -> str:
+	return (
+		"from camas import Config, Sequential, Task\n\n" + _FIX + "check = Task(\n"
+		f'\t("python", "-c", "import pathlib, sys; sys.exit(\'{marker}\' in pathlib.Path(\'sample.py\').read_text())"),\n'
+		'\tname="check",\n)\n'
+		"_ = Config(default_task=Sequential(fix, check))\n"
+	)
+
+
+def _text(result: types.CallToolResult) -> str:
+	return "".join(c.text for c in result.content if isinstance(c, types.TextContent))
+
+
+def _session(tmp_path: Path, marker: str) -> Session:
+	(tmp_path / "tasks.py").write_text(_tasks_py(marker))
+	return Session(load_tasks_from_py(tmp_path / "tasks.py"), tmp_path, Compat())
+
+
+async def test_gate_autofix_edits_a_real_file_then_passes(
+	tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+	monkeypatch.chdir(tmp_path)
+	(tmp_path / "sample.py").write_text("TODO\nvalue = 1\n")
+	result = await serve.call(_session(tmp_path, "TODO"), "camas_gate", {})
+	assert not result.isError
+	assert "autofixed" in _text(result)
+	assert "TODO" not in (tmp_path / "sample.py").read_text()
+
+
+async def test_gate_blocks_on_a_residual_the_fixer_cannot_resolve(
+	tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+	monkeypatch.chdir(tmp_path)
+	(tmp_path / "sample.py").write_text("FIXME\nvalue = 1\n")
+	result = await serve.call(_session(tmp_path, "FIXME"), "camas_gate", {})
+	assert not result.isError
+	assert "needs_reasoning" in _text(result)

--- a/tests/plugin/test_shipped_plugin.py
+++ b/tests/plugin/test_shipped_plugin.py
@@ -34,6 +34,13 @@ def test_gate_hook_targets_the_real_gate_tool() -> None:
 	assert hook["tool"] == ToolName.GATE.value
 
 
+def test_filechanged_hook_runs_the_deterministic_autofix() -> None:
+	hooks = json.loads((_PLUGIN / "hooks" / "hooks.json").read_text())["hooks"]
+	fc = hooks["FileChanged"][0]["hooks"][0]
+	assert fc["type"] == "command"
+	assert "camas fix" in fc["command"]
+
+
 def test_marketplace_points_at_the_shipped_plugin() -> None:
 	catalog = json.loads((_REPO / ".claude-plugin" / "marketplace.json").read_text())
 	entry = next(p for p in catalog["plugins"] if p["name"] == "camas")

--- a/tests/plugin/test_shipped_plugin.py
+++ b/tests/plugin/test_shipped_plugin.py
@@ -1,0 +1,45 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2026 JP Hutchins
+
+"""The camas Claude Code plugin is shipped as committed files (distributed via the repo's
+marketplace), not unit-tested machinery — so these guard that the static artifacts are
+well-formed and self-consistent: the hook targets the real gate tool, and the marketplace
+points at the plugin that exists."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from camas.mcp.serve import ToolName
+
+_REPO = Path(__file__).resolve().parents[2]
+_PLUGIN = _REPO / "agent" / "claude" / "plugin"
+
+
+def test_plugin_manifest_is_named_camas() -> None:
+	assert json.loads((_PLUGIN / ".claude-plugin" / "plugin.json").read_text())["name"] == "camas"
+
+
+def test_bundled_mcp_server_launches_camas_mcp() -> None:
+	server = json.loads((_PLUGIN / ".mcp.json").read_text())["mcpServers"]["camas"]
+	assert (server["command"], server["args"]) == ("camas", ["mcp"])
+
+
+def test_gate_hook_targets_the_real_gate_tool() -> None:
+	hooks = json.loads((_PLUGIN / "hooks" / "hooks.json").read_text())["hooks"]
+	hook = hooks["PostToolBatch"][0]["hooks"][0]
+	assert hook["type"] == "mcp_tool"
+	assert hook["server"] == "camas"
+	assert hook["tool"] == ToolName.GATE.value
+
+
+def test_marketplace_points_at_the_shipped_plugin() -> None:
+	catalog = json.loads((_REPO / ".claude-plugin" / "marketplace.json").read_text())
+	entry = next(p for p in catalog["plugins"] if p["name"] == "camas")
+	assert (_REPO / entry["source"]).resolve() == _PLUGIN.resolve()
+
+
+def test_plugin_ships_the_fixer_and_skill() -> None:
+	assert "name: camas-fixer" in (_PLUGIN / "agents" / "camas-fixer.md").read_text()
+	assert "name: gate" in (_PLUGIN / "skills" / "gate" / "SKILL.md").read_text()


### PR DESCRIPTION
Advances #80 (the last epic layer). Targets **`epic/sa-gate`**.

## What

The camas gate ships as an **installable Claude Code plugin, distributed from this repo's marketplace** — *not* scaffolded into user projects (a distributable plugin is published once and installed). Users:

```
/plugin marketplace add JPHutchins/camas
/plugin install camas@camas
```
(with `camas` itself pip/uv-installed so `camas mcp` is on PATH).

- **`agent/claude/plugin/`** — the plugin (namespaced under `agent/` for future agent integrations):
  - `.claude-plugin/plugin.json` — manifest (name `camas`)
  - `.mcp.json` — the camas MCP server (`camas mcp`, exposing `camas_gate` + the tools)
  - `hooks/hooks.json` — a **`PostToolBatch`** hook (verified to block on exit 2, unlike `Stop`) calling the `camas_gate` MCP tool
  - `agents/camas-fixer.md` — a cheap fixer subagent **stub** (the `mechanical_delegatable` tier it applies is #79, not yet shipped)
  - `skills/gate/SKILL.md` — the conventions incl. the no-masking rule (`/camas:gate`)
- **`.claude-plugin/marketplace.json`** — the repo marketplace listing the plugin.

## Verification
- Gate **system** e2e in a pytest `tmp_path` (auto-deleted, no `.claude` touched): a real `tasks.py` driven through the actual `camas_gate` tool, asserting the autofix **edits a real file** and the residual is classified.
- The committed artifacts are guarded by well-formedness tests: the hook's tool **can't drift from `ToolName.GATE`**, and the marketplace `source` must point at the plugin that exists.
- 100% coverage (1007 passed); all five typecheckers; ruff lint + format clean.

## Remaining for #80 (follow-ups)
- Live-validate in the sandbox: does `camas_gate`'s output drive the `PostToolBatch` block, or surface-only? Pin the changed-files input placeholder to scope the gate to the batch (today the hook input is `{}` → gates the project default task).
- The fixer subagent's `mechanical_delegatable` payload — gated on #79.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
