### PR TITLE
feat(plugin): the judgment loop — camas-fixer loops on the gate, bounded, then escalates (#79)

### DIFF
--- a/agent/claude/plugin/agents/camas-fixer.md
+++ b/agent/claude/plugin/agents/camas-fixer.md
@@ -1,11 +1,23 @@
 ---
 name: camas-fixer
-description: Applies the mechanical, behavior-preserving fixes the camas gate marks delegatable, then re-gates. Invoked when camas_gate returns a residual safe for a cheap model.
+description: Resolves a camas gate `needs_reasoning` residual on a cheap model, off the main agent's context — loops fix → `camas_gate` → fix within a bounded turn budget, then hands any unresolved residual back. Invoke it whenever the gate surfaces a residual, before reasoning about the failure yourself.
 model: haiku
+maxTurns: 5
 tools: Read, Edit, Bash, mcp__camas__camas_gate
 ---
 
-Apply only mechanical, behavior-preserving fixes for the diagnostics the camas gate marks
-delegatable, then call `camas_gate` again to confirm the residual is gone. Never change
-behavior, and never mask a diagnostic — do not suppress, disable, or loosen a check. Anything
-that needs understanding intent, hand back to the main agent unchanged.
+You resolve camas gate residuals cheaply, so the main agent spends no reasoning on what a
+fix-and-recheck loop can settle. Loop:
+
+1. Read the failing diagnostics, edit the code to fix the underlying cause, and call
+   `camas_gate` again.
+2. If it comes back green, you are done — say so.
+3. If it still fails, refine and re-gate. Repeat until green or you run out of turns.
+
+Never change behavior, and never mask a diagnostic — do not suppress, disable, loosen, or
+ignore a check to make the gate pass. A green gate must mean the code is actually correct.
+
+When you run out of turns, or hit something that needs understanding intent rather than a
+mechanical fix, stop and hand back: your final message must say the gate is not yet green and
+quote the remaining diagnostics verbatim, so the main agent can take over without re-running
+anything.

--- a/agent/claude/plugin/skills/gate/SKILL.md
+++ b/agent/claude/plugin/skills/gate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gate
-description: How the camas gate works — when it runs, how to read a needs_reasoning residual, and the no-masking rule.
+description: How the camas gate works — when it runs, how a needs_reasoning residual is delegated to the cheap fixer, and the no-masking rule.
 ---
 
 The camas gate keeps the workspace green as you edit, in two layers:
@@ -12,9 +12,15 @@ The camas gate keeps the workspace green as you edit, in two layers:
   the deterministic fixes for free, runs the project's checks over the fixed workspace, and
   classifies the residual — `autofixed` (nothing left) or `needs_reasoning` (a check still fails).
 
-When the gate surfaces a `needs_reasoning` residual, fix the underlying problem — never mask
-it: do not suppress, disable, or loosen a check to make the gate pass. A green gate must mean
-the work is actually correct.
+When the gate surfaces a `needs_reasoning` residual, delegate it to the `camas-fixer` subagent
+before reasoning about the failure yourself. It runs on a cheap model, off your context, and
+loops fix → re-gate within a bounded turn budget, so a fix-and-recheck loop never costs your
+tokens. It hands back only what it could not settle: if its final message says the gate is
+green, the work is done; if it quotes remaining diagnostics, those are the ones that actually
+need your reasoning.
+
+Never mask a residual — yours or the fixer's: do not suppress, disable, or loosen a check to
+make the gate pass. A green gate must mean the work is actually correct.
 
 The gate runs the project's default camas task; scope or time-box it by editing the hook's
 `input` in `hooks/hooks.json`.


### PR DESCRIPTION
Part of the #77 SA-gate epic — targets `epic/sa-gate`, not `main`. Closes #79.

**The last substantive layer: the judgment loop.** Reframed by JP — drop the deterministic `mechanical_delegatable` allowlist + per-`output_kind` code-parsing; the cheap judgment agent *is* the classifier and the deterministic gate *is* the arbiter.

## What changed

On a `needs_reasoning` residual, the cheap `camas-fixer` subagent (shipped as a stub in #80) now gets it **first**, off the main agent's context:

1. fix → call `camas_gate` → refine → re-gate;
2. loop until green or it runs out of turns;
3. on exhaustion (or anything needing real reasoning) it hands the residual back **verbatim** so the main agent takes over without re-running anything.

The gate's binary verdict is the only signal — **no allowlist, no diagnostic-code parsing, no model call in camas core.** Pure plugin artifacts; the gate (#69) is untouched.

- `agents/camas-fixer.md` — reframed from "the fixes the gate *marks delegatable*" to the loop; `model: haiku`, **`maxTurns: 5`** (the cutoff), re-gate instructions, escalate-via-final-message.
- `skills/gate/SKILL.md` — instruct the main agent to delegate a residual to `camas-fixer` first; no-masking rule now covers the fixer's output too.

No new tests: this is prose + frontmatter consumed by the Claude Code runtime, not camas code. The existing shipped-plugin tests already guard the structural integrity that *can* drift (hook → `ToolName.GATE`, marketplace → real dir); asserting the markdown contains the words the markdown contains would just be a change-detector duplicating the spec.

## The cutoff: fixed `maxTurns`, fast determinism

JP: *"fast determinism is the name of the game, so let's set a reasonable max turns."* A fixed `maxTurns: 5` (runtime-enforced), **not** a no-progress detector — deciding two diagnostic dumps are "the same" is itself a judgment call, the non-determinism the gate exists to remove. `5` ≈ 4 fix→re-gate cycles + a handback turn; it's the knob the benchmark calibrates.

## One honest caveat (platform, not design)

Verified against the Claude Code docs: **hooks cannot spawn subagents.** So the *cutoff* is deterministic (runtime `maxTurns`), but *routing a residual to the fixer* is skill-guided — the main agent invokes `camas-fixer` because the gate skill + the subagent's `description` tell it to, not because a hook forces it. There is no more deterministic mechanism today (the hook→subagent feature is an open, unimplemented request). Noted here so it's a known property, not a surprise.

## Verification

Local: `camas check` (ruff format + lint, all 5 typecheckers, tests) and `camas coverage` (100%) green. CI monitored to completion before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
