### PR TITLE
feat: SA-delegation gate — delegate fast checks off the main agent's context (epic #77)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,13 @@
+{
+  "name": "camas",
+  "owner": {
+    "name": "JP Hutchins"
+  },
+  "plugins": [
+    {
+      "name": "camas",
+      "source": "./agent/claude/plugin",
+      "description": "The camas gate \u2014 deterministic autofix on every change, plus residual-only surfacing after each batch."
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -208,22 +208,17 @@ web = Task("prettier --write {paths}", mutates=True, paths="web")
 _ = Config(agent=Claude(fix=Sequential(py, web)))
 ```
 
-`agent.fix` is the project's deterministic auto-fix node; `camas fix` runs it (no task need be *named* `fix`). Without `--paths`, every `{paths}` resolves to its full-run default (`ruff format src`). With it, each leaf runs only over the changed files it covers, and a leaf that covers none is dropped — `--paths` is repeatable, or comma-separated:
+`--paths` works on any task — `camas check --paths src/a.py`. Without it, every `{paths}` resolves to its full-run default (`ruff format src`); with it, each leaf runs only over the changed files it covers, and a leaf that covers none is dropped (`--paths` is repeatable, or comma-separated).
 
-```
-camas fix --paths web/app.ts          # prettier only
-camas fix --paths src/a.py,src/b.py   # ruff only
-```
-
-This is the FileChanged half of the camas Claude Code plugin — it fixes only what changed, zero model tokens. Install the plugin (`/plugin marketplace add JPHutchins/camas`), or wire the hook by hand:
+For the Claude Code plugin, you **register** the auto-fix node — whatever you named it — to `Config.agent.fix`; the FileChanged hook runs *that* node over the just-changed file, zero model tokens. Install the plugin (`/plugin marketplace add JPHutchins/camas`), or wire the hook by hand:
 
 ```jsonc
 // .claude/settings.json
 { "hooks": { "FileChanged": [
-  { "hooks": [{ "type": "command", "command": "camas fix --paths ${file_path}" }] } ] } }
+  { "hooks": [{ "type": "command", "command": "camas mcp fix --paths ${file_path}" }] } ] } }
 ```
 
-When no leaf covers any changed path, the run is a no-op (exits 0).
+`camas mcp fix` runs the registered `Config.agent.fix` node (not a task named `fix` — that's just `camas fix`, your own task); with no fix registered it is a clean no-op, so the hook is harmless without it.
 
 ## Effects plugins
 

--- a/README.md
+++ b/README.md
@@ -189,12 +189,12 @@ lint = Task("ruff check .")
 
 ```
 $ camas --under=1s --dry-run
-Time budget 1.00s — selected 6 leaf(s), excluded 2 (2 over budget, 0 untimed).
+Time budget 1.00s — running 6 leaf(s) (0 unmeasured), excluded 2 over budget.
   over budget: pyright ~4.57s, coverage ~20.98s
 fix → fmt → (mypy | ty | zuban | pyrefly)
 ```
 
-Durations are `1s`, `500ms`, `2m`, `1h`, or a bare number of seconds. Leaves with no recorded timing yet are excluded (a budget can't bound them — run the task once normally to time them). The budget is per-leaf: a leaf is selected when its own estimate fits, so the parallel group's wall-clock stays near the budget.
+Durations are `1s`, `500ms`, `2m`, `1h`, or a bare number of seconds. Only leaves *measured* to exceed the budget are excluded; a leaf with no recorded timing yet runs anyway (and is thereby measured) — skipping it would keep it forever untimed. The budget is per-leaf: a measured leaf runs when its own estimate fits, so the parallel group's wall-clock stays near the budget.
 
 **For agents**, `camas_run` exposes the same budget as its `under` argument (omit `task` to budget the project default), and the response's `budget` field reports what was selected and excluded — a tight, time-boxed validate loop over structured MCP.
 

--- a/README.md
+++ b/README.md
@@ -200,22 +200,22 @@ Durations are `1s`, `500ms`, `2m`, `1h`, or a bare number of seconds. Leaves wit
 
 ## Path scoping (`--paths`)
 
-`camas --paths <path>…` scopes a run to changed paths instead of the whole tree. A leaf opts in by writing the `{paths}` placeholder in its command and declaring its scope with `paths=` — a directory prefix, or a `(changed) -> paths` callable:
+`camas <task> --paths <path>…` scopes a run to changed paths instead of the whole tree. A leaf opts in by writing the `{paths}` placeholder in its command and declaring its scope with `paths=` — a directory prefix, or a `(changed) -> paths` callable:
 
 ```python
 py = Task("ruff format {paths}", mutates=True, paths="src")
 web = Task("prettier --write {paths}", mutates=True, paths="web")
-fix = Sequential(py, web)
+_ = Config(agent=Claude(fix=Sequential(py, web)))
 ```
 
-Without the flag, every `{paths}` resolves to its full-run default (`ruff format src`). With it, each leaf runs only over the changed files it covers, and a leaf that covers none is dropped — `--paths` is repeatable, or comma-separated:
+`agent.fix` is the project's deterministic auto-fix node; `camas fix` runs it (no task need be *named* `fix`). Without `--paths`, every `{paths}` resolves to its full-run default (`ruff format src`). With it, each leaf runs only over the changed files it covers, and a leaf that covers none is dropped — `--paths` is repeatable, or comma-separated:
 
 ```
 camas fix --paths web/app.ts          # prettier only
 camas fix --paths src/a.py,src/b.py   # ruff only
 ```
 
-This is the entry point for a Claude Code `FileChanged` hook — point it at your fixing task and it fixes only what changed, zero model tokens:
+This is the FileChanged half of the camas Claude Code plugin — it fixes only what changed, zero model tokens. Install the plugin (`/plugin marketplace add JPHutchins/camas`), or wire the hook by hand:
 
 ```jsonc
 // .claude/settings.json

--- a/README.md
+++ b/README.md
@@ -198,6 +198,33 @@ Durations are `1s`, `500ms`, `2m`, `1h`, or a bare number of seconds. Leaves wit
 
 **For agents**, `camas_run` exposes the same budget as its `under` argument (omit `task` to budget the project default), and the response's `budget` field reports what was selected and excluded — a tight, time-boxed validate loop over structured MCP.
 
+## Path scoping (`--paths`)
+
+`camas --paths <path>…` scopes a run to changed paths instead of the whole tree. A leaf opts in by writing the `{paths}` placeholder in its command and declaring its scope with `paths=` — a directory prefix, or a `(changed) -> paths` callable:
+
+```python
+py = Task("ruff format {paths}", mutates=True, paths="src")
+web = Task("prettier --write {paths}", mutates=True, paths="web")
+fix = Sequential(py, web)
+```
+
+Without the flag, every `{paths}` resolves to its full-run default (`ruff format src`). With it, each leaf runs only over the changed files it covers, and a leaf that covers none is dropped — `--paths` is repeatable, or comma-separated:
+
+```
+camas fix --paths web/app.ts          # prettier only
+camas fix --paths src/a.py,src/b.py   # ruff only
+```
+
+This is the entry point for a Claude Code `FileChanged` hook — point it at your fixing task and it fixes only what changed, zero model tokens:
+
+```jsonc
+// .claude/settings.json
+{ "hooks": { "FileChanged": [
+  { "hooks": [{ "type": "command", "command": "camas fix --paths ${file_path}" }] } ] } }
+```
+
+When no leaf covers any changed path, the run is a no-op (exits 0).
+
 ## Effects plugins
 
 Define an `Effect` in your `tasks.py` and it's discovered automatically — usable by name from `--effects` and listed under `camas --effects`. See [examples/effect-plugin/](https://github.com/JPHutchins/camas/tree/main/tests/fixtures/effect-plugin) for a typed `Tail` effect that streams per-task output as it arrives.

--- a/agent/claude/plugin/.claude-plugin/plugin.json
+++ b/agent/claude/plugin/.claude-plugin/plugin.json
@@ -1,0 +1,5 @@
+{
+  "name": "camas",
+  "description": "The camas gate: applies the deterministic fixes for free after each change, and surfaces only the residual that needs reasoning.",
+  "version": "0.1.0"
+}

--- a/agent/claude/plugin/.mcp.json
+++ b/agent/claude/plugin/.mcp.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "camas": {
+      "type": "stdio",
+      "command": "camas",
+      "args": [
+        "mcp"
+      ]
+    }
+  }
+}

--- a/agent/claude/plugin/agents/camas-fixer.md
+++ b/agent/claude/plugin/agents/camas-fixer.md
@@ -1,11 +1,23 @@
 ---
 name: camas-fixer
-description: Applies the mechanical, behavior-preserving fixes the camas gate marks delegatable, then re-gates. Invoked when camas_gate returns a residual safe for a cheap model.
+description: Resolves a camas gate `needs_reasoning` residual on a cheap model, off the main agent's context — loops fix → `camas_gate` → fix within a bounded turn budget, then hands any unresolved residual back. Invoke it whenever the gate surfaces a residual, before reasoning about the failure yourself.
 model: haiku
+maxTurns: 5
 tools: Read, Edit, Bash, mcp__camas__camas_gate
 ---
 
-Apply only mechanical, behavior-preserving fixes for the diagnostics the camas gate marks
-delegatable, then call `camas_gate` again to confirm the residual is gone. Never change
-behavior, and never mask a diagnostic — do not suppress, disable, or loosen a check. Anything
-that needs understanding intent, hand back to the main agent unchanged.
+You resolve camas gate residuals cheaply, so the main agent spends no reasoning on what a
+fix-and-recheck loop can settle. Loop:
+
+1. Read the failing diagnostics, edit the code to fix the underlying cause, and call
+   `camas_gate` again.
+2. If it comes back green, you are done — say so.
+3. If it still fails, refine and re-gate. Repeat until green or you run out of turns.
+
+Never change behavior, and never mask a diagnostic — do not suppress, disable, loosen, or
+ignore a check to make the gate pass. A green gate must mean the code is actually correct.
+
+When you run out of turns, or hit something that needs understanding intent rather than a
+mechanical fix, stop and hand back: your final message must say the gate is not yet green and
+quote the remaining diagnostics verbatim, so the main agent can take over without re-running
+anything.

--- a/agent/claude/plugin/agents/camas-fixer.md
+++ b/agent/claude/plugin/agents/camas-fixer.md
@@ -1,0 +1,11 @@
+---
+name: camas-fixer
+description: Applies the mechanical, behavior-preserving fixes the camas gate marks delegatable, then re-gates. Invoked when camas_gate returns a residual safe for a cheap model.
+model: haiku
+tools: Read, Edit, Bash, mcp__camas__camas_gate
+---
+
+Apply only mechanical, behavior-preserving fixes for the diagnostics the camas gate marks
+delegatable, then call `camas_gate` again to confirm the residual is gone. Never change
+behavior, and never mask a diagnostic — do not suppress, disable, or loosen a check. Anything
+that needs understanding intent, hand back to the main agent unchanged.

--- a/agent/claude/plugin/agents/camas-fixer.md
+++ b/agent/claude/plugin/agents/camas-fixer.md
@@ -1,17 +1,19 @@
 ---
 name: camas-fixer
-description: Resolves a camas gate `needs_reasoning` residual on a cheap model, off the main agent's context — loops fix → `camas_gate` → fix within a bounded turn budget, then hands any unresolved residual back. Invoke it whenever the gate surfaces a residual, before reasoning about the failure yourself.
+description: Resolves a camas gate `needs_reasoning` residual on a cheap model, off the main agent's context — fixes the scoped files and re-gates that same scope in a loop within a bounded turn budget, then hands any unresolved residual back. Invoke it when the gate surfaces a residual, passing the gate's rerun scope (its changed paths).
 model: haiku
 maxTurns: 5
 tools: Read, Edit, Bash, mcp__camas__camas_gate
 ---
 
 You resolve camas gate residuals cheaply, so the main agent spends no reasoning on what a
-fix-and-recheck loop can settle. Loop:
+fix-and-recheck loop can settle. You are given the failing diagnostics and the scope that
+produced them — the gate's `rerun` handle: the changed paths (and task) it ran over. Loop:
 
-1. Read the failing diagnostics, edit the code to fix the underlying cause, and call
-   `camas_gate` again.
-2. If it comes back green, you are done — say so.
+1. Read the diagnostics, edit the code to fix the underlying cause, and re-gate the SAME scope:
+   run `camas mcp gate --paths <the changed paths you were given>` (do not widen the scope —
+   re-gate exactly what was handed to you).
+2. If it comes back green (exit 0), you are done — say so.
 3. If it still fails, refine and re-gate. Repeat until green or you run out of turns.
 
 Never change behavior, and never mask a diagnostic — do not suppress, disable, loosen, or

--- a/agent/claude/plugin/hooks/hooks.json
+++ b/agent/claude/plugin/hooks/hooks.json
@@ -1,0 +1,27 @@
+{
+  "hooks": {
+    "FileChanged": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "camas fix --paths ${file_path}"
+          }
+        ]
+      }
+    ],
+    "PostToolBatch": [
+      {
+        "matcher": "Edit|Write|MultiEdit|NotebookEdit",
+        "hooks": [
+          {
+            "type": "mcp_tool",
+            "server": "camas",
+            "tool": "camas_gate",
+            "input": {}
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/agent/claude/plugin/hooks/hooks.json
+++ b/agent/claude/plugin/hooks/hooks.json
@@ -15,10 +15,8 @@
         "matcher": "Edit|Write|MultiEdit|NotebookEdit",
         "hooks": [
           {
-            "type": "mcp_tool",
-            "server": "camas",
-            "tool": "camas_gate",
-            "input": {}
+            "type": "command",
+            "command": "camas mcp gate"
           }
         ]
       }

--- a/agent/claude/plugin/hooks/hooks.json
+++ b/agent/claude/plugin/hooks/hooks.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "camas fix --paths ${file_path}"
+            "command": "camas mcp fix --paths ${file_path}"
           }
         ]
       }

--- a/agent/claude/plugin/skills/gate/SKILL.md
+++ b/agent/claude/plugin/skills/gate/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: gate
+description: How the camas gate works — when it runs, how to read a needs_reasoning residual, and the no-masking rule.
+---
+
+The camas gate keeps the workspace green as you edit, in two layers:
+
+- On every file change, a `FileChanged` hook runs camas's deterministic fixers (`camas fix`)
+  scoped to that file — zero model tokens. Define a `fix` task (your mutating,
+  behavior-preserving leaves) for it to run.
+- After each batch of edits, a `PostToolBatch` hook calls the `camas_gate` tool: it applies
+  the deterministic fixes for free, runs the project's checks over the fixed workspace, and
+  classifies the residual — `autofixed` (nothing left) or `needs_reasoning` (a check still fails).
+
+When the gate surfaces a `needs_reasoning` residual, fix the underlying problem — never mask
+it: do not suppress, disable, or loosen a check to make the gate pass. A green gate must mean
+the work is actually correct.
+
+The gate runs the project's default camas task; scope or time-box it by editing the hook's
+`input` in `hooks/hooks.json`.

--- a/agent/claude/plugin/skills/gate/SKILL.md
+++ b/agent/claude/plugin/skills/gate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gate
-description: How the camas gate works — when it runs, how to read a needs_reasoning residual, and the no-masking rule.
+description: How the camas gate works — when it runs, how a needs_reasoning residual is delegated to the cheap fixer, and the no-masking rule.
 ---
 
 The camas gate keeps the workspace green as you edit, in two layers:
@@ -12,9 +12,15 @@ The camas gate keeps the workspace green as you edit, in two layers:
   the deterministic fixes for free, runs the project's checks over the fixed workspace, and
   classifies the residual — `autofixed` (nothing left) or `needs_reasoning` (a check still fails).
 
-When the gate surfaces a `needs_reasoning` residual, fix the underlying problem — never mask
-it: do not suppress, disable, or loosen a check to make the gate pass. A green gate must mean
-the work is actually correct.
+When the gate surfaces a `needs_reasoning` residual, delegate it to the `camas-fixer` subagent
+before reasoning about the failure yourself. It runs on a cheap model, off your context, and
+loops fix → re-gate within a bounded turn budget, so a fix-and-recheck loop never costs your
+tokens. It hands back only what it could not settle: if its final message says the gate is
+green, the work is done; if it quotes remaining diagnostics, those are the ones that actually
+need your reasoning.
+
+Never mask a residual — yours or the fixer's: do not suppress, disable, or loosen a check to
+make the gate pass. A green gate must mean the work is actually correct.
 
 The gate runs the project's default camas task; scope or time-box it by editing the hook's
 `input` in `hooks/hooks.json`.

--- a/agent/claude/plugin/skills/gate/SKILL.md
+++ b/agent/claude/plugin/skills/gate/SKILL.md
@@ -1,26 +1,27 @@
 ---
 name: gate
-description: How the camas gate works — when it runs, how a needs_reasoning residual is delegated to the cheap fixer, and the no-masking rule.
+description: How the camas gate works — the two deterministic layers, how a needs_reasoning residual is delegated to the cheap fixer, and the no-masking rule.
 ---
 
-The camas gate keeps the workspace green as you edit, in two layers:
+The camas gate keeps the workspace green as you edit, in two deterministic layers — both
+driven by what the project declares in `Config.agent`:
 
-- On every file change, a `FileChanged` hook runs camas's deterministic fixers (`camas fix`)
-  scoped to that file — zero model tokens. Define a `fix` task (your mutating,
-  behavior-preserving leaves) for it to run.
-- After each batch of edits, a `PostToolBatch` hook calls the `camas_gate` tool: it applies
-  the deterministic fixes for free, runs the project's checks over the fixed workspace, and
-  classifies the residual — `autofixed` (nothing left) or `needs_reasoning` (a check still fails).
+- **Fix (FileChanged, scoped).** On every file change, a `FileChanged` hook runs
+  `camas fix --paths <file>` — the project's declared `Config.agent.fix` node (its mutating,
+  behavior-preserving auto-fixers: formatters, `--fix` linters), scoped to that file, at zero
+  model tokens. It never asks you anything.
+- **Check (PostToolBatch, scoped).** After each batch of edits, a `PostToolBatch` hook runs
+  `camas mcp gate` over the just-edited files. The gate is read-only — it does NOT fix — it
+  runs the project's check node (`Config.agent.check`, else the default task) scoped to those
+  files and returns a binary verdict: `green` (the checks pass) or `needs_reasoning` (a check
+  still fails), with the failing diagnostics.
 
-When the gate surfaces a `needs_reasoning` residual, delegate it to the `camas-fixer` subagent
-before reasoning about the failure yourself. It runs on a cheap model, off your context, and
-loops fix → re-gate within a bounded turn budget, so a fix-and-recheck loop never costs your
-tokens. It hands back only what it could not settle: if its final message says the gate is
-green, the work is done; if it quotes remaining diagnostics, those are the ones that actually
-need your reasoning.
+When the gate returns `needs_reasoning`, delegate it to the `camas-fixer` subagent before
+reasoning about the failure yourself. It runs on a cheap model, off your context, and loops
+fix → re-gate within a bounded turn budget, so a fix-and-recheck loop never costs your tokens.
+It hands back only what it could not settle: if its final message says the gate is green, the
+work is done; if it quotes remaining diagnostics, those are the ones that actually need your
+reasoning — and the gate prints the exact `camas mcp gate …` command to re-run that scope.
 
 Never mask a residual — yours or the fixer's: do not suppress, disable, or loosen a check to
 make the gate pass. A green gate must mean the work is actually correct.
-
-The gate runs the project's default camas task; scope or time-box it by editing the hook's
-`input` in `hooks/hooks.json`.

--- a/agent/claude/plugin/skills/gate/SKILL.md
+++ b/agent/claude/plugin/skills/gate/SKILL.md
@@ -7,9 +7,10 @@ The camas gate keeps the workspace green as you edit, in two deterministic layer
 driven by what the project declares in `Config.agent`:
 
 - **Fix (FileChanged, scoped).** On every file change, a `FileChanged` hook runs
-  `camas fix --paths <file>` — the project's declared `Config.agent.fix` node (its mutating,
-  behavior-preserving auto-fixers: formatters, `--fix` linters), scoped to that file, at zero
-  model tokens. It never asks you anything.
+  `camas mcp fix --paths <file>` — which runs the node the project *registered* as
+  `Config.agent.fix` (its mutating, behavior-preserving auto-fixers: formatters, `--fix`
+  linters, named whatever the author chose), scoped to that file, at zero model tokens. It
+  never asks you anything; with no fix registered it is a no-op.
 - **Check (PostToolBatch, scoped).** After each batch of edits, a `PostToolBatch` hook runs
   `camas mcp gate` over the just-edited files. The gate is read-only — it does NOT fix — it
   runs the project's check node (`Config.agent.check`, else the default task) scoped to those
@@ -17,11 +18,12 @@ driven by what the project declares in `Config.agent`:
   still fails), with the failing diagnostics.
 
 When the gate returns `needs_reasoning`, delegate it to the `camas-fixer` subagent before
-reasoning about the failure yourself. It runs on a cheap model, off your context, and loops
-fix → re-gate within a bounded turn budget, so a fix-and-recheck loop never costs your tokens.
-It hands back only what it could not settle: if its final message says the gate is green, the
-work is done; if it quotes remaining diagnostics, those are the ones that actually need your
-reasoning — and the gate prints the exact `camas mcp gate …` command to re-run that scope.
+reasoning about the failure yourself — and hand it the gate's **`rerun`** handle (its
+`{task, paths, under}`, also printed as the `camas mcp gate …` re-run command). That tells the
+fixer exactly which scope to re-gate: it loops fix → `camas mcp gate --paths <those paths>` on
+a cheap model, off your context, within a bounded turn budget, so the loop never costs your
+tokens. It hands back only what it could not settle: if its final message says the gate is
+green, the work is done; if it quotes remaining diagnostics, those actually need your reasoning.
 
 Never mask a residual — yours or the fixer's: do not suppress, disable, or loosen a check to
 make the gate pass. A green gate must mean the work is actually correct.

--- a/src/camas/__init__.py
+++ b/src/camas/__init__.py
@@ -333,6 +333,7 @@ help: ``camas <task> --help``.
 
 import typing
 
+from .v0 import AgentFormat as AgentFormat
 from .v0 import Config as Config
 from .v0 import Effect as Effect
 from .v0 import Parallel as Parallel

--- a/src/camas/__init__.py
+++ b/src/camas/__init__.py
@@ -333,7 +333,9 @@ help: ``camas <task> --help``.
 
 import typing
 
+from .v0 import Agent as Agent
 from .v0 import AgentFormat as AgentFormat
+from .v0 import Claude as Claude
 from .v0 import Config as Config
 from .v0 import Effect as Effect
 from .v0 import Parallel as Parallel

--- a/src/camas/core/budget.py
+++ b/src/camas/core/budget.py
@@ -34,7 +34,9 @@ class OverBudget(NamedTuple):
 
 
 class Untimed(NamedTuple):
-	"""A leaf with no recorded estimate — excluded from a strict budget."""
+	"""A leaf with no recorded estimate — run anyway (and thereby measured), since skipping it
+	would keep it forever unmeasured.
+	"""
 
 	task: Task
 
@@ -74,15 +76,17 @@ def classify(task: Task, budget_s: float, timings: Mapping[TaskLabel, TaskTiming
 def plan_under(
 	node: TaskNode, budget_s: float, timings: Mapping[TaskLabel, TaskTiming]
 ) -> BudgetPlan:
-	"""Partition ``node``'s expanded, de-duplicated leaves by ``budget_s``; untimed leaves
-	are excluded, since a budget can't bound a leaf it has never measured.
+	"""Partition ``node``'s expanded, de-duplicated leaves by ``budget_s``. Only leaves measured
+	to exceed the budget are excluded; untimed leaves are run (and thereby measured), since a
+	budget that skipped them would keep them forever unmeasured.
 	"""
 	leaves = tuple(dict.fromkeys(info.task for info in flatten_leaves(expand_matrix(node))))
 	dispositions = tuple(classify(leaf, budget_s, timings) for leaf in leaves)
 	fits = tuple(d for d in dispositions if isinstance(d, Fits))
 	over_budget = tuple(d for d in dispositions if isinstance(d, OverBudget))
 	untimed = tuple(d for d in dispositions if isinstance(d, Untimed))
-	return BudgetPlan(budget_s, schedule(tuple(f.task for f in fits)), fits, over_budget, untimed)
+	runnable = tuple(d.task for d in dispositions if not isinstance(d, OverBudget))
+	return BudgetPlan(budget_s, schedule(runnable), fits, over_budget, untimed)
 
 
 def schedule(fitting: tuple[Task, ...]) -> TaskNode | None:

--- a/src/camas/core/execution.py
+++ b/src/camas/core/execution.py
@@ -32,6 +32,7 @@ from ..v0.task_event import CompletedEvent, OutputEvent, StartedEvent, TaskEvent
 from .completion import RunResult, TaskResult
 from .leaf_state import KILL_PRESSES, next_state, to_interrupting
 from .matrix import expand_matrix, resolve_cmd
+from .scope import with_default_paths
 from .task import task_label
 from .traversal import flatten_leaves, subtree_leaf_indices
 
@@ -253,7 +254,7 @@ async def run(
 	if jobs is not None and jobs < 1:
 		raise ValueError(f"jobs must be >= 1, got {jobs}")
 	limiter: Final[Limiter] = asyncio.Semaphore(jobs) if jobs is not None else nullcontext()
-	expanded: Final = expand_matrix(task)
+	expanded: Final = with_default_paths(expand_matrix(task))
 	leaf_infos: Final = flatten_leaves(expanded)
 	leaves: Final = tuple(info.task for info in leaf_infos)
 	index_map: Final = {id(info.task): i for i, info in enumerate(leaf_infos)}

--- a/src/camas/core/gate.py
+++ b/src/camas/core/gate.py
@@ -7,6 +7,8 @@ and classify the residual ``autofixed`` vs ``needs_reasoning`` for a ``PostToolB
 
 from __future__ import annotations
 
+import dataclasses
+import shlex
 import sys
 from typing import TYPE_CHECKING, Literal, NamedTuple, TypeAlias
 
@@ -96,6 +98,49 @@ def filter_by_mutates(node: TaskNode, *, mutates: bool) -> TaskNode | None:
 			assert_never(node)
 
 
+def with_agent_format(node: TaskNode) -> TaskNode:
+	"""Append each leaf's ``agent_format.args`` to its command — the agent-only structured-output
+	variant the gate runs; a human run never applies this, so ``cmd`` is otherwise untouched.
+
+	>>> from camas.v0.task import AgentFormat
+	>>> with_agent_format(Task("ruff check .", agent_format=AgentFormat("--output-format sarif", "sarif"))).cmd
+	'ruff check . --output-format sarif'
+	>>> with_agent_format(Task("ruff check .")).cmd
+	'ruff check .'
+	"""
+	match node:
+		case Task():
+			if node.agent_format is None:
+				return node
+			args = node.agent_format.args
+			cmd = (
+				f"{node.cmd} {args}"
+				if isinstance(node.cmd, str)
+				else (*node.cmd, *shlex.split(args))
+			)
+			return dataclasses.replace(node, cmd=cmd)
+		case Sequential(tasks=children, name=name, matrix=matrix, env=env, cwd=cwd, help=help):
+			return Sequential(
+				*(with_agent_format(c) for c in children),
+				name=name,
+				matrix=matrix,
+				env=env,
+				cwd=cwd,
+				help=help,
+			)
+		case Parallel(tasks=children, name=name, matrix=matrix, env=env, cwd=cwd, help=help):
+			return Parallel(
+				*(with_agent_format(c) for c in children),
+				name=name,
+				matrix=matrix,
+				env=env,
+				cwd=cwd,
+				help=help,
+			)
+		case _:
+			assert_never(node)
+
+
 async def run_gate(
 	node: TaskNode,
 	changed: tuple[str, ...],
@@ -108,6 +153,7 @@ async def run_gate(
 	scoped = scope_to_changed(node, changed)
 	if scoped is None:
 		return GateOutcome("autofixed", None, None, None)
+	scoped = with_agent_format(scoped)
 	mutating = filter_by_mutates(scoped, mutates=True)
 	if (
 		mutating is not None

--- a/src/camas/core/gate.py
+++ b/src/camas/core/gate.py
@@ -1,0 +1,126 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2026 JP Hutchins
+
+"""The SA-delegation gate: scope a task to the changed paths, autofix, run the remaining checks,
+and classify the residual ``autofixed`` vs ``needs_reasoning`` for a ``PostToolBatch`` hook.
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import TYPE_CHECKING, Literal, NamedTuple, TypeAlias
+
+from ..v0.task import Parallel, Sequential, Task
+from .budget import plan_under
+from .execution import run
+from .scope import scope_to_changed
+
+if sys.version_info >= (3, 11):
+	from typing import assert_never
+else:  # pragma: no cover
+	from typing_extensions import assert_never
+
+if TYPE_CHECKING:
+	from collections.abc import Mapping
+
+	from ..v0.task import TaskNode
+	from .budget import BudgetPlan
+	from .completion import RunResult
+	from .timings import TaskLabel, TaskTiming
+
+
+ResidualClass: TypeAlias = Literal["autofixed", "needs_reasoning"]
+Decision: TypeAlias = Literal["continue", "block"]
+
+
+class GateOutcome(NamedTuple):
+	"""A gate run's verdict and the residual that produced it."""
+
+	residual_class: ResidualClass
+	residual_node: TaskNode | None
+	"""The failing run's node and result, paired — both set on ``needs_reasoning``, both ``None`` otherwise."""
+	residual_result: RunResult | None
+	budget: BudgetPlan | None
+
+
+def decision_of(residual_class: ResidualClass) -> Decision:
+	"""The ``PostToolBatch`` routing for a class: a surviving residual blocks, else continue.
+
+	>>> decision_of("autofixed"), decision_of("needs_reasoning")
+	('continue', 'block')
+	"""
+	match residual_class:
+		case "autofixed":
+			return "continue"
+		case "needs_reasoning":
+			return "block"
+		case _:
+			assert_never(residual_class)
+
+
+def filter_by_mutates(node: TaskNode, *, mutates: bool) -> TaskNode | None:
+	"""``node`` with only the leaves whose ``mutates`` equals ``mutates``, emptied groups pruned.
+
+	>>> chk = Task("ruff check .", name="lint")
+	>>> filter_by_mutates(chk, mutates=True) is None
+	True
+	>>> filter_by_mutates(chk, mutates=False) is chk
+	True
+	"""
+	match node:
+		case Task():
+			return node if node.mutates == mutates else None
+		case Sequential(tasks=children, name=name, matrix=matrix, env=env, cwd=cwd, help=help):
+			kept = tuple(
+				k
+				for k in (filter_by_mutates(c, mutates=mutates) for c in children)
+				if k is not None
+			)
+			return (
+				Sequential(*kept, name=name, matrix=matrix, env=env, cwd=cwd, help=help)
+				if kept
+				else None
+			)
+		case Parallel(tasks=children, name=name, matrix=matrix, env=env, cwd=cwd, help=help):
+			kept = tuple(
+				k
+				for k in (filter_by_mutates(c, mutates=mutates) for c in children)
+				if k is not None
+			)
+			return (
+				Parallel(*kept, name=name, matrix=matrix, env=env, cwd=cwd, help=help)
+				if kept
+				else None
+			)
+		case _:
+			assert_never(node)
+
+
+async def run_gate(
+	node: TaskNode,
+	changed: tuple[str, ...],
+	*,
+	under: float | None = None,
+	jobs: int | None = None,
+	timings: Mapping[TaskLabel, TaskTiming] | None = None,
+) -> GateOutcome:
+	"""Scope ``node`` to ``changed``, autofix, run the remaining checks, and classify the residual."""
+	scoped = scope_to_changed(node, changed)
+	if scoped is None:
+		return GateOutcome("autofixed", None, None, None)
+	mutating = filter_by_mutates(scoped, mutates=True)
+	if (
+		mutating is not None
+		and (autofix := await run(mutating, jobs=jobs, interactive=False)).returncode != 0
+	):
+		return GateOutcome("needs_reasoning", mutating, autofix, None)
+	readonly = filter_by_mutates(scoped, mutates=False)
+	if readonly is None:
+		return GateOutcome("autofixed", None, None, None)
+	plan = plan_under(readonly, under, timings or {}) if under is not None else None
+	checks_node = plan.node if plan is not None else readonly
+	if checks_node is None:
+		return GateOutcome("autofixed", None, None, plan)
+	if (checks := await run(checks_node, jobs=jobs, interactive=False)).returncode != 0:
+		return GateOutcome("needs_reasoning", checks_node, checks, plan)
+	return GateOutcome("autofixed", None, None, plan)

--- a/src/camas/core/gate.py
+++ b/src/camas/core/gate.py
@@ -1,8 +1,9 @@
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: 2026 JP Hutchins
 
-"""The SA-delegation gate: scope a task to the changed paths, autofix, run the remaining checks,
-and classify the residual ``autofixed`` vs ``needs_reasoning`` for a ``PostToolBatch`` hook.
+"""The SA-delegation gate: scope the check node to the changed paths, run the checks, and
+classify the residual ``green`` vs ``needs_reasoning`` for a ``PostToolBatch`` hook. The gate
+never mutates — the deterministic fixers run separately on ``FileChanged`` (``camas fix``).
 """
 
 from __future__ import annotations
@@ -15,6 +16,7 @@ from typing import TYPE_CHECKING, Literal, NamedTuple, TypeAlias
 from ..v0.task import Parallel, Sequential, Task
 from .budget import plan_under
 from .execution import run
+from .matrix import expand_matrix
 from .scope import scope_to_changed
 
 if sys.version_info >= (3, 11):
@@ -31,71 +33,36 @@ if TYPE_CHECKING:
 	from .timings import TaskLabel, TaskTiming
 
 
-ResidualClass: TypeAlias = Literal["autofixed", "needs_reasoning"]
+ResidualClass: TypeAlias = Literal["green", "needs_reasoning"]
 Decision: TypeAlias = Literal["continue", "block"]
 
 
 class GateOutcome(NamedTuple):
-	"""A gate run's verdict and the residual that produced it."""
+	"""A gate run's verdict and the check run that produced it."""
 
 	residual_class: ResidualClass
-	residual_node: TaskNode | None
-	"""The failing run's node and result, paired — both set on ``needs_reasoning``, both ``None`` otherwise."""
-	residual_result: RunResult | None
+	node: TaskNode | None
+	"""The check node that ran and its result, paired — both set when a run happened (whether
+	``green`` or ``needs_reasoning``), both ``None`` when nothing ran. Diagnostics derive from
+	them only on ``needs_reasoning``.
+	"""
+	result: RunResult | None
 	budget: BudgetPlan | None
 
 
 def decision_of(residual_class: ResidualClass) -> Decision:
 	"""The ``PostToolBatch`` routing for a class: a surviving residual blocks, else continue.
 
-	>>> decision_of("autofixed"), decision_of("needs_reasoning")
+	>>> decision_of("green"), decision_of("needs_reasoning")
 	('continue', 'block')
 	"""
 	match residual_class:
-		case "autofixed":
+		case "green":
 			return "continue"
 		case "needs_reasoning":
 			return "block"
 		case _:
 			assert_never(residual_class)
-
-
-def filter_by_mutates(node: TaskNode, *, mutates: bool) -> TaskNode | None:
-	"""``node`` with only the leaves whose ``mutates`` equals ``mutates``, emptied groups pruned.
-
-	>>> chk = Task("ruff check .", name="lint")
-	>>> filter_by_mutates(chk, mutates=True) is None
-	True
-	>>> filter_by_mutates(chk, mutates=False) is chk
-	True
-	"""
-	match node:
-		case Task():
-			return node if node.mutates == mutates else None
-		case Sequential(tasks=children, name=name, matrix=matrix, env=env, cwd=cwd, help=help):
-			kept = tuple(
-				k
-				for k in (filter_by_mutates(c, mutates=mutates) for c in children)
-				if k is not None
-			)
-			return (
-				Sequential(*kept, name=name, matrix=matrix, env=env, cwd=cwd, help=help)
-				if kept
-				else None
-			)
-		case Parallel(tasks=children, name=name, matrix=matrix, env=env, cwd=cwd, help=help):
-			kept = tuple(
-				k
-				for k in (filter_by_mutates(c, mutates=mutates) for c in children)
-				if k is not None
-			)
-			return (
-				Parallel(*kept, name=name, matrix=matrix, env=env, cwd=cwd, help=help)
-				if kept
-				else None
-			)
-		case _:
-			assert_never(node)
 
 
 def with_agent_format(node: TaskNode) -> TaskNode:
@@ -149,24 +116,24 @@ async def run_gate(
 	jobs: int | None = None,
 	timings: Mapping[TaskLabel, TaskTiming] | None = None,
 ) -> GateOutcome:
-	"""Scope ``node`` to ``changed``, autofix, run the remaining checks, and classify the residual."""
-	scoped = scope_to_changed(node, changed)
+	"""Run the check ``node`` over the ``changed`` paths and classify the residual.
+
+	The check node is expanded, time-boxed (``under``), scoped to ``changed``, and run; the gate
+	never mutates. Untimed leaves are run (and thereby measured); only leaves measured to exceed
+	``under`` are skipped. ``green`` means the checks passed — or the change touched nothing the
+	checks cover, or every leaf was measured too slow for ``under``; ``needs_reasoning`` means a
+	check still fails. Budgeting precedes scoping so each leaf's estimate reuses its unscoped
+	record (a scoped run is no slower than the whole).
+	"""
+	expanded = expand_matrix(node)
+	plan = plan_under(expanded, under, timings or {}) if under is not None else None
+	budgeted = plan.node if plan is not None else expanded
+	if budgeted is None:
+		return GateOutcome("green", None, None, plan)
+	scoped = scope_to_changed(budgeted, changed)
 	if scoped is None:
-		return GateOutcome("autofixed", None, None, None)
-	scoped = with_agent_format(scoped)
-	mutating = filter_by_mutates(scoped, mutates=True)
-	if (
-		mutating is not None
-		and (autofix := await run(mutating, jobs=jobs, interactive=False)).returncode != 0
-	):
-		return GateOutcome("needs_reasoning", mutating, autofix, None)
-	readonly = filter_by_mutates(scoped, mutates=False)
-	if readonly is None:
-		return GateOutcome("autofixed", None, None, None)
-	plan = plan_under(readonly, under, timings or {}) if under is not None else None
-	checks_node = plan.node if plan is not None else readonly
-	if checks_node is None:
-		return GateOutcome("autofixed", None, None, plan)
-	if (checks := await run(checks_node, jobs=jobs, interactive=False)).returncode != 0:
-		return GateOutcome("needs_reasoning", checks_node, checks, plan)
-	return GateOutcome("autofixed", None, None, plan)
+		return GateOutcome("green", None, None, plan)
+	checks_node = with_agent_format(scoped)
+	checks = await run(checks_node, jobs=jobs, interactive=False)
+	residual: ResidualClass = "needs_reasoning" if checks.returncode != 0 else "green"
+	return GateOutcome(residual, checks_node, checks, plan)

--- a/src/camas/core/matrix.py
+++ b/src/camas/core/matrix.py
@@ -108,6 +108,7 @@ def specialize_task(task: Task, binding: MatrixBinding, suffix: str) -> Task:
 		help=substitute_help(task.help, binding),
 		mutates=task.mutates,
 		paths=substitute_paths(task.paths, binding),
+		agent_format=task.agent_format,
 	)
 
 
@@ -339,6 +340,7 @@ def expand_matrix(
 				help=task.help,
 				mutates=task.mutates,
 				paths=task.paths,
+				agent_format=task.agent_format,
 			)
 		case Sequential(tasks=tasks, matrix=matrix, env=env, cwd=cwd):
 			seq_env: Final = parent_env | env

--- a/src/camas/core/matrix.py
+++ b/src/camas/core/matrix.py
@@ -23,6 +23,8 @@ from .task import MatrixBinding, VarBinding, task_label
 if TYPE_CHECKING:
 	from collections.abc import Mapping
 
+	from ..v0.task import PathScope
+
 
 def resolve_cmd(cmd: str | tuple[str, ...]) -> tuple[str, ...]:
 	"""Resolve a command to a tuple of argv tokens, splitting shell strings with shlex.
@@ -75,6 +77,12 @@ def substitute_help(help: str | None, binding: MatrixBinding) -> str | None:
 	return substitute_in_str(help, binding) if help is not None else None
 
 
+def substitute_paths(
+	paths: str | PathScope | None, binding: MatrixBinding
+) -> str | PathScope | None:
+	return substitute_in_str(paths, binding) if isinstance(paths, str) else paths
+
+
 def specialize_task(task: Task, binding: MatrixBinding, suffix: str) -> Task:
 	"""Specialize a leaf Task with concrete variable values from a matrix binding.
 
@@ -82,6 +90,8 @@ def specialize_task(task: Task, binding: MatrixBinding, suffix: str) -> Task:
 	Task(cmd='test 3.14', name='test 3.14 [PY=3.14]', env={'PY': '3.14'}, cwd=None)
 	>>> specialize_task(Task("go", env={"VENV": ".venv-{PY}"}), (VarBinding("PY", "3.14"),), "[PY=3.14]").env
 	{'VENV': '.venv-3.14', 'PY': '3.14'}
+	>>> specialize_task(Task("t {paths}", paths="pkg-{PY}"), (VarBinding("PY", "3.14"),), "[PY=3.14]").paths
+	'pkg-3.14'
 	"""
 	match task.cmd:
 		case str():
@@ -97,6 +107,7 @@ def specialize_task(task: Task, binding: MatrixBinding, suffix: str) -> Task:
 		cwd=substitute_cwd(task.cwd, binding),
 		help=substitute_help(task.help, binding),
 		mutates=task.mutates,
+		paths=substitute_paths(task.paths, binding),
 	)
 
 
@@ -327,6 +338,7 @@ def expand_matrix(
 				cwd=task.cwd if task.cwd is not None else ancestor_cwd,
 				help=task.help,
 				mutates=task.mutates,
+				paths=task.paths,
 			)
 		case Sequential(tasks=tasks, matrix=matrix, env=env, cwd=cwd):
 			seq_env: Final = parent_env | env

--- a/src/camas/core/scope.py
+++ b/src/camas/core/scope.py
@@ -11,15 +11,16 @@ files the leaf covers, and a leaf that covers none of them is dropped.
 
 :func:`with_default_paths` resolves the full-run default and is applied before every run.
 :func:`scope_to_changed` resolves and prunes against a changed set — the entry point for
-the gate (#67/#69). Detecting the changed set is the caller's job; paths match POSIX,
-relative to the same root.
+the gate (#67/#69). Detecting the changed set is the caller's job; :func:`to_changed`
+normalizes an externally-supplied set (absolute hook paths, CLI ``--paths``) to the
+repo-relative POSIX form the matcher expects.
 """
 
 from __future__ import annotations
 
 import shlex
 import sys
-from pathlib import PurePosixPath
+from pathlib import Path, PurePosixPath
 from typing import TYPE_CHECKING, Final
 
 if sys.version_info >= (3, 11):
@@ -30,10 +31,32 @@ else:  # pragma: no cover
 from ..v0.task import Parallel, Sequential, Task
 
 if TYPE_CHECKING:
+	from collections.abc import Iterable
+
 	from ..v0.task import PathScope, TaskNode
 
 
 PATHS_TOKEN: Final = "{paths}"
+
+
+def to_changed(raw: Iterable[str], base: Path) -> tuple[str, ...]:
+	"""Normalize externally-supplied changed paths to the repo-relative POSIX form
+	:func:`scope_to_changed` matches: resolve each against ``base`` (a hook's ``${file_path}``
+	is absolute), drop any that fall outside it. The boundary every changed set passes through —
+	the CLI ``--paths``, the gate request, and the ``PostToolBatch`` event all carry raw paths.
+
+	>>> import tempfile, os
+	>>> d = Path(tempfile.mkdtemp()); _ = (d / "src").mkdir()
+	>>> _ = (d / "src" / "a.py").write_text(""); _ = (d / "b.py").write_text("")
+	>>> to_changed([str(d / "src" / "a.py"), "b.py", "/elsewhere/x.py"], d)
+	('src/a.py', 'b.py')
+	"""
+	root = base.resolve()
+	return tuple(
+		rp.relative_to(root).as_posix()
+		for r in raw
+		if (rp := (root / r).resolve()).is_relative_to(root)
+	)
 
 
 def _within(path: str, prefix: str) -> bool:
@@ -76,14 +99,40 @@ def _inject(cmd: str | tuple[str, ...], parts: tuple[str, ...]) -> str | tuple[s
 	'ruff format a.py b.py'
 	>>> _inject(("ruff", "format", "{paths}"), ("a.py", "b.py"))
 	('ruff', 'format', 'a.py', 'b.py')
+	>>> _inject("ruff format {paths}", ())
+	'ruff format'
 	"""
 	match cmd:
 		case str():
+			if not parts:
+				return cmd.replace(" " + PATHS_TOKEN, "").replace(PATHS_TOKEN, "")
 			return cmd.replace(PATHS_TOKEN, shlex.join(parts))
 		case tuple():
 			return tuple(p for tok in cmd for p in (parts if tok == PATHS_TOKEN else (tok,)))
 		case _:
 			assert_never(cmd)
+
+
+def _rebase_to_cwd(parts: tuple[str, ...], cwd: Path | None) -> tuple[str, ...]:
+	"""Rebase repo-relative injected paths into a leaf's ``cwd`` frame, so a tool that runs from
+	a subdir (``cargo`` in ``src-tauri``) gets paths relative to where it runs. A part outside
+	``cwd`` is left as-is — a prefix/cwd mismatch is the author's to resolve.
+
+	>>> from pathlib import Path
+	>>> _rebase_to_cwd(("src-tauri/src/main.rs", "outside/x"), Path("src-tauri"))
+	('src/main.rs', 'outside/x')
+	>>> _rebase_to_cwd(("a.py",), None)
+	('a.py',)
+	"""
+	if cwd is None:
+		return parts
+	root = PurePosixPath(cwd.as_posix())
+	return tuple(
+		PurePosixPath(p).relative_to(root).as_posix()
+		if PurePosixPath(p).is_relative_to(root)
+		else p
+		for p in parts
+	)
 
 
 def _resolve_leaf(task: Task, changed: tuple[str, ...]) -> Task | None:
@@ -95,7 +144,7 @@ def _resolve_leaf(task: Task, changed: tuple[str, ...]) -> Task | None:
 			if changed and not parts:
 				return None
 			return Task(
-				cmd=_inject(task.cmd, parts),
+				cmd=_inject(task.cmd, _rebase_to_cwd(parts, task.cwd)),
 				name=task.name,
 				env=task.env,
 				cwd=task.cwd,
@@ -158,3 +207,16 @@ def with_default_paths(node: TaskNode) -> TaskNode:
 	Task(cmd='mypy .', name=None, env={}, cwd=None)
 	"""
 	return scope_to_changed(node, ()) or node
+
+
+def resolve_default_leaf(task: Task) -> Task:
+	"""``task`` with its ``{paths}`` resolved to the full-run default — the form a normal run
+	records its timing under. The timing lookup keys on this so a ``{paths}``-template leaf
+	reuses its recorded (unscoped) estimate instead of missing the cache.
+
+	>>> resolve_default_leaf(Task("ruff check {paths}", paths=".")).cmd
+	'ruff check .'
+	>>> resolve_default_leaf(Task("mypy .")).cmd
+	'mypy .'
+	"""
+	return _resolve_leaf(task, ()) or task

--- a/src/camas/core/scope.py
+++ b/src/camas/core/scope.py
@@ -102,6 +102,7 @@ def _resolve_leaf(task: Task, changed: tuple[str, ...]) -> Task | None:
 				help=task.help,
 				mutates=task.mutates,
 				paths=task.paths,
+				agent_format=task.agent_format,
 			)
 
 

--- a/src/camas/core/scope.py
+++ b/src/camas/core/scope.py
@@ -1,0 +1,159 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2026 JP Hutchins
+
+"""Path-scoping: resolve a leaf's ``{paths}`` placeholder against the changed files.
+
+A leaf opts into scoping by putting ``{paths}`` in its command and setting ``Task.paths``
+to either a directory-prefix string (``"."``, ``"frontend"``) or a ``(changed) -> args``
+callable. On a full run (no changed set) ``{paths}`` becomes the prefix — or the callable's
+default — so the task still runs over everything; on a scoped run it becomes the changed
+files the leaf covers, and a leaf that covers none of them is dropped.
+
+:func:`with_default_paths` resolves the full-run default and is applied before every run.
+:func:`scope_to_changed` resolves and prunes against a changed set — the entry point for
+the gate (#67/#69). Detecting the changed set is the caller's job; paths match POSIX,
+relative to the same root.
+"""
+
+from __future__ import annotations
+
+import shlex
+import sys
+from pathlib import PurePosixPath
+from typing import TYPE_CHECKING, Final
+
+if sys.version_info >= (3, 11):
+	from typing import assert_never
+else:  # pragma: no cover
+	from typing_extensions import assert_never
+
+from ..v0.task import Parallel, Sequential, Task
+
+if TYPE_CHECKING:
+	from ..v0.task import PathScope, TaskNode
+
+
+PATHS_TOKEN: Final = "{paths}"
+
+
+def _within(path: str, prefix: str) -> bool:
+	"""True when POSIX ``path`` lies under ``prefix`` (segment-wise, so ``frontend`` does
+	not cover ``frontendx``); ``"."`` covers everything.
+
+	>>> _within("frontend/app.ts", "frontend"), _within("frontendx/app.ts", "frontend")
+	(True, False)
+	>>> _within("anywhere/at/all", ".")
+	True
+	"""
+	base = PurePosixPath(prefix).parts
+	return PurePosixPath(path).parts[: len(base)] == base
+
+
+def _as_scope(paths: str | PathScope) -> PathScope:
+	"""Normalize the ``paths`` field to a scope function. A prefix string covers the changed
+	files under it, falling back to the prefix itself for a full run.
+
+	>>> _as_scope(".")(())
+	('.',)
+	>>> _as_scope("src")(("src/app.py", "docs/readme.md"))
+	('src/app.py',)
+	>>> _as_scope(lambda c: tuple(p for p in c if p.endswith(".py")))(("a.py", "b.rs"))
+	('a.py',)
+	"""
+	if not isinstance(paths, str):
+		return paths
+	prefix = paths
+	return lambda changed: (
+		(prefix,) if not changed else tuple(c for c in changed if _within(c, prefix))
+	)
+
+
+def _inject(cmd: str | tuple[str, ...], parts: tuple[str, ...]) -> str | tuple[str, ...]:
+	"""Replace the ``{paths}`` placeholder in ``cmd`` with ``parts``: shell-joined into a
+	string command, spliced as tokens into a tuple command.
+
+	>>> _inject("ruff format {paths}", ("a.py", "b.py"))
+	'ruff format a.py b.py'
+	>>> _inject(("ruff", "format", "{paths}"), ("a.py", "b.py"))
+	('ruff', 'format', 'a.py', 'b.py')
+	"""
+	match cmd:
+		case str():
+			return cmd.replace(PATHS_TOKEN, shlex.join(parts))
+		case tuple():
+			return tuple(p for tok in cmd for p in (parts if tok == PATHS_TOKEN else (tok,)))
+		case _:
+			assert_never(cmd)
+
+
+def _resolve_leaf(task: Task, changed: tuple[str, ...]) -> Task | None:
+	match task.paths:
+		case None:
+			return task
+		case scope:
+			parts = _as_scope(scope)(tuple(c.replace("\\", "/") for c in changed))
+			if changed and not parts:
+				return None
+			return Task(
+				cmd=_inject(task.cmd, parts),
+				name=task.name,
+				env=task.env,
+				cwd=task.cwd,
+				help=task.help,
+				mutates=task.mutates,
+				paths=task.paths,
+			)
+
+
+def scope_to_changed(node: TaskNode, changed: tuple[str, ...]) -> TaskNode | None:
+	"""``node`` with each leaf's ``{paths}`` resolved for ``changed``, leaves covering none
+	of it pruned, and emptied groups dropped (``None`` when nothing remains).
+
+	A leaf whose command omits ``{paths}`` but sets ``paths`` runs whole when its prefix
+	changed and is skipped otherwise — the selection a file-list-averse tool (``mypy``,
+	``cargo``) needs; here the Rust check drops on a Python-only change.
+
+	>>> py = Task("ruff check {paths}", name="lint", paths=".")
+	>>> rs = Task("cargo check", name="cargo", paths="rust")
+	>>> scope_to_changed(Parallel(py, rs), ("src/app.py",))
+	Parallel(tasks=(Task(cmd='ruff check src/app.py', name='lint', env={}, cwd=None, paths='.'),), name=None, matrix=None, env={}, cwd=None)
+	>>> scope_to_changed(Parallel(py), ("README.md",)) == Parallel(Task("ruff check README.md", name="lint", paths="."))
+	True
+	>>> scope_to_changed(Parallel(Task("ruff {paths}", paths="src")), ("docs/x.md",)) is None
+	True
+	"""
+	match node:
+		case Task():
+			return _resolve_leaf(node, changed)
+		case Sequential(tasks=children, name=name, matrix=matrix, env=env, cwd=cwd, help=help):
+			kept = tuple(
+				s for s in (scope_to_changed(c, changed) for c in children) if s is not None
+			)
+			return (
+				Sequential(*kept, name=name, matrix=matrix, env=env, cwd=cwd, help=help)
+				if kept
+				else None
+			)
+		case Parallel(tasks=children, name=name, matrix=matrix, env=env, cwd=cwd, help=help):
+			kept = tuple(
+				s for s in (scope_to_changed(c, changed) for c in children) if s is not None
+			)
+			return (
+				Parallel(*kept, name=name, matrix=matrix, env=env, cwd=cwd, help=help)
+				if kept
+				else None
+			)
+		case _:
+			assert_never(node)
+
+
+def with_default_paths(node: TaskNode) -> TaskNode:
+	"""``node`` with every ``{paths}`` resolved to its full-run default. Total — the empty
+	change set never prunes — so it is safe to apply before any run.
+
+	>>> with_default_paths(Task("ruff format {paths}", paths="."))
+	Task(cmd='ruff format .', name=None, env={}, cwd=None, paths='.')
+	>>> with_default_paths(Task("mypy ."))
+	Task(cmd='mypy .', name=None, env={}, cwd=None)
+	"""
+	return scope_to_changed(node, ()) or node

--- a/src/camas/core/timings.py
+++ b/src/camas/core/timings.py
@@ -12,6 +12,7 @@ from typing import IO, TYPE_CHECKING, Final, NamedTuple, TypeAlias
 
 from ..v0.completion import Finished, Skipped, Stopped
 from ..v0.task import Parallel, Sequential, Task
+from .scope import resolve_default_leaf
 from .task import task_label
 
 if sys.version_info >= (3, 11):
@@ -80,7 +81,7 @@ def estimate(node: TaskNode, timings: Mapping[TaskLabel, TaskTiming]) -> Estimat
 	"""
 	match node:
 		case Task():
-			label = task_label(node)
+			label = task_label(resolve_default_leaf(node))
 			timing = timings.get(label)
 			if timing is None:
 				return None

--- a/src/camas/main/argv.py
+++ b/src/camas/main/argv.py
@@ -65,7 +65,16 @@ def apply_passthrough(task: TaskNode, args: tuple[str, ...]) -> Task:
 	Task(cmd="pytest -k 'a b'", name=None, env={}, cwd=None)
 	"""
 	match task:
-		case Task(cmd=cmd, name=name, env=env, cwd=cwd, help=help, mutates=mutates, paths=paths):
+		case Task(
+			cmd=cmd,
+			name=name,
+			env=env,
+			cwd=cwd,
+			help=help,
+			mutates=mutates,
+			paths=paths,
+			agent_format=agent_format,
+		):
 			return Task(
 				cmd=f"{cmd} {shlex.join(args)}" if isinstance(cmd, str) else cmd + args,
 				name=name,
@@ -74,6 +83,7 @@ def apply_passthrough(task: TaskNode, args: tuple[str, ...]) -> Task:
 				help=help,
 				mutates=mutates,
 				paths=paths,
+				agent_format=agent_format,
 			)
 		case Sequential() | Parallel():
 			raise ValueError(

--- a/src/camas/main/argv.py
+++ b/src/camas/main/argv.py
@@ -65,7 +65,7 @@ def apply_passthrough(task: TaskNode, args: tuple[str, ...]) -> Task:
 	Task(cmd="pytest -k 'a b'", name=None, env={}, cwd=None)
 	"""
 	match task:
-		case Task(cmd=cmd, name=name, env=env, cwd=cwd, help=help, mutates=mutates):
+		case Task(cmd=cmd, name=name, env=env, cwd=cwd, help=help, mutates=mutates, paths=paths):
 			return Task(
 				cmd=f"{cmd} {shlex.join(args)}" if isinstance(cmd, str) else cmd + args,
 				name=name,
@@ -73,6 +73,7 @@ def apply_passthrough(task: TaskNode, args: tuple[str, ...]) -> Task:
 				cwd=cwd,
 				help=help,
 				mutates=mutates,
+				paths=paths,
 			)
 		case Sequential() | Parallel():
 			raise ValueError(

--- a/src/camas/main/dispatch.py
+++ b/src/camas/main/dispatch.py
@@ -22,6 +22,7 @@ from ..core.budget import plan_under
 from ..core.execution import run
 from ..core.matrix import matrix_axes, override_matrix
 from ..core.render import print_tree
+from ..core.scope import with_default_paths
 from ..core.task import task_label
 from ..v0.config import Config
 from .argv import apply_passthrough, parse_axis_values, parse_matrix_kv, split_passthrough
@@ -121,7 +122,7 @@ def run_under(
 	if plan.node is None:
 		return 0
 	if dry_run:
-		print_tree(plan.node, show_cmd=True)
+		print_tree(with_default_paths(plan.node), show_cmd=True)
 		return 0
 	return finish_run(asyncio.run(run(plan.node, effects=effects, jobs=jobs)))
 
@@ -367,7 +368,7 @@ def dispatch(state: TasksState, argv: list[str] | None = None) -> None:
 				print(f"error: {e}", file=sys.stderr)
 				sys.exit(2)
 			if args.dry_run:
-				print_tree(task, show_cmd=True)
+				print_tree(with_default_paths(task), show_cmd=True)
 				sys.exit(0)
 			try:
 				jobs: Final = resolve_jobs(args.jobs)

--- a/src/camas/main/dispatch.py
+++ b/src/camas/main/dispatch.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import argparse
 import asyncio
 import os
 import re
@@ -133,6 +134,39 @@ def finish_run(result: RunResult) -> int:
 	if result.interrupt_count:
 		print_interrupt_banner(result.interrupt_count)
 	return result.returncode
+
+
+def fix_cli(argv: list[str]) -> int:
+	"""``camas mcp fix [--paths P]…``: run the project's *registered* agent fix node
+	(``Config.agent.fix`` — whatever the user named it), scoped to the changed paths. This is
+	the FileChanged autofix entry, in the ``camas mcp`` namespace so it never collides with a
+	user's own ``camas <task>``. A clean no-op (exit 0) when no fix node is registered — without
+	registration there is simply nothing for the hook to run.
+	"""
+	parser = argparse.ArgumentParser(
+		prog="camas mcp fix", description="Run the registered agent fix node."
+	)
+	parser.add_argument(
+		"--paths",
+		action="append",
+		default=[],
+		metavar="PATH",
+		help="changed path to scope to (repeatable)",
+	)
+	args = parser.parse_args(argv)
+	state, _ = resolve_tasks_source([])
+	if not isinstance(state, LoadOk) or state.config is None:
+		return 0
+	node = state.config.gate_fix()
+	if node is None:
+		return 0
+	base = state.source.parent if state.source is not None else Path.cwd()
+	changed = to_changed(args.paths, base)
+	expanded = expand_matrix(node)
+	scoped = scope_to_changed(expanded, changed) if changed else with_default_paths(expanded)
+	if scoped is None:
+		return 0
+	return finish_run(asyncio.run(run(scoped, effects=(), jobs=None)))
 
 
 def print_interrupt_banner(count: int) -> None:
@@ -290,10 +324,7 @@ def dispatch(state: TasksState, argv: list[str] | None = None) -> None:
 				sys.exit(0)
 
 			resolved: TaskNode
-			fix_node = effective_config.gate_fix() if args.expression == "fix" else None
-			if fix_node is not None:
-				resolved = fix_node
-			elif args.expression is None:
+			if args.expression is None:
 				if default_node is None:
 					parser.print_help()
 					sys.stdout.flush()

--- a/src/camas/main/dispatch.py
+++ b/src/camas/main/dispatch.py
@@ -20,9 +20,9 @@ else:  # pragma: no cover
 from ..core import timings
 from ..core.budget import plan_under
 from ..core.execution import run
-from ..core.matrix import matrix_axes, override_matrix
+from ..core.matrix import expand_matrix, matrix_axes, override_matrix
 from ..core.render import print_tree
-from ..core.scope import scope_to_changed, with_default_paths
+from ..core.scope import scope_to_changed, to_changed, with_default_paths
 from ..core.task import task_label
 from ..v0.config import Config
 from .argv import apply_passthrough, parse_axis_values, parse_matrix_kv, split_passthrough
@@ -81,11 +81,12 @@ def dispatch_arg(arg: str, tasks: Mapping[str, TaskNode]) -> TaskNode:
 
 
 def budget_summary_lines(plan: BudgetPlan) -> list[str]:
-	"""The ``--under`` summary: how many leaves fit the budget, and what was excluded."""
-	excluded = len(plan.over_budget) + len(plan.untimed)
+	"""The ``--under`` summary: how many leaves run (and which are unmeasured), and what was
+	excluded as measured-over-budget.
+	"""
 	lines = [
-		f"Time budget {plan.budget_s:.2f}s — selected {len(plan.fits)} leaf(s), "
-		f"excluded {excluded} ({len(plan.over_budget)} over budget, {len(plan.untimed)} untimed)."
+		f"Time budget {plan.budget_s:.2f}s — running {len(plan.fits) + len(plan.untimed)} leaf(s) "
+		f"({len(plan.untimed)} unmeasured), excluded {len(plan.over_budget)} over budget."
 	]
 	if plan.over_budget:
 		lines.append(
@@ -94,11 +95,11 @@ def budget_summary_lines(plan: BudgetPlan) -> list[str]:
 		)
 	if plan.untimed:
 		lines.append(
-			"  untimed (run the task normally once to record an estimate): "
+			"  unmeasured (running to record an estimate): "
 			+ ", ".join(task_label(u.task) for u in plan.untimed)
 		)
 	if plan.node is None:
-		lines.append("Nothing fits the budget — nothing to run.")
+		lines.append("All leaves exceed the budget — nothing to run.")
 	return lines
 
 
@@ -289,7 +290,10 @@ def dispatch(state: TasksState, argv: list[str] | None = None) -> None:
 				sys.exit(0)
 
 			resolved: TaskNode
-			if args.expression is None:
+			fix_node = effective_config.gate_fix() if args.expression == "fix" else None
+			if fix_node is not None:
+				resolved = fix_node
+			elif args.expression is None:
 				if default_node is None:
 					parser.print_help()
 					sys.stdout.flush()
@@ -341,11 +345,13 @@ def dispatch(state: TasksState, argv: list[str] | None = None) -> None:
 					sys.exit(2)
 
 			if args.paths is not None:
-				changed = tuple(p for raw in args.paths for p in parse_axis_values(raw))
-				scoped = scope_to_changed(resolved, changed) if changed else None
+				base = source.parent if source is not None else Path.cwd()
+				raw_changed = tuple(p for raw in args.paths for p in parse_axis_values(raw))
+				changed = to_changed(raw_changed, base)
+				scoped = scope_to_changed(expand_matrix(resolved), changed) if changed else None
 				if scoped is None:
 					print(
-						f"No task leaf covers {', '.join(changed) or '(no paths given)'}"
+						f"No task leaf covers {', '.join(raw_changed) or '(no paths given)'}"
 						" — nothing to run."
 					)
 					sys.exit(0)

--- a/src/camas/main/dispatch.py
+++ b/src/camas/main/dispatch.py
@@ -22,7 +22,7 @@ from ..core.budget import plan_under
 from ..core.execution import run
 from ..core.matrix import matrix_axes, override_matrix
 from ..core.render import print_tree
-from ..core.scope import with_default_paths
+from ..core.scope import scope_to_changed, with_default_paths
 from ..core.task import task_label
 from ..v0.config import Config
 from .argv import apply_passthrough, parse_axis_values, parse_matrix_kv, split_passthrough
@@ -339,6 +339,17 @@ def dispatch(state: TasksState, argv: list[str] | None = None) -> None:
 				except ValueError as e:
 					print(f"error: {e}", file=sys.stderr)
 					sys.exit(2)
+
+			if args.paths is not None:
+				changed = tuple(p for raw in args.paths for p in parse_axis_values(raw))
+				scoped = scope_to_changed(resolved, changed) if changed else None
+				if scoped is None:
+					print(
+						f"No task leaf covers {', '.join(changed) or '(no paths given)'}"
+						" — nothing to run."
+					)
+					sys.exit(0)
+				resolved = scoped
 
 			if args.under is not None:
 				try:

--- a/src/camas/main/expression.py
+++ b/src/camas/main/expression.py
@@ -16,7 +16,7 @@ if sys.version_info >= (3, 11):
 else:  # pragma: no cover
 	from typing_extensions import assert_never
 
-from ..v0.task import Parallel, Sequential, Task, TaskNode
+from ..v0.task import AgentFormat, OutputKind, Parallel, Sequential, Task, TaskNode
 
 if TYPE_CHECKING:
 	from collections.abc import Mapping
@@ -107,6 +107,33 @@ def eval_opt_bool(node: ast.expr | None) -> bool:
 			return b
 		case _:
 			raise ValueError(f"expected bool literal, got {ast.dump(node)}")
+
+
+def _output_kind(node: ast.expr) -> OutputKind:
+	match node:
+		case ast.Constant(value="sarif" | "rdjson" | "lsp" | "junit" | "tap" | "raw" as kind):
+			return kind
+		case _:
+			raise ValueError(
+				f"AgentFormat kind must be sarif/rdjson/lsp/junit/tap/raw, got {ast.dump(node)}"
+			)
+
+
+def eval_agent_format(node: ast.expr | None) -> AgentFormat | None:
+	match node:
+		case None:
+			return None
+		case ast.Call(func=ast.Name(id="AgentFormat"), args=call_args, keywords=call_kw):
+			kw = {k.arg: k.value for k in call_kw if k.arg is not None}
+			args_node = call_args[0] if call_args else kw.get("args")
+			kind_node = call_args[1] if len(call_args) > 1 else kw.get("kind")
+			if args_node is None or kind_node is None:
+				raise ValueError("AgentFormat requires args and kind")
+			return AgentFormat(eval_str_lit(args_node), _output_kind(kind_node))
+		case ast.Tuple(elts=[args_node, kind_node]):
+			return AgentFormat(eval_str_lit(args_node), _output_kind(kind_node))
+		case _:
+			raise ValueError(f"agent_format must be AgentFormat(args, kind), got {ast.dump(node)}")
 
 
 def eval_env(node: ast.expr | None) -> dict[str, str]:
@@ -217,6 +244,7 @@ def eval_node(
 						help=eval_opt_str(kw.get("help")),
 						mutates=eval_opt_bool(kw.get("mutates")),
 						paths=eval_opt_str(kw.get("paths")),
+						agent_format=eval_agent_format(kw.get("agent_format")),
 					)
 				case "Sequential" | "Parallel":
 					ctor = Sequential if name == "Sequential" else Parallel

--- a/src/camas/main/expression.py
+++ b/src/camas/main/expression.py
@@ -20,6 +20,7 @@ from ..v0.task import AgentFormat, OutputKind, Parallel, Sequential, Task, TaskN
 
 if TYPE_CHECKING:
 	from collections.abc import Mapping
+	from pathlib import Path
 
 	from ..v0.task import PathScope
 
@@ -341,14 +342,26 @@ def to_expression(node: TaskNode) -> str:
 	'Sequential(Parallel(Task("a"), name="p"), Task("b"), name="s")'
 	>>> to_expression(Task("ruff check {paths}", name="lint", paths="src"))
 	'Task("ruff check {paths}", name="lint", paths="src")'
+	>>> to_expression(Task("test", cwd="rust", help="run tests"))
+	'Task("test", cwd="rust", help="run tests")'
 	>>> from camas.v0.task import AgentFormat
 	>>> to_expression(Task("ruff check .", agent_format=AgentFormat("--output-format sarif", "sarif")))
 	'Task("ruff check .", agent_format=AgentFormat("--output-format sarif", "sarif"))'
 	"""
 	match node:
-		case Task(cmd=cmd, name=name, mutates=mutates, paths=paths, agent_format=agent_format):
+		case Task(
+			cmd=cmd,
+			name=name,
+			env=env,
+			cwd=cwd,
+			help=help,
+			mutates=mutates,
+			paths=paths,
+			agent_format=agent_format,
+		):
 			return (
-				f"Task({quote(join_command(cmd))}{name_kwarg(name)}{mutates_kwarg(mutates)}"
+				f"Task({quote(join_command(cmd))}{name_kwarg(name)}{env_kwarg(env)}"
+				f"{cwd_kwarg(cwd)}{help_kwarg(help)}{mutates_kwarg(mutates)}"
 				f"{paths_kwarg(paths)}{agent_format_kwarg(agent_format)})"
 			)
 		case Sequential(tasks=tasks, name=name):
@@ -365,6 +378,18 @@ def render_members(tasks: tuple[TaskNode, ...]) -> str:
 
 def name_kwarg(name: str | None) -> str:
 	return f", name={quote(name)}" if name is not None else ""
+
+
+def env_kwarg(env: Mapping[str, str]) -> str:
+	return f", env={dict(env)!r}" if env else ""
+
+
+def cwd_kwarg(cwd: Path | None) -> str:
+	return f", cwd={quote(cwd.as_posix())}" if cwd is not None else ""
+
+
+def help_kwarg(help: str | None) -> str:
+	return f", help={quote(help)}" if help is not None else ""
 
 
 def mutates_kwarg(mutates: bool) -> str:

--- a/src/camas/main/expression.py
+++ b/src/camas/main/expression.py
@@ -21,6 +21,8 @@ from ..v0.task import AgentFormat, OutputKind, Parallel, Sequential, Task, TaskN
 if TYPE_CHECKING:
 	from collections.abc import Mapping
 
+	from ..v0.task import PathScope
+
 
 class Ref(NamedTuple):
 	"""Parser-only sentinel for a task referenced by name inside a config expression.
@@ -337,10 +339,18 @@ def to_expression(node: TaskNode) -> str:
 	'Parallel(Task("a"), Task("b"), name="checks")'
 	>>> to_expression(Sequential(Parallel(Task("a"), name="p"), Task("b"), name="s"))
 	'Sequential(Parallel(Task("a"), name="p"), Task("b"), name="s")'
+	>>> to_expression(Task("ruff check {paths}", name="lint", paths="src"))
+	'Task("ruff check {paths}", name="lint", paths="src")'
+	>>> from camas.v0.task import AgentFormat
+	>>> to_expression(Task("ruff check .", agent_format=AgentFormat("--output-format sarif", "sarif")))
+	'Task("ruff check .", agent_format=AgentFormat("--output-format sarif", "sarif"))'
 	"""
 	match node:
-		case Task(cmd=cmd, name=name, mutates=mutates):
-			return f"Task({quote(join_command(cmd))}{name_kwarg(name)}{mutates_kwarg(mutates)})"
+		case Task(cmd=cmd, name=name, mutates=mutates, paths=paths, agent_format=agent_format):
+			return (
+				f"Task({quote(join_command(cmd))}{name_kwarg(name)}{mutates_kwarg(mutates)}"
+				f"{paths_kwarg(paths)}{agent_format_kwarg(agent_format)})"
+			)
 		case Sequential(tasks=tasks, name=name):
 			return f"Sequential({render_members(tasks)}{name_kwarg(name)})"
 		case Parallel(tasks=tasks, name=name):
@@ -359,6 +369,23 @@ def name_kwarg(name: str | None) -> str:
 
 def mutates_kwarg(mutates: bool) -> str:
 	return ", mutates=True" if mutates else ""
+
+
+def paths_kwarg(paths: str | PathScope | None) -> str:
+	"""A str scope round-trips; a callable scope has no source, so it renders as a
+	non-parseable marker (this preview is informational, never re-evaluated by camas).
+	"""
+	if paths is None:
+		return ""
+	if isinstance(paths, str):
+		return f", paths={quote(paths)}"
+	return ", paths=<callable>"
+
+
+def agent_format_kwarg(agent_format: AgentFormat | None) -> str:
+	if agent_format is None:
+		return ""
+	return f", agent_format=AgentFormat({quote(agent_format.args)}, {quote(agent_format.kind)})"
 
 
 def quote(value: str) -> str:

--- a/src/camas/main/expression.py
+++ b/src/camas/main/expression.py
@@ -216,6 +216,7 @@ def eval_node(
 						cwd=eval_opt_str(kw.get("cwd")),
 						help=eval_opt_str(kw.get("help")),
 						mutates=eval_opt_bool(kw.get("mutates")),
+						paths=eval_opt_str(kw.get("paths")),
 					)
 				case "Sequential" | "Parallel":
 					ctor = Sequential if name == "Sequential" else Parallel

--- a/src/camas/main/parser.py
+++ b/src/camas/main/parser.py
@@ -321,8 +321,8 @@ def build_parser(state: TasksState = EMPTY_STATE) -> argparse.ArgumentParser:
 		default=None,
 		metavar="PATH[,PATH...]",
 		help="scope the run to these changed paths (repeatable): inject them into each "
-		"leaf's {paths} and drop leaves that match none. The entry point a FileChanged "
-		"hook drives, e.g. camas fix --paths ${file_path}",
+		"leaf's {paths} and drop leaves that match none, e.g. camas check --paths src/a.py. "
+		"A FileChanged hook drives the agent fix node this way via camas mcp fix --paths <file>",
 	)
 	return parser
 

--- a/src/camas/main/parser.py
+++ b/src/camas/main/parser.py
@@ -230,6 +230,8 @@ def build_parser(state: TasksState = EMPTY_STATE) -> argparse.ArgumentParser:
 	True
 	>>> "task | expression" in build_parser(LoadOk({"all": Task("x")}, None, {})).format_usage()
 	True
+	>>> build_parser().parse_args(["fix", "--paths", "a.py", "--paths", "b.py"]).paths
+	['a.py', 'b.py']
 	"""
 	tasks_for_metavar: Mapping[str, TaskNode] = state.tasks if isinstance(state, LoadOk) else {}
 	config: Final = (
@@ -313,6 +315,15 @@ def build_parser(state: TasksState = EMPTY_STATE) -> argparse.ArgumentParser:
 		"parallel; untimed leaves are skipped. Operates on the named task, or the "
 		"Config default when none is given",
 	)
+	parser.add_argument(
+		"--paths",
+		action="append",
+		default=None,
+		metavar="PATH[,PATH...]",
+		help="scope the run to these changed paths (repeatable): inject them into each "
+		"leaf's {paths} and drop leaves that match none. The entry point a FileChanged "
+		"hook drives, e.g. camas fix --paths ${file_path}",
+	)
 	return parser
 
 
@@ -329,6 +340,7 @@ RESERVED_FLAGS: Final = frozenset(
 		"matrix",
 		"jobs",
 		"under",
+		"paths",
 	}
 )
 

--- a/src/camas/main/starter.py
+++ b/src/camas/main/starter.py
@@ -20,7 +20,7 @@ Both are inert under plain ``camas``; delete them if you don't want the
 standalone path.
 """
 
-from camas import Config, Parallel, Sequential, Task, run_cli
+from camas import Claude, Config, Parallel, Sequential, Task, run_cli
 
 # A leaf is any shell command, shlex-split (so quote the -c payload). A bare
 # string inside Sequential/Parallel coerces to an anonymous Task; tuple form
@@ -46,10 +46,19 @@ ci = Sequential(
 	Parallel(greet, "python --version"),
 )
 
-# Config is discovered by type, under any binding name (here `_`): bare
-# `camas` runs default_task — or github_task under GitHub Actions, falling
-# back to default_task when unset.
-_ = Config(default_task=ci)
+# The agent fix node: your deterministic, behavior-preserving auto-fixers, with {paths} so a
+# run scopes to the changed files. `camas fix --paths <file>` runs it (the camas Claude Code
+# plugin's FileChanged hook does this on every edit, for free); replace the placeholder with
+# your real fixers, e.g.:
+#   fix = Task("ruff check --fix {paths}", mutates=True, paths=".")
+#   fix = Parallel(Task("ruff format {paths}", mutates=True), Task("ruff check --fix {paths}", mutates=True), paths=".")
+fix = Task('python -c "" {paths}', name="fix", mutates=True, paths=".")
+
+# Config is discovered by type, under any binding name (here `_`): bare `camas` runs
+# default_task — or github_task under GitHub Actions, falling back to default_task when unset.
+# agent= wires the Claude Code plugin: agent.fix is the FileChanged autofix node above; the
+# gate checks default_task (override with Claude(fix=..., check=...)).
+_ = Config(default_task=ci, agent=Claude(fix=fix))
 
 # The PEP 723 standalone flow (see the docstring): running this file directly
 # (`uv run tasks.py <task>`) dispatches through camas. Inert when the `camas`

--- a/src/camas/main/starter.py
+++ b/src/camas/main/starter.py
@@ -46,19 +46,19 @@ ci = Sequential(
 	Parallel(greet, "python --version"),
 )
 
-# The agent fix node: your deterministic, behavior-preserving auto-fixers, with {paths} so a
-# run scopes to the changed files. `camas fix --paths <file>` runs it (the camas Claude Code
-# plugin's FileChanged hook does this on every edit, for free); replace the placeholder with
-# your real fixers, e.g.:
-#   fix = Task("ruff check --fix {paths}", mutates=True, paths=".")
-#   fix = Parallel(Task("ruff format {paths}", mutates=True), Task("ruff check --fix {paths}", mutates=True), paths=".")
-fix = Task('python -c "" {paths}', name="fix", mutates=True, paths=".")
+# Your deterministic, behavior-preserving auto-fixers, with {paths} so a run scopes to the
+# changed files. Register the node (named anything) to Config.agent.fix below; the camas Claude
+# Code plugin's FileChanged hook runs it on every edit via `camas mcp fix --paths <file>`, for
+# free. Replace the placeholder with your real fixers, e.g.:
+#   autofix = Task("ruff check --fix {paths}", mutates=True, paths=".")
+#   autofix = Parallel(Task("ruff format {paths}", mutates=True), Task("ruff check --fix {paths}", mutates=True), paths=".")
+autofix = Task('python -c "" {paths}', name="autofix", mutates=True, paths=".")
 
 # Config is discovered by type, under any binding name (here `_`): bare `camas` runs
 # default_task — or github_task under GitHub Actions, falling back to default_task when unset.
-# agent= wires the Claude Code plugin: agent.fix is the FileChanged autofix node above; the
-# gate checks default_task (override with Claude(fix=..., check=...)).
-_ = Config(default_task=ci, agent=Claude(fix=fix))
+# agent= wires the Claude Code plugin: agent.fix is the registered FileChanged autofix node
+# above; the gate checks default_task (override with Claude(fix=..., check=...)).
+_ = Config(default_task=ci, agent=Claude(fix=autofix))
 
 # The PEP 723 standalone flow (see the docstring): running this file directly
 # (`uv run tasks.py <task>`) dispatches through camas. Inert when the `camas`

--- a/src/camas/main/tasks.py
+++ b/src/camas/main/tasks.py
@@ -47,9 +47,25 @@ def assign_key_name(node: TaskNode | Ref, key: str) -> TaskNode | Ref:
 	Ref(name='bar')
 	"""
 	match node:
-		case Task(cmd=cmd, name=None, env=env, cwd=cwd, help=help, mutates=mutates, paths=paths):
+		case Task(
+			cmd=cmd,
+			name=None,
+			env=env,
+			cwd=cwd,
+			help=help,
+			mutates=mutates,
+			paths=paths,
+			agent_format=agent_format,
+		):
 			return Task(
-				cmd=cmd, name=key, env=env, cwd=cwd, help=help, mutates=mutates, paths=paths
+				cmd=cmd,
+				name=key,
+				env=env,
+				cwd=cwd,
+				help=help,
+				mutates=mutates,
+				paths=paths,
+				agent_format=agent_format,
 			)
 		case Sequential(tasks=tasks, name=None, matrix=matrix, env=env, cwd=cwd, help=help):
 			return Sequential(*tasks, name=key, matrix=matrix, env=env, cwd=cwd, help=help)

--- a/src/camas/main/tasks.py
+++ b/src/camas/main/tasks.py
@@ -17,7 +17,7 @@ else:  # pragma: no cover
 	import tomli as tomllib
 	from typing_extensions import assert_never
 
-from ..v0.config import Config
+from ..v0.config import Agent, Claude, Config
 from ..v0.effect import Effect
 from ..v0.task import Parallel, Sequential, Task, TaskNode
 from .expression import Ref, parse_task_value, resolve_refs
@@ -192,17 +192,25 @@ def name_scope_config(scope: Mapping[str, object]) -> Config | None:
 		if not name.startswith("_") and isinstance(val, Task | Sequential | Parallel)
 	}
 
-	def promote_field(node: TaskNode | None) -> TaskNode | None:
-		if node is None:
-			return None
+	def promote_required(node: TaskNode) -> TaskNode:
 		name = name_by_id.get(id(node))
 		return promoted[name] if name is not None else node
+
+	def promote_field(node: TaskNode | None) -> TaskNode | None:
+		return None if node is None else promote_required(node)
+
+	def promote_agent(agent: Agent | None) -> Agent | None:
+		if agent is None:
+			return None
+		return Claude(fix=promote_required(agent.fix), check=promote_field(agent.check))
 
 	return Config(
 		default_task=promote_field(config.default_task),
 		github_task=promote_field(config.github_task),
 		default_effects=config.default_effects,
 		default_github_effects=config.default_github_effects,
+		camas_dir=config.camas_dir,
+		agent=promote_agent(config.agent),
 	)
 
 

--- a/src/camas/main/tasks.py
+++ b/src/camas/main/tasks.py
@@ -47,8 +47,10 @@ def assign_key_name(node: TaskNode | Ref, key: str) -> TaskNode | Ref:
 	Ref(name='bar')
 	"""
 	match node:
-		case Task(cmd=cmd, name=None, env=env, cwd=cwd, help=help, mutates=mutates):
-			return Task(cmd=cmd, name=key, env=env, cwd=cwd, help=help, mutates=mutates)
+		case Task(cmd=cmd, name=None, env=env, cwd=cwd, help=help, mutates=mutates, paths=paths):
+			return Task(
+				cmd=cmd, name=key, env=env, cwd=cwd, help=help, mutates=mutates, paths=paths
+			)
 		case Sequential(tasks=tasks, name=None, matrix=matrix, env=env, cwd=cwd, help=help):
 			return Sequential(*tasks, name=key, matrix=matrix, env=env, cwd=cwd, help=help)
 		case Parallel(tasks=tasks, name=None, matrix=matrix, env=env, cwd=cwd, help=help):

--- a/src/camas/mcp/cli.py
+++ b/src/camas/mcp/cli.py
@@ -14,6 +14,9 @@ camas mcp — serve this project's tasks to AI agents over the Model Context Pro
 Usage:
   camas mcp [--rich]        run the MCP stdio server (an MCP client launches this)
   camas mcp init [--rich]   write this project's .mcp.json entry for the camas server
+  camas mcp gate [task]     run the gate once, headless — print the verdict as JSON, exit
+    [--paths P]… [--under N]  0 (continue) / 2 (block); scope to --paths or a PostToolBatch
+                              event on stdin (the command-hook entry; parallel + benchmark)
 
 Options:
   --rich        emit the 2025-11-25 tool fields (title, annotations, outputSchema) and
@@ -36,6 +39,15 @@ def main(argv: list[str]) -> None:
 		from .scaffold import write_mcp_json
 
 		sys.exit(write_mcp_json(argv[1:]))
+	if argv and argv[0] == "gate":
+		try:
+			from .serve import gate_cli
+		except ModuleNotFoundError as e:
+			if e.name != "mcp":
+				raise
+			print("camas mcp gate: requires feature camas[mcp]", file=sys.stderr)
+			sys.exit(2)
+		sys.exit(gate_cli(argv[1:]))
 	unexpected = [arg for arg in argv if arg != "--rich"]
 	if unexpected:
 		hint = " (did you mean 'camas mcp init'?)" if "--init" in unexpected else ""

--- a/src/camas/mcp/cli.py
+++ b/src/camas/mcp/cli.py
@@ -14,6 +14,8 @@ camas mcp — serve this project's tasks to AI agents over the Model Context Pro
 Usage:
   camas mcp [--rich]        run the MCP stdio server (an MCP client launches this)
   camas mcp init [--rich]   write this project's .mcp.json entry for the camas server
+  camas mcp fix [--paths P]… run the registered agent fix node (Config.agent.fix) over the
+                              changed paths — the FileChanged autofix; no-op if unregistered
   camas mcp gate [task]     run the gate once, headless — print the verdict as JSON, exit
     [--paths P]… [--under N]  0 (continue) / 2 (block); scope to --paths or a PostToolBatch
                               event on stdin (the command-hook entry; parallel + benchmark)
@@ -39,6 +41,10 @@ def main(argv: list[str]) -> None:
 		from .scaffold import write_mcp_json
 
 		sys.exit(write_mcp_json(argv[1:]))
+	if argv and argv[0] == "fix":
+		from ..main.dispatch import fix_cli
+
+		sys.exit(fix_cli(argv[1:]))
 	if argv and argv[0] == "gate":
 		try:
 			from .serve import gate_cli

--- a/src/camas/mcp/result.py
+++ b/src/camas/mcp/result.py
@@ -190,9 +190,37 @@ def report(task: Task, result: TaskResult, *, verbosity: Verbosity, tail: int) -
 	)
 
 
+def to_agent_envelope(task: Task, result: TaskResult, *, tail: int = 50) -> wire.AgentEnvelope:
+	comp = result.completion
+	match comp:
+		case Finished(output=output) | Stopped(output=output):
+			decoded = decode(output, tail)
+		case Skipped():
+			decoded = Decoded([], truncated=False)
+		case _:
+			assert_never(comp)
+	return wire.AgentEnvelope(
+		name=result.name,
+		exit_code=comp.returncode,
+		output_kind=task.agent_format.kind if task.agent_format is not None else "raw",
+		payload="\n".join(decoded.lines),
+		truncated=decoded.truncated,
+	)
+
+
+def agent_envelopes(node: TaskNode, result: RunResult) -> tuple[wire.AgentEnvelope, ...]:
+	"""The failing leaves of a finished run as AgentJSON envelopes, in DFS order."""
+	leaves = tuple(info.task for info in flatten_leaves(expand_matrix(node)))
+	return tuple(
+		to_agent_envelope(task, tr)
+		for task, tr in zip(leaves, result.results, strict=True)
+		if tr.completion.returncode != 0
+	)
+
+
 def to_gate_response(outcome: GateOutcome, budget: wire.BudgetReport | None) -> wire.GateResponse:
 	diagnostics = (
-		to_run_response(outcome.residual_node, outcome.residual_result, verbosity="failures")
+		agent_envelopes(outcome.residual_node, outcome.residual_result)
 		if outcome.residual_node is not None and outcome.residual_result is not None
 		else None
 	)

--- a/src/camas/mcp/result.py
+++ b/src/camas/mcp/result.py
@@ -9,6 +9,7 @@ import shlex
 import sys
 from typing import TYPE_CHECKING, Literal, NamedTuple
 
+from ..core.gate import decision_of
 from ..core.matrix import expand_matrix
 from ..core.render import strip_ansi
 from ..core.traversal import flatten_leaves
@@ -35,6 +36,7 @@ if TYPE_CHECKING:
 	from pathlib import Path
 
 	from ..core.completion import RunResult, TaskResult
+	from ..core.gate import GateOutcome
 	from ..main.state import TasksState
 	from ..v0.completion import Completion
 	from ..v0.task import Task, TaskNode
@@ -185,4 +187,18 @@ def report(task: Task, result: TaskResult, *, verbosity: Verbosity, tail: int) -
 		cwd=str(task.cwd) if task.cwd is not None else None,
 		completion=completion,
 		truncated=decoded.truncated,
+	)
+
+
+def to_gate_response(outcome: GateOutcome, budget: wire.BudgetReport | None) -> wire.GateResponse:
+	diagnostics = (
+		to_run_response(outcome.residual_node, outcome.residual_result, verbosity="failures")
+		if outcome.residual_node is not None and outcome.residual_result is not None
+		else None
+	)
+	return wire.GateResponse(
+		decision=decision_of(outcome.residual_class),
+		residual_class=outcome.residual_class,
+		diagnostics=diagnostics,
+		budget=budget,
 	)

--- a/src/camas/mcp/result.py
+++ b/src/camas/mcp/result.py
@@ -156,10 +156,12 @@ def command_of(task: Task) -> str:
 	return task.cmd if isinstance(task.cmd, str) else shlex.join(task.cmd)
 
 
-def decode(output: Sequence[bytes], tail: int) -> Decoded:
-	"""Decode merged stdout/stderr to ANSI-free lines, tail-truncated to ``tail``."""
+def decode(output: Sequence[bytes], tail: int | None) -> Decoded:
+	"""Decode merged stdout/stderr to ANSI-free lines, tail-truncated to ``tail`` (``None`` keeps
+	all lines — for a structured payload that must pass verbatim).
+	"""
 	lines = [strip_ansi(b.decode("utf-8", errors="replace")).rstrip("\n") for b in output]
-	if len(lines) > tail:
+	if tail is not None and len(lines) > tail:
 		return Decoded(lines[-tail:], truncated=True)
 	return Decoded(lines, truncated=False)
 
@@ -192,9 +194,11 @@ def report(task: Task, result: TaskResult, *, verbosity: Verbosity, tail: int) -
 
 def to_agent_envelope(task: Task, result: TaskResult, *, tail: int = 50) -> wire.AgentEnvelope:
 	comp = result.completion
+	kind = task.agent_format.kind if task.agent_format is not None else "raw"
+	cap = tail if kind == "raw" else None
 	match comp:
 		case Finished(output=output) | Stopped(output=output):
-			decoded = decode(output, tail)
+			decoded = decode(output, cap)
 		case Skipped():
 			decoded = Decoded([], truncated=False)
 		case _:
@@ -202,26 +206,32 @@ def to_agent_envelope(task: Task, result: TaskResult, *, tail: int = 50) -> wire
 	return wire.AgentEnvelope(
 		name=result.name,
 		exit_code=comp.returncode,
-		output_kind=task.agent_format.kind if task.agent_format is not None else "raw",
+		output_kind=kind,
 		payload="\n".join(decoded.lines),
 		truncated=decoded.truncated,
 	)
 
 
 def agent_envelopes(node: TaskNode, result: RunResult) -> tuple[wire.AgentEnvelope, ...]:
-	"""The failing leaves of a finished run as AgentJSON envelopes, in DFS order."""
+	"""The failing leaves of a finished run as AgentJSON envelopes, in DFS order. A ``Skipped``
+	leaf never ran, so it is not a failure to surface — only its blocker is.
+	"""
 	leaves = tuple(info.task for info in flatten_leaves(expand_matrix(node)))
 	return tuple(
 		to_agent_envelope(task, tr)
 		for task, tr in zip(leaves, result.results, strict=True)
-		if tr.completion.returncode != 0
+		if not isinstance(tr.completion, Skipped) and tr.completion.returncode != 0
 	)
 
 
-def to_gate_response(outcome: GateOutcome, budget: wire.BudgetReport | None) -> wire.GateResponse:
+def to_gate_response(
+	outcome: GateOutcome, budget: wire.BudgetReport | None, rerun: wire.GateRerun
+) -> wire.GateResponse:
 	diagnostics = (
-		agent_envelopes(outcome.residual_node, outcome.residual_result)
-		if outcome.residual_node is not None and outcome.residual_result is not None
+		agent_envelopes(outcome.node, outcome.result)
+		if outcome.residual_class == "needs_reasoning"
+		and outcome.node is not None
+		and outcome.result is not None
 		else None
 	)
 	return wire.GateResponse(
@@ -229,4 +239,5 @@ def to_gate_response(outcome: GateOutcome, budget: wire.BudgetReport | None) -> 
 		residual_class=outcome.residual_class,
 		diagnostics=diagnostics,
 		budget=budget,
+		rerun=rerun,
 	)

--- a/src/camas/mcp/serve.py
+++ b/src/camas/mcp/serve.py
@@ -5,9 +5,12 @@
 
 from __future__ import annotations
 
+import argparse
 import asyncio
+import json
 import os
 import re
+import shlex
 import sys
 import textwrap
 from contextlib import redirect_stdout
@@ -15,7 +18,7 @@ from dataclasses import dataclass, field
 from enum import Enum
 from importlib.metadata import version
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Final, NamedTuple
+from typing import TYPE_CHECKING, Any, Final, NamedTuple, cast
 
 from mcp import types
 from mcp.server.lowlevel import Server
@@ -28,6 +31,7 @@ from ..core.execution import run
 from ..core.gate import run_gate
 from ..core.matrix import override_matrix
 from ..core.render import render_tree_lines, strip_ansi
+from ..core.scope import to_changed
 from ..core.task import task_label
 from ..main.argv import apply_passthrough
 from ..main.format import format_load_error_hint
@@ -74,9 +78,7 @@ RUN_ANNOTATIONS: Final = types.ToolAnnotations(
 )
 CHECK_ANNOTATIONS: Final = types.ToolAnnotations(readOnlyHint=True, openWorldHint=False)
 DOCS_ANNOTATIONS: Final = types.ToolAnnotations(readOnlyHint=True, openWorldHint=False)
-GATE_ANNOTATIONS: Final = types.ToolAnnotations(
-	readOnlyHint=False, destructiveHint=True, idempotentHint=False, openWorldHint=True
-)
+GATE_ANNOTATIONS: Final = types.ToolAnnotations(readOnlyHint=True, openWorldHint=False)
 
 
 class Compat(NamedTuple):
@@ -348,13 +350,12 @@ def tools(task_names: tuple[str, ...], compat: Compat) -> Tools:
 			name=ToolName.GATE.value,
 			description=textwrap.dedent("""\
 				The SA-delegation gate, for a PostToolBatch hook: scope THIS project's checks to the
-				files just changed, apply the deterministic autofix (the mutates=True leaves —
-				formatters, import sorting) for free, run the remaining checks over the fixed
-				workspace, and return a binary verdict. residual_class is 'autofixed' (decision
-				'continue') when nothing survives the fixers, or 'needs_reasoning' (decision 'block')
-				when a check still fails — then diagnostics carries the failing leaves. Pass paths=[…]
-				(the changed files) to scope; omit to gate the whole task. under=<seconds> time-boxes
-				the checks; the autofix always runs. Mutates the workspace (it runs formatters).
+				files just changed, run them, and return a binary verdict. It does not mutate — the
+				deterministic fixers run separately on FileChanged (camas fix). residual_class is
+				'green' (decision 'continue') when the checks pass, or 'needs_reasoning' (decision
+				'block') when a check still fails — then diagnostics carries the failing leaves. Pass
+				paths=[…] (the changed files) to scope; omit to gate the whole check node. under=<seconds>
+				time-boxes the checks: leaves measured to exceed it are skipped, untimed leaves run.
 			""").strip(),
 			input_schema=wire.gate_input_schema(task_names),
 			output_model=wire.GateResponse,
@@ -520,19 +521,42 @@ def budget_source(
 	return default
 
 
+def gate_source(tasks: Mapping[str, TaskNode], config: Config | None, task: str | None) -> TaskNode:
+	"""The node the gate checks: the named task, else the agent's ``check`` node (or the default).
+
+	Raises:
+		ValueError: when ``task`` names no task, or no task is named and no check node
+			(``Config.agent.check`` or ``default_task``) exists.
+	"""
+	if task is not None:
+		if task not in tasks:
+			known = ", ".join(sorted(tasks)) or "none"
+			raise ValueError(f"no task named {task!r} (known: {known})")
+		return tasks[task]
+	check = config.gate_check(github=False) if config is not None else None
+	if check is None:
+		raise ValueError(
+			"no task given and no check node (Config.agent.check or default_task) to gate"
+		)
+	return check
+
+
 def to_budget_report(plan: BudgetPlan) -> wire.BudgetReport:
-	"""The wire ``BudgetReport`` for a plan: the selected leaves and the excluded ones."""
+	"""The wire ``BudgetReport`` for a plan: the leaves that run (fitting + unmeasured) and the
+	over-budget leaves that don't.
+	"""
 	return wire.BudgetReport(
 		budget_s=plan.budget_s,
-		selected=tuple(task_label(f.task) for f in plan.fits),
-		excluded=(
-			*(
-				wire.ExcludedLeaf(
-					name=task_label(o.task), reason="over_budget", estimated_s=o.estimated_s
-				)
-				for o in plan.over_budget
-			),
-			*(wire.ExcludedLeaf(name=task_label(u.task), reason="untimed") for u in plan.untimed),
+		selected=(
+			*(task_label(f.task) for f in plan.fits),
+			*(task_label(u.task) for u in plan.untimed),
+		),
+		unmeasured=tuple(task_label(u.task) for u in plan.untimed),
+		excluded=tuple(
+			wire.ExcludedLeaf(
+				name=task_label(o.task), reason="over_budget", estimated_s=o.estimated_s
+			)
+			for o in plan.over_budget
 		),
 	)
 
@@ -543,19 +567,18 @@ def attach_budget(resp: wire.RunResponse, report: wire.BudgetReport) -> wire.Run
 
 
 def budget_headline(report: wire.BudgetReport) -> str:
-	"""The load-bearing budget summary: leaves selected, and what was excluded and why."""
-	over = tuple(e for e in report.excluded if e.reason == "over_budget")
-	untimed = tuple(e for e in report.excluded if e.reason == "untimed")
+	"""The load-bearing budget summary: leaves running (and which are unmeasured), and which
+	were excluded as measured-over-budget.
+	"""
 	lines = [
-		f"Time budget {report.budget_s:.2f}s — selected {len(report.selected)} leaf(s), "
-		f"excluded {len(report.excluded)} ({len(over)} over budget, {len(untimed)} untimed)."
+		f"Time budget {report.budget_s:.2f}s — running {len(report.selected)} leaf(s) "
+		f"({len(report.unmeasured)} unmeasured), excluded {len(report.excluded)} over budget."
 	]
-	if over:
-		lines.append("  over budget: " + ", ".join(excluded_note(e) for e in over))
-	if untimed:
+	if report.excluded:
+		lines.append("  over budget: " + ", ".join(excluded_note(e) for e in report.excluded))
+	if report.unmeasured:
 		lines.append(
-			"  untimed (run the task normally once to record an estimate): "
-			+ ", ".join(excluded_note(e) for e in untimed)
+			"  unmeasured (running to record an estimate): " + ", ".join(report.unmeasured)
 		)
 	return "\n".join(lines)
 
@@ -859,25 +882,27 @@ async def gate_for(
 	except ValidationError as e:
 		return error_result(f"invalid camas_gate arguments:\n{e}")
 	try:
-		node = budget_source(tasks, config, req.task)
+		node = gate_source(tasks, config, req.task)
 	except ValueError as e:
 		return error_result(str(e))
+	changed = to_changed(req.paths, session.base)
 	outcome = await run_gate(
 		node,
-		tuple(req.paths),
+		changed,
 		under=req.under,
 		jobs=req.jobs,
 		timings=timings.load(session.camas_dir),
 	)
 	budget = to_budget_report(outcome.budget) if outcome.budget is not None else None
-	resp = to_gate_response(outcome, budget)
+	rerun = wire.GateRerun(task=req.task, paths=changed, under=req.under)
+	resp = to_gate_response(outcome, budget, rerun)
 	return success(gate_text(resp), resp, session.compat)
 
 
 def gate_text(resp: wire.GateResponse) -> str:
 	"""The load-bearing agent-facing summary for ``camas_gate`` — verdict, budget, residual."""
 	headline = (
-		"CONTINUE — autofixed; no residual needs reasoning"
+		"CONTINUE — checks green; no residual needs reasoning"
 		if resp.decision == "continue"
 		else "BLOCK — a residual needs reasoning"
 	)
@@ -889,4 +914,123 @@ def gate_text(resp: wire.GateResponse) -> str:
 		for env in resp.diagnostics:
 			lines.append(f"  {env.name} (exit {env.exit_code}, {env.output_kind})")
 			lines.extend(f"    {line}" for line in env.payload.splitlines())
+			if env.truncated:
+				lines.append("    … earlier output truncated")
+	if resp.decision == "block":
+		lines.extend(["", f"Re-gate this scope: {rerun_command(resp.rerun)}"])
 	return "\n".join(lines)
+
+
+def rerun_command(rerun: wire.GateRerun) -> str:
+	"""The ``camas mcp gate`` invocation that reproduces a verdict — the handle a higher tier
+	or the main agent re-issues against the same scope.
+	"""
+	task = (rerun.task,) if rerun.task is not None else ()
+	paths = tuple(arg for p in rerun.paths for arg in ("--paths", p))
+	under = ("--under", str(rerun.under)) if rerun.under is not None else ()
+	return shlex.join(("camas", "mcp", "gate", *task, *paths, *under))
+
+
+class GateArgs(NamedTuple):
+	"""Parsed ``camas mcp gate`` arguments."""
+
+	task: str | None
+	paths: tuple[str, ...]
+	under: float | None
+	jobs: int | None
+
+
+def parse_gate_args(argv: list[str]) -> GateArgs:
+	"""Parse ``camas mcp gate [task] [--paths P]… [--under N] [--jobs N]``."""
+	parser = argparse.ArgumentParser(
+		prog="camas mcp gate", description="Run the gate once, headless."
+	)
+	parser.add_argument(
+		"task", nargs="?", default=None, help="task to gate; omit for the check node"
+	)
+	parser.add_argument(
+		"--paths",
+		action="append",
+		default=[],
+		metavar="PATH",
+		help="changed path to scope to (repeatable)",
+	)
+	parser.add_argument(
+		"--under", type=float, default=None, metavar="SECONDS", help="wall-clock budget"
+	)
+	parser.add_argument("--jobs", type=int, default=None, metavar="N", help="max concurrent leaves")
+	ns = parser.parse_args(argv)
+	return GateArgs(task=ns.task, paths=tuple(ns.paths), under=ns.under, jobs=ns.jobs)
+
+
+def _event_get(obj: object, key: str) -> object:
+	"""``obj[key]`` for a parsed-JSON object, else ``None`` — narrows JSON's ``Any`` to ``object``."""
+	return cast("dict[str, object]", obj).get(key) if isinstance(obj, dict) else None
+
+
+def changed_from_stdin() -> tuple[str, ...]:
+	"""The edited files in a ``PostToolBatch`` event piped on stdin (the command-hook delivery),
+	de-duplicated in order; ``()`` when stdin is a tty, empty, or not such an event.
+	"""
+	if sys.stdin.isatty():
+		return ()
+	raw = sys.stdin.read().strip()
+	if not raw:
+		return ()
+	try:
+		event: object = json.loads(raw)
+	except json.JSONDecodeError:
+		return ()
+	calls = _event_get(event, "tool_calls")
+	if not isinstance(calls, list):
+		return ()
+	edited = (
+		_event_get(_event_get(call, "tool_input"), key)
+		for call in cast("list[object]", calls)
+		for key in ("file_path", "path", "notebook_path")
+	)
+	return tuple(dict.fromkeys(f for f in edited if isinstance(f, str)))
+
+
+def gate_cli(argv: list[str]) -> int:
+	"""Run the gate once, headless: scope this project's checks to the changed paths (``--paths``,
+	else the files in a ``PostToolBatch`` event on stdin), print the ``GateResponse`` as JSON to
+	stdout, and exit ``0`` (continue) / ``2`` (block) — on a block the agent-facing summary goes
+	to stderr. The process-isolated, machine-readable gate entry: the ``PostToolBatch`` command
+	hook, parallel fixers, and the benchmark all drive it.
+	"""
+	args = parse_gate_args(argv)
+	base = project_base()
+	state = resolve_project_quiet(base)
+	match state:
+		case LoadErr(source=source, exception=exception):
+			print(f"camas mcp gate: cannot load {source}: {exception}", file=sys.stderr)
+			return 2
+		case LoadOk(tasks=tasks, config=config):
+			return run_gate_cli(args, base, tasks, config)
+		case _:
+			assert_never(state)
+
+
+def run_gate_cli(
+	args: GateArgs, base: Path, tasks: Mapping[str, TaskNode], config: Config | None
+) -> int:
+	"""Resolve the check node, run the gate over the changed paths, emit the verdict."""
+	try:
+		node = gate_source(tasks, config, args.task)
+	except ValueError as e:
+		print(f"camas mcp gate: {e}", file=sys.stderr)
+		return 2
+	changed = to_changed(args.paths or changed_from_stdin(), base)
+	camas_dir = (config if config is not None else Config()).camas_path(base)
+	outcome = asyncio.run(
+		run_gate(node, changed, under=args.under, jobs=args.jobs, timings=timings.load(camas_dir))
+	)
+	budget = to_budget_report(outcome.budget) if outcome.budget is not None else None
+	rerun = wire.GateRerun(task=args.task, paths=changed, under=args.under)
+	resp = to_gate_response(outcome, budget, rerun)
+	print(resp.model_dump_json(indent=2))
+	if resp.decision == "block":
+		print(gate_text(resp), file=sys.stderr)
+		return 2
+	return 0

--- a/src/camas/mcp/serve.py
+++ b/src/camas/mcp/serve.py
@@ -886,6 +886,7 @@ def gate_text(resp: wire.GateResponse) -> str:
 		lines.extend(["", budget_headline(resp.budget)])
 	if resp.diagnostics is not None:
 		lines.extend(["", "Residual (failing checks):"])
-		for leaf in resp.diagnostics.leaves:
-			lines.extend(leaf_lines(leaf, None))
+		for env in resp.diagnostics:
+			lines.append(f"  {env.name} (exit {env.exit_code}, {env.output_kind})")
+			lines.extend(f"    {line}" for line in env.payload.splitlines())
 	return "\n".join(lines)

--- a/src/camas/mcp/serve.py
+++ b/src/camas/mcp/serve.py
@@ -25,6 +25,7 @@ from pydantic import AnyUrl, BaseModel, ValidationError
 from ..core import timings
 from ..core.budget import plan_under
 from ..core.execution import run
+from ..core.gate import run_gate
 from ..core.matrix import override_matrix
 from ..core.render import render_tree_lines, strip_ansi
 from ..core.task import task_label
@@ -37,7 +38,7 @@ from ..v0.config import Config
 from . import wire
 from .catalog import to_list_response
 from .docs import to_docs_response
-from .result import to_check_response, to_plan_response, to_run_response
+from .result import to_check_response, to_gate_response, to_plan_response, to_run_response
 
 if sys.version_info >= (3, 11):
 	from typing import assert_never
@@ -59,6 +60,7 @@ class ToolName(Enum):
 	RUN = "camas_run"
 	CHECK = "camas_check"
 	DOCS = "camas_docs"
+	GATE = "camas_gate"
 
 
 NO_ARGS_SCHEMA: Final[dict[str, Any]] = {
@@ -72,6 +74,9 @@ RUN_ANNOTATIONS: Final = types.ToolAnnotations(
 )
 CHECK_ANNOTATIONS: Final = types.ToolAnnotations(readOnlyHint=True, openWorldHint=False)
 DOCS_ANNOTATIONS: Final = types.ToolAnnotations(readOnlyHint=True, openWorldHint=False)
+GATE_ANNOTATIONS: Final = types.ToolAnnotations(
+	readOnlyHint=False, destructiveHint=True, idempotentHint=False, openWorldHint=True
+)
 
 
 class Compat(NamedTuple):
@@ -201,6 +206,8 @@ async def call(session: Session, name: str, arguments: dict[str, Any]) -> types.
 			return check_call(session)
 		case ToolName.DOCS:
 			return docs_call(session)
+		case ToolName.GATE:
+			return await gate_call(session, arguments)
 		case _:
 			known = ", ".join(repr(tool.value) for tool in ToolName)
 			return error_result(f"unknown tool {name!r}; expected one of: {known}")
@@ -223,6 +230,7 @@ class Tools(NamedTuple):
 	execution: types.Tool
 	validation: types.Tool
 	docs: types.Tool
+	gate: types.Tool
 
 
 def tool_def(
@@ -334,6 +342,24 @@ def tools(task_names: tuple[str, ...], compat: Compat) -> Tools:
 			output_model=wire.DocsResponse,
 			title="How to author camas tasks",
 			annotations=DOCS_ANNOTATIONS,
+		),
+		gate=tool_def(
+			compat,
+			name=ToolName.GATE.value,
+			description=textwrap.dedent("""\
+				The SA-delegation gate, for a PostToolBatch hook: scope THIS project's checks to the
+				files just changed, apply the deterministic autofix (the mutates=True leaves —
+				formatters, import sorting) for free, run the remaining checks over the fixed
+				workspace, and return a binary verdict. residual_class is 'autofixed' (decision
+				'continue') when nothing survives the fixers, or 'needs_reasoning' (decision 'block')
+				when a check still fails — then diagnostics carries the failing leaves. Pass paths=[…]
+				(the changed files) to scope; omit to gate the whole task. under=<seconds> time-boxes
+				the checks; the autofix always runs. Mutates the workspace (it runs formatters).
+			""").strip(),
+			input_schema=wire.gate_input_schema(task_names),
+			output_model=wire.GateResponse,
+			title="SA-delegation gate",
+			annotations=GATE_ANNOTATIONS,
 		),
 	)
 
@@ -699,7 +725,11 @@ def docs_text(resp: wire.DocsResponse) -> str:
 
 def success(
 	text: str,
-	model: wire.ListResponse | wire.RunResponse | wire.CheckResponse | wire.DocsResponse,
+	model: wire.ListResponse
+	| wire.RunResponse
+	| wire.CheckResponse
+	| wire.DocsResponse
+	| wire.GateResponse,
 	compat: Compat,
 	*,
 	links: tuple[types.ResourceLink, ...] = (),
@@ -804,3 +834,58 @@ def slug(name: str) -> str:
 
 def decode_log(output: Sequence[bytes]) -> str:
 	return strip_ansi("".join(chunk.decode("utf-8", errors="replace") for chunk in output))
+
+
+async def gate_call(session: Session, arguments: dict[str, Any]) -> types.CallToolResult:
+	"""Handle ``camas_gate``: scope to the changed paths, autofix, run the checks, classify."""
+	match session.project:
+		case LoadErr(source=source, exception=exception):
+			return error_result(format_load_error_hint(source, exception))
+		case LoadOk(tasks=tasks, config=config):
+			return await gate_for(session, tasks, config, arguments)
+		case _:
+			assert_never(session.project)
+
+
+async def gate_for(
+	session: Session,
+	tasks: Mapping[str, TaskNode],
+	config: Config | None,
+	arguments: dict[str, Any],
+) -> types.CallToolResult:
+	"""Validate, resolve the gated task, run the gate, and build the verdict."""
+	try:
+		req = wire.GateRequest.model_validate(arguments)
+	except ValidationError as e:
+		return error_result(f"invalid camas_gate arguments:\n{e}")
+	try:
+		node = budget_source(tasks, config, req.task)
+	except ValueError as e:
+		return error_result(str(e))
+	outcome = await run_gate(
+		node,
+		tuple(req.paths),
+		under=req.under,
+		jobs=req.jobs,
+		timings=timings.load(session.camas_dir),
+	)
+	budget = to_budget_report(outcome.budget) if outcome.budget is not None else None
+	resp = to_gate_response(outcome, budget)
+	return success(gate_text(resp), resp, session.compat)
+
+
+def gate_text(resp: wire.GateResponse) -> str:
+	"""The load-bearing agent-facing summary for ``camas_gate`` — verdict, budget, residual."""
+	headline = (
+		"CONTINUE — autofixed; no residual needs reasoning"
+		if resp.decision == "continue"
+		else "BLOCK — a residual needs reasoning"
+	)
+	lines: list[str] = [f"camas_gate: {headline} (residual_class={resp.residual_class})"]
+	if resp.budget is not None:
+		lines.extend(["", budget_headline(resp.budget)])
+	if resp.diagnostics is not None:
+		lines.extend(["", "Residual (failing checks):"])
+		for leaf in resp.diagnostics.leaves:
+			lines.extend(leaf_lines(leaf, None))
+	return "\n".join(lines)

--- a/src/camas/mcp/wire.py
+++ b/src/camas/mcp/wire.py
@@ -240,14 +240,26 @@ class GateRequest(BaseModel):
 	)
 
 
+class AgentEnvelope(BaseModel):
+	"""One task's agent-facing result: its exit code and the tool's output tagged by the
+	standard it is in (``output_kind``) and passed through verbatim — camas never parses it.
+	"""
+
+	name: str
+	exit_code: int
+	output_kind: Literal["sarif", "rdjson", "lsp", "junit", "tap", "raw"]
+	payload: str
+	truncated: bool = False
+
+
 class GateResponse(BaseModel):
 	"""The SA-delegation gate's verdict: how to route the batch, and the residual that decided it."""
 
 	decision: Literal["continue", "block"]
 	"""``block`` when a residual needs reasoning (a PostToolBatch hook surfaces it), else ``continue``."""
 	residual_class: Literal["autofixed", "needs_reasoning"]
-	diagnostics: RunResponse | None = None
-	"""The failing residual run (failures-only); null when the autofix left nothing to reason about."""
+	diagnostics: tuple[AgentEnvelope, ...] | None = None
+	"""The failing leaves as AgentJSON envelopes (failures-only); null when nothing survived the fixers."""
 	budget: BudgetReport | None = None
 	"""How ``under`` partitioned the checks, when a budget was given."""
 

--- a/src/camas/mcp/wire.py
+++ b/src/camas/mcp/wire.py
@@ -211,3 +211,58 @@ def run_input_schema(task_names: tuple[str, ...]) -> dict[str, Any]:
 		if branch.get("type") == "string":
 			branch["enum"] = list(task_names)
 	return schema
+
+
+class GateRequest(BaseModel):
+	"""Arguments to ``camas_gate``."""
+
+	model_config = ConfigDict(extra="forbid")
+
+	paths: list[str] = Field(
+		default_factory=list,
+		description="Changed paths to scope the gate to — a FileChanged/PostToolBatch hook's "
+		"edited files. Empty gates the whole task; each leaf's {paths} is injected with the "
+		"files it covers and leaves covering nothing are dropped.",
+	)
+	task: str | None = Field(
+		default=None,
+		description="Task to gate — one of the names from camas_list. Omit to gate the project's "
+		"default task.",
+	)
+	under: float | None = Field(
+		default=None,
+		gt=0,
+		description="Wall-clock budget in seconds for the checks (the read-only leaves); the "
+		"deterministic autofix always runs. Untimed leaves are skipped.",
+	)
+	jobs: int | None = Field(
+		default=None, ge=1, description="Max concurrent leaf subprocesses; null = unbounded."
+	)
+
+
+class GateResponse(BaseModel):
+	"""The SA-delegation gate's verdict: how to route the batch, and the residual that decided it."""
+
+	decision: Literal["continue", "block"]
+	"""``block`` when a residual needs reasoning (a PostToolBatch hook surfaces it), else ``continue``."""
+	residual_class: Literal["autofixed", "needs_reasoning"]
+	diagnostics: RunResponse | None = None
+	"""The failing residual run (failures-only); null when the autofix left nothing to reason about."""
+	budget: BudgetReport | None = None
+	"""How ``under`` partitioned the checks, when a budget was given."""
+
+
+def gate_input_schema(task_names: tuple[str, ...]) -> dict[str, Any]:
+	"""``GateRequest``'s JSON Schema with the live task-name ``enum`` spliced into ``task``.
+
+	>>> schema = gate_input_schema(("lint", "test"))
+	>>> next(b["enum"] for b in schema["properties"]["task"]["anyOf"] if b.get("type") == "string")
+	['lint', 'test']
+	>>> schema["additionalProperties"]
+	False
+	"""
+	schema: dict[str, Any] = GateRequest.model_json_schema()
+	for branch in schema["properties"]["task"]["anyOf"]:
+		if branch.get("type") == "string":
+			branch["enum"] = list(task_names)
+	return schema

--- a/src/camas/mcp/wire.py
+++ b/src/camas/mcp/wire.py
@@ -54,10 +54,10 @@ class LeafReport(BaseModel):
 
 
 class ExcludedLeaf(BaseModel):
-	"""A leaf a time budget did not run, and why."""
+	"""A leaf a time budget did not run — measured to exceed the budget."""
 
 	name: str
-	reason: Literal["over_budget", "untimed"]
+	reason: Literal["over_budget"]
 	estimated_s: float | None = None
 	"""The leaf's observed estimate; null when it has never been timed."""
 
@@ -67,7 +67,11 @@ class BudgetReport(BaseModel):
 
 	budget_s: float
 	selected: tuple[str, ...]
-	"""Leaves whose estimate fit the budget — the ones that were scheduled to run."""
+	"""Leaves that run: those whose estimate fit the budget, plus any unmeasured ones."""
+	unmeasured: tuple[str, ...] = ()
+	"""The selected leaves with no prior estimate — run to record one, since skipping them
+	would keep them forever unmeasured.
+	"""
 	excluded: tuple[ExcludedLeaf, ...]
 
 
@@ -232,8 +236,8 @@ class GateRequest(BaseModel):
 	under: float | None = Field(
 		default=None,
 		gt=0,
-		description="Wall-clock budget in seconds for the checks (the read-only leaves); the "
-		"deterministic autofix always runs. Untimed leaves are skipped.",
+		description="Wall-clock budget in seconds for the checks: leaves measured to exceed it are "
+		"skipped; untimed leaves run (and get measured). The gate never mutates.",
 	)
 	jobs: int | None = Field(
 		default=None, ge=1, description="Max concurrent leaf subprocesses; null = unbounded."
@@ -252,16 +256,31 @@ class AgentEnvelope(BaseModel):
 	truncated: bool = False
 
 
+class GateRerun(BaseModel):
+	"""The exact gate invocation that produced a verdict — a self-describing handle a higher
+	fixer tier (or the main agent) re-issues to re-gate the same scope.
+	"""
+
+	task: str | None = None
+	"""The named task gated, or null for the project's check node."""
+	paths: tuple[str, ...] = ()
+	"""The (repo-relative) changed paths the run was scoped to; empty means the whole check node."""
+	under: float | None = None
+	"""The wall-clock budget applied, if any."""
+
+
 class GateResponse(BaseModel):
 	"""The SA-delegation gate's verdict: how to route the batch, and the residual that decided it."""
 
 	decision: Literal["continue", "block"]
 	"""``block`` when a residual needs reasoning (a PostToolBatch hook surfaces it), else ``continue``."""
-	residual_class: Literal["autofixed", "needs_reasoning"]
+	residual_class: Literal["green", "needs_reasoning"]
 	diagnostics: tuple[AgentEnvelope, ...] | None = None
-	"""The failing leaves as AgentJSON envelopes (failures-only); null when nothing survived the fixers."""
+	"""The failing leaves as AgentJSON envelopes (failures-only); null when the checks pass."""
 	budget: BudgetReport | None = None
 	"""How ``under`` partitioned the checks, when a budget was given."""
+	rerun: GateRerun
+	"""The invocation that produced this verdict — the handle to re-gate the same scope."""
 
 
 def gate_input_schema(task_names: tuple[str, ...]) -> dict[str, Any]:

--- a/src/camas/v0/__init__.py
+++ b/src/camas/v0/__init__.py
@@ -6,6 +6,7 @@ import typing
 
 from .config import Config as Config
 from .effect import Effect as Effect
+from .task import AgentFormat as AgentFormat
 from .task import Parallel as Parallel
 from .task import Sequential as Sequential
 from .task import Task as Task

--- a/src/camas/v0/__init__.py
+++ b/src/camas/v0/__init__.py
@@ -4,6 +4,8 @@
 
 import typing
 
+from .config import Agent as Agent
+from .config import Claude as Claude
 from .config import Config as Config
 from .effect import Effect as Effect
 from .task import AgentFormat as AgentFormat

--- a/src/camas/v0/config.py
+++ b/src/camas/v0/config.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Final, NamedTuple
+from typing import TYPE_CHECKING, Final, NamedTuple, TypeAlias
 
 if TYPE_CHECKING:
 	from pathlib import Path
@@ -17,6 +17,24 @@ if TYPE_CHECKING:
 
 DEFAULT_CAMAS_DIR: Final = ".camas"
 """The default project subdirectory for camas's run logs and timing cache."""
+
+
+class Claude(NamedTuple):
+	"""The Claude Code agent integration: the explicitly declared fix and check nodes."""
+
+	fix: TaskNode
+	"""The deterministic, behavior-preserving autofix node the FileChanged hook runs (scoped,
+	zero tokens). Declared, not derived from ``mutates`` — a mutating leaf may be codegen or a
+	compiler, which is not a fixer.
+	"""
+	check: TaskNode | None = None
+	"""The node the gate checks; ``None`` defers to the default (or github) task, scoped by
+	``--paths`` and time-boxed by ``--under``.
+	"""
+
+
+Agent: TypeAlias = Claude
+"""The agent integration backend — a union as backends land (e.g. an ``InternalModel`` CI backend)."""
 
 
 class Config(NamedTuple):
@@ -32,6 +50,8 @@ class Config(NamedTuple):
 	"""``None`` defers to the engine's default; ``()`` is an explicit no-effects."""
 	camas_dir: str = DEFAULT_CAMAS_DIR
 	"""Project subdirectory for run logs and the timing cache; delete it to opt out."""
+	agent: Agent | None = None
+	"""The agent integration (the gate's fix and check nodes); ``None`` when unconfigured."""
 
 	def camas_path(self, base: Path) -> Path:
 		"""The resolved camas directory under ``base``."""
@@ -50,3 +70,13 @@ class Config(NamedTuple):
 		if github:
 			return self.default_github_effects
 		return self.default_effects
+
+	def gate_check(self, *, github: bool) -> TaskNode | None:
+		"""The node the gate checks: the agent's explicit ``check`` override, else the bare task."""
+		if self.agent is not None and self.agent.check is not None:
+			return self.agent.check
+		return self.bare_task(github=github)
+
+	def gate_fix(self) -> TaskNode | None:
+		"""The declared deterministic autofix node, or ``None`` when no agent is configured."""
+		return self.agent.fix if self.agent is not None else None

--- a/src/camas/v0/task.py
+++ b/src/camas/v0/task.py
@@ -11,7 +11,12 @@ from types import MappingProxyType
 from typing import TYPE_CHECKING, TypeAlias
 
 if TYPE_CHECKING:
-	from collections.abc import Mapping
+	from collections.abc import Callable, Mapping
+
+
+PathScope: TypeAlias = "Callable[[tuple[str, ...]], tuple[str, ...]]"
+"""Maps the changed paths to the args injected at ``{paths}``: called with ``()`` for a
+full run (return the default target), with the changed set otherwise (``()`` → skip)."""
 
 
 _EMPTY_ENV: Mapping[str, str] = MappingProxyType({})
@@ -37,6 +42,10 @@ class Task:
 	The ``--under`` budget scheduler runs such leaves sequentially, before the
 	read-only group, so they never race a checker over the same files.
 
+	``paths`` opts a leaf into ``{paths}`` substitution (:mod:`camas.core.scope`): a
+	directory-prefix string (``"."``) or a ``(changed) -> tuple[str, ...]`` callable that
+	maps the changed files into the command; ``None`` leaves the command untouched.
+
 	>>> Task("echo hi")
 	Task(cmd='echo hi', name=None, env={}, cwd=None)
 	>>> Task(("ruff", "check", "."), name="lint")
@@ -49,6 +58,8 @@ class Task:
 	'Lint all sources'
 	>>> Task("ruff format .", mutates=True)
 	Task(cmd='ruff format .', name=None, env={}, cwd=None, mutates=True)
+	>>> Task("ruff format {paths}", mutates=True, paths=".")
+	Task(cmd='ruff format {paths}', name=None, env={}, cwd=None, mutates=True, paths='.')
 	>>> hash(Task("a")) == hash(Task("a"))
 	True
 	>>> {Task("a", env={"K": "v"}), Task("a", env={"K": "v"})} == {Task("a", env={"K": "v"})}
@@ -61,6 +72,7 @@ class Task:
 	cwd: Path | None
 	help: str | None
 	mutates: bool
+	paths: str | PathScope | None
 
 	def __init__(
 		self,
@@ -70,6 +82,7 @@ class Task:
 		cwd: str | Path | None = None,
 		help: str | None = None,
 		mutates: bool = False,
+		paths: str | PathScope | None = None,
 	) -> None:
 		put = object.__setattr__
 		put(self, "cmd", cmd)
@@ -78,6 +91,7 @@ class Task:
 		put(self, "cwd", Path(cwd) if isinstance(cwd, str) else cwd)
 		put(self, "help", help)
 		put(self, "mutates", mutates)
+		put(self, "paths", paths)
 
 	def __hash__(self) -> int:
 		return hash(
@@ -88,6 +102,7 @@ class Task:
 				self.cwd,
 				self.help,
 				self.mutates,
+				self.paths,
 			)
 		)
 
@@ -99,6 +114,7 @@ class Task:
 			f"cwd={self.cwd!r}",
 			*([f"help={self.help!r}"] if self.help is not None else []),
 			*(["mutates=True"] if self.mutates else []),
+			*([f"paths={self.paths!r}"] if self.paths is not None else []),
 		)
 		return f"Task({', '.join(parts)})"
 

--- a/src/camas/v0/task.py
+++ b/src/camas/v0/task.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from pathlib import Path
 from types import MappingProxyType
-from typing import TYPE_CHECKING, TypeAlias
+from typing import TYPE_CHECKING, Literal, NamedTuple, TypeAlias
 
 if TYPE_CHECKING:
 	from collections.abc import Callable, Mapping
@@ -17,6 +17,24 @@ if TYPE_CHECKING:
 PathScope: TypeAlias = "Callable[[tuple[str, ...]], tuple[str, ...]]"
 """Maps the changed paths to the args injected at ``{paths}``: called with ``()`` for a
 full run (return the default target), with the changed set otherwise (``()`` → skip)."""
+
+
+OutputKind: TypeAlias = Literal["sarif", "rdjson", "lsp", "junit", "tap", "raw"]
+"""The standard a leaf's command emits its diagnostics in — the agent-facing format camas
+tags and passes through verbatim, never parsing. ``raw`` (the default) is plain text."""
+
+
+class AgentFormat(NamedTuple):
+	"""A leaf's agent-only structured-output variant: ``args`` (a producing flag the user
+	supplies — camas never infers it) appended to the command, and the ``kind`` of diagnostics
+	it makes the tool emit. Applied only when an agent runs; a human run leaves the command as-is.
+
+	>>> AgentFormat("--output-format sarif", "sarif")
+	AgentFormat(args='--output-format sarif', kind='sarif')
+	"""
+
+	args: str
+	kind: OutputKind
 
 
 _EMPTY_ENV: Mapping[str, str] = MappingProxyType({})
@@ -46,6 +64,10 @@ class Task:
 	directory-prefix string (``"."``) or a ``(changed) -> tuple[str, ...]`` callable that
 	maps the changed files into the command; ``None`` leaves the command untouched.
 
+	``agent_format`` is the agent-only structured-output variant (:class:`AgentFormat`): the gate
+	appends its ``args`` and tags the diagnostics ``kind``; a human run leaves the command as-is.
+	A bare ``(args, kind)`` tuple is coerced to an :class:`AgentFormat`.
+
 	>>> Task("echo hi")
 	Task(cmd='echo hi', name=None, env={}, cwd=None)
 	>>> Task(("ruff", "check", "."), name="lint")
@@ -60,6 +82,10 @@ class Task:
 	Task(cmd='ruff format .', name=None, env={}, cwd=None, mutates=True)
 	>>> Task("ruff format {paths}", mutates=True, paths=".")
 	Task(cmd='ruff format {paths}', name=None, env={}, cwd=None, mutates=True, paths='.')
+	>>> Task("ruff check .", agent_format=AgentFormat("--output-format sarif", "sarif"))
+	Task(cmd='ruff check .', name=None, env={}, cwd=None, agent_format=AgentFormat(args='--output-format sarif', kind='sarif'))
+	>>> Task("ruff check .", agent_format=("--output-format sarif", "sarif")).agent_format
+	AgentFormat(args='--output-format sarif', kind='sarif')
 	>>> hash(Task("a")) == hash(Task("a"))
 	True
 	>>> {Task("a", env={"K": "v"}), Task("a", env={"K": "v"})} == {Task("a", env={"K": "v"})}
@@ -73,6 +99,7 @@ class Task:
 	help: str | None
 	mutates: bool
 	paths: str | PathScope | None
+	agent_format: AgentFormat | None
 
 	def __init__(
 		self,
@@ -83,6 +110,7 @@ class Task:
 		help: str | None = None,
 		mutates: bool = False,
 		paths: str | PathScope | None = None,
+		agent_format: AgentFormat | tuple[str, OutputKind] | None = None,
 	) -> None:
 		put = object.__setattr__
 		put(self, "cmd", cmd)
@@ -92,6 +120,13 @@ class Task:
 		put(self, "help", help)
 		put(self, "mutates", mutates)
 		put(self, "paths", paths)
+		put(
+			self,
+			"agent_format",
+			agent_format
+			if agent_format is None or isinstance(agent_format, AgentFormat)
+			else AgentFormat(*agent_format),
+		)
 
 	def __hash__(self) -> int:
 		return hash(
@@ -103,6 +138,7 @@ class Task:
 				self.help,
 				self.mutates,
 				self.paths,
+				self.agent_format,
 			)
 		)
 
@@ -115,6 +151,7 @@ class Task:
 			*([f"help={self.help!r}"] if self.help is not None else []),
 			*(["mutates=True"] if self.mutates else []),
 			*([f"paths={self.paths!r}"] if self.paths is not None else []),
+			*([f"agent_format={self.agent_format!r}"] if self.agent_format is not None else []),
 		)
 		return f"Task({', '.join(parts)})"
 

--- a/tasks.py
+++ b/tasks.py
@@ -4,10 +4,10 @@ from pathlib import Path
 
 from camas import Config, Parallel, Sequential, Task
 
-format = Task("uv run ruff format .", mutates=True)
-format_check = Task("uv run ruff format --check .")
-lint = Task("uv run ruff check .")
-lint_fix = Task("uv run ruff check --fix .", mutates=True)
+format = Task("uv run ruff format {paths}", mutates=True, paths=".")
+format_check = Task("uv run ruff format --check {paths}", paths=".")
+lint = Task("uv run ruff check {paths}", paths=".")
+lint_fix = Task("uv run ruff check --fix {paths}", mutates=True, paths=".")
 fix = Sequential(lint_fix, format)
 mypy = Task("uv run mypy .")
 ty = Task("uv run ty check")

--- a/tests/core/test_budget.py
+++ b/tests/core/test_budget.py
@@ -51,10 +51,10 @@ def test_plan_under_partitions_and_schedules() -> None:
 	assert plan.untimed == ()
 
 
-def test_plan_under_excludes_untimed() -> None:
+def test_plan_under_runs_untimed() -> None:
 	a, b = Task("a", name="a"), Task("b", name="b")
 	plan = plan_under(Parallel(a, b), 5.0, {"a": TaskTiming(0.1, 1)})
-	assert plan.node == Parallel(a)
+	assert plan.node == Parallel(a, b)
 	assert [u.task for u in plan.untimed] == [b]
 
 

--- a/tests/core/test_gate.py
+++ b/tests/core/test_gate.py
@@ -3,76 +3,47 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 from camas import AgentFormat, Parallel, Sequential, Task
-from camas.core.gate import (
-	GateOutcome,
-	decision_of,
-	filter_by_mutates,
-	run_gate,
-	with_agent_format,
-)
+from camas.core.gate import GateOutcome, decision_of, run_gate, with_agent_format
 from camas.core.task import task_label
 from camas.core.timings import TaskTiming
 
-if TYPE_CHECKING:
-	from camas.v0.task import TaskNode
-
 CHECK_PASS = Task(("python", "-c", "pass"), name="check")
 CHECK_FAIL = Task(("python", "-c", "raise SystemExit(1)"), name="check")
-FIX = Task(("python", "-c", "pass"), name="fmt", mutates=True)
-FIX_FAIL = Task(("python", "-c", "raise SystemExit(1)"), name="fmt", mutates=True)
 
 
-def test_filter_by_mutates_keeps_matching_group() -> None:
-	assert filter_by_mutates(Sequential(FIX, CHECK_PASS), mutates=True) == Sequential(FIX)
+def test_decision_of() -> None:
+	assert decision_of("green") == "continue"
+	assert decision_of("needs_reasoning") == "block"
 
 
-def test_filter_by_mutates_prunes_emptied_group() -> None:
-	assert filter_by_mutates(Parallel(CHECK_PASS), mutates=True) is None
-
-
-async def test_gate_all_pass_is_autofixed() -> None:
-	out = await run_gate(Parallel(FIX, CHECK_PASS), ())
-	assert out.residual_class == "autofixed"
-	assert out.residual_result is None
+async def test_gate_pass_is_green() -> None:
+	out = await run_gate(Parallel(CHECK_PASS), ())
+	assert out.residual_class == "green"
+	assert out.node is not None
+	assert out.result is not None
+	assert out.result.returncode == 0
 	assert decision_of(out.residual_class) == "continue"
 
 
 async def test_gate_failing_check_needs_reasoning() -> None:
-	out = await run_gate(Parallel(FIX, CHECK_FAIL), ())
+	out = await run_gate(Parallel(CHECK_FAIL), ())
 	assert out.residual_class == "needs_reasoning"
-	assert out.residual_result is not None
-	assert out.residual_result.returncode != 0
+	assert out.result is not None
+	assert out.result.returncode != 0
 	assert decision_of(out.residual_class) == "block"
 
 
-async def test_gate_failing_autofix_needs_reasoning() -> None:
-	out = await run_gate(Parallel(FIX_FAIL, CHECK_PASS), ())
-	assert out.residual_class == "needs_reasoning"
-	assert out.residual_node is not None
+async def test_gate_scoped_to_nothing_is_green_noop() -> None:
+	node = Task(("cargo", "check", "{paths}"), name="rust", paths="rust")
+	assert await run_gate(node, ("src/app.py",)) == GateOutcome("green", None, None, None)
 
 
-async def test_gate_no_mutating_leaves_runs_checks() -> None:
-	out = await run_gate(Parallel(CHECK_PASS), ())
-	assert out.residual_class == "autofixed"
-
-
-async def test_gate_only_mutating_leaves_autofixed() -> None:
-	out = await run_gate(Parallel(FIX), ())
-	assert out.residual_class == "autofixed"
-	assert out.residual_result is None
-
-
-async def test_gate_scoped_to_nothing_is_noop() -> None:
-	node: TaskNode = Task(("cargo", "check", "{paths}"), name="rust", paths="rust")
-	assert await run_gate(node, ("src/app.py",)) == GateOutcome("autofixed", None, None, None)
-
-
-async def test_gate_budget_excludes_untimed_checks() -> None:
+async def test_gate_runs_untimed_check_under_budget() -> None:
+	# untimed leaves RUN (and get measured), never skipped — the check executes and passes
 	out = await run_gate(Parallel(CHECK_PASS), (), under=1.0, timings={})
-	assert out.residual_class == "autofixed"
+	assert out.residual_class == "green"
+	assert out.result is not None
 	assert out.budget is not None
 
 
@@ -80,8 +51,19 @@ async def test_gate_budget_runs_fitting_check() -> None:
 	out = await run_gate(
 		Parallel(CHECK_PASS), (), under=1.0, timings={task_label(CHECK_PASS): TaskTiming(0.01, 1)}
 	)
-	assert out.residual_class == "autofixed"
+	assert out.residual_class == "green"
+	assert out.result is not None
+
+
+async def test_gate_budget_skips_over_budget_check() -> None:
+	# a leaf measured to exceed the budget is skipped; nothing runs → green (deliberate time-box)
+	out = await run_gate(
+		Parallel(CHECK_PASS), (), under=0.001, timings={task_label(CHECK_PASS): TaskTiming(99.0, 1)}
+	)
+	assert out.residual_class == "green"
+	assert out.result is None
 	assert out.budget is not None
+	assert out.budget.node is None
 
 
 def test_with_agent_format_appends_to_tuple_command() -> None:

--- a/tests/core/test_gate.py
+++ b/tests/core/test_gate.py
@@ -5,8 +5,14 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from camas import Parallel, Sequential, Task
-from camas.core.gate import GateOutcome, decision_of, filter_by_mutates, run_gate
+from camas import AgentFormat, Parallel, Sequential, Task
+from camas.core.gate import (
+	GateOutcome,
+	decision_of,
+	filter_by_mutates,
+	run_gate,
+	with_agent_format,
+)
 from camas.core.task import task_label
 from camas.core.timings import TaskTiming
 
@@ -76,3 +82,32 @@ async def test_gate_budget_runs_fitting_check() -> None:
 	)
 	assert out.residual_class == "autofixed"
 	assert out.budget is not None
+
+
+def test_with_agent_format_appends_to_tuple_command() -> None:
+	t = Task(("ruff", "check", "."), agent_format=AgentFormat("--output-format sarif", "sarif"))
+	result = with_agent_format(t)
+	assert isinstance(result, Task)
+	assert result.cmd == ("ruff", "check", ".", "--output-format", "sarif")
+
+
+def test_with_agent_format_recurses_groups_and_leaves_plain_untouched() -> None:
+	fmt = Task("ruff check .", name="lint", agent_format=AgentFormat("--out sarif", "sarif"))
+	plain = Task("mypy .", name="types")
+	out = with_agent_format(Sequential(fmt, plain))
+	assert isinstance(out, Sequential)
+	first, second = out.tasks
+	assert isinstance(first, Task)
+	assert isinstance(second, Task)
+	assert first.cmd == "ruff check . --out sarif"
+	assert second.cmd == "mypy ."
+
+
+async def test_gate_tags_residual_with_agent_format_kind() -> None:
+	chk = Task(
+		("python", "-c", "import sys; sys.exit(1)"),
+		name="lint",
+		agent_format=AgentFormat("--quiet", "sarif"),
+	)
+	out = await run_gate(Parallel(chk), ())
+	assert out.residual_class == "needs_reasoning"

--- a/tests/core/test_gate.py
+++ b/tests/core/test_gate.py
@@ -1,0 +1,78 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2026 JP Hutchins
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from camas import Parallel, Sequential, Task
+from camas.core.gate import GateOutcome, decision_of, filter_by_mutates, run_gate
+from camas.core.task import task_label
+from camas.core.timings import TaskTiming
+
+if TYPE_CHECKING:
+	from camas.v0.task import TaskNode
+
+CHECK_PASS = Task(("python", "-c", "pass"), name="check")
+CHECK_FAIL = Task(("python", "-c", "raise SystemExit(1)"), name="check")
+FIX = Task(("python", "-c", "pass"), name="fmt", mutates=True)
+FIX_FAIL = Task(("python", "-c", "raise SystemExit(1)"), name="fmt", mutates=True)
+
+
+def test_filter_by_mutates_keeps_matching_group() -> None:
+	assert filter_by_mutates(Sequential(FIX, CHECK_PASS), mutates=True) == Sequential(FIX)
+
+
+def test_filter_by_mutates_prunes_emptied_group() -> None:
+	assert filter_by_mutates(Parallel(CHECK_PASS), mutates=True) is None
+
+
+async def test_gate_all_pass_is_autofixed() -> None:
+	out = await run_gate(Parallel(FIX, CHECK_PASS), ())
+	assert out.residual_class == "autofixed"
+	assert out.residual_result is None
+	assert decision_of(out.residual_class) == "continue"
+
+
+async def test_gate_failing_check_needs_reasoning() -> None:
+	out = await run_gate(Parallel(FIX, CHECK_FAIL), ())
+	assert out.residual_class == "needs_reasoning"
+	assert out.residual_result is not None
+	assert out.residual_result.returncode != 0
+	assert decision_of(out.residual_class) == "block"
+
+
+async def test_gate_failing_autofix_needs_reasoning() -> None:
+	out = await run_gate(Parallel(FIX_FAIL, CHECK_PASS), ())
+	assert out.residual_class == "needs_reasoning"
+	assert out.residual_node is not None
+
+
+async def test_gate_no_mutating_leaves_runs_checks() -> None:
+	out = await run_gate(Parallel(CHECK_PASS), ())
+	assert out.residual_class == "autofixed"
+
+
+async def test_gate_only_mutating_leaves_autofixed() -> None:
+	out = await run_gate(Parallel(FIX), ())
+	assert out.residual_class == "autofixed"
+	assert out.residual_result is None
+
+
+async def test_gate_scoped_to_nothing_is_noop() -> None:
+	node: TaskNode = Task(("cargo", "check", "{paths}"), name="rust", paths="rust")
+	assert await run_gate(node, ("src/app.py",)) == GateOutcome("autofixed", None, None, None)
+
+
+async def test_gate_budget_excludes_untimed_checks() -> None:
+	out = await run_gate(Parallel(CHECK_PASS), (), under=1.0, timings={})
+	assert out.residual_class == "autofixed"
+	assert out.budget is not None
+
+
+async def test_gate_budget_runs_fitting_check() -> None:
+	out = await run_gate(
+		Parallel(CHECK_PASS), (), under=1.0, timings={task_label(CHECK_PASS): TaskTiming(0.01, 1)}
+	)
+	assert out.residual_class == "autofixed"
+	assert out.budget is not None

--- a/tests/core/test_scope.py
+++ b/tests/core/test_scope.py
@@ -1,0 +1,97 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2026 JP Hutchins
+
+from __future__ import annotations
+
+from camas import Parallel, Sequential, Task
+from camas.core.scope import scope_to_changed, with_default_paths
+
+
+def _cmd(node: object) -> str | tuple[str, ...]:
+	assert isinstance(node, Task)
+	return node.cmd
+
+
+def test_prefix_string_full_run_uses_prefix() -> None:
+	fmt = Task("ruff format {paths}", mutates=True, paths=".")
+	assert with_default_paths(fmt) == Task("ruff format .", mutates=True, paths=".")
+
+
+def test_prefix_string_scoped_run_injects_changed_files() -> None:
+	fmt = Task("ruff format {paths}", name="fmt", paths=".")
+	assert scope_to_changed(fmt, ("src/a.py", "src/b.py")) == Task(
+		"ruff format src/a.py src/b.py", name="fmt", paths="."
+	)
+
+
+def test_prefix_string_filters_to_its_subtree() -> None:
+	tsc = Task("tsc {paths}", name="tsc", paths="frontend")
+	assert scope_to_changed(tsc, ("frontend/app.ts", "backend/api.py")) == Task(
+		"tsc frontend/app.ts", name="tsc", paths="frontend"
+	)
+
+
+def test_prefix_string_skips_when_nothing_under_it() -> None:
+	tsc = Task("tsc {paths}", paths="frontend")
+	assert scope_to_changed(tsc, ("backend/api.py",)) is None
+
+
+def test_none_paths_leaf_is_untouched_and_always_runs() -> None:
+	mypy = Task("mypy .", name="mypy")
+	assert scope_to_changed(mypy, ("anything.py",)) == mypy
+	assert with_default_paths(mypy) == mypy
+
+
+def test_prefix_without_placeholder_is_run_whole_or_skip() -> None:
+	"""A leaf with ``paths`` but no ``{paths}`` runs its command unchanged when its prefix
+	changed (the selection a file-list-averse tool needs), and is skipped otherwise."""
+	mypy = Task("mypy .", name="mypy", paths="src")
+	assert scope_to_changed(mypy, ("src/app.py",)) == mypy
+	assert scope_to_changed(mypy, ("docs/readme.md",)) is None
+
+
+def test_callable_paths_full_control() -> None:
+	def py_only(changed: tuple[str, ...]) -> tuple[str, ...]:
+		return (".",) if not changed else tuple(c for c in changed if c.endswith(".py"))
+
+	lint = Task("ruff check {paths}", name="lint", paths=py_only)
+	assert _cmd(scope_to_changed(lint, ("a.py", "b.rs"))) == "ruff check a.py"
+	assert scope_to_changed(lint, ("b.rs",)) is None
+	assert _cmd(with_default_paths(lint)) == "ruff check ."
+
+
+def test_tuple_command_splices_path_tokens() -> None:
+	fmt = Task(("ruff", "format", "{paths}"), name="fmt", paths=".")
+	assert _cmd(scope_to_changed(fmt, ("a.py", "b.py"))) == ("ruff", "format", "a.py", "b.py")
+
+
+def test_full_run_default_never_prunes() -> None:
+	tree = Parallel(Task("ruff {paths}", paths="src"), Task("mypy ."))
+	assert with_default_paths(tree) == Parallel(Task("ruff src", paths="src"), Task("mypy ."))
+
+
+def test_group_pruned_when_all_leaves_skip() -> None:
+	tree = Parallel(Task("a {paths}", paths="a"), Task("b {paths}", paths="b"))
+	assert scope_to_changed(tree, ("c/x.py",)) is None
+
+
+def test_nested_structure_preserved_through_pruning() -> None:
+	lint = Task("ruff check {paths}", name="lint", paths=".")
+	tsc = Task("tsc {paths}", name="tsc", paths="frontend")
+	mypy = Task("mypy .", name="mypy")
+	tree = Sequential(Parallel(lint, tsc), mypy, name="ci")
+	assert scope_to_changed(tree, ("src/app.py",)) == Sequential(
+		Parallel(Task("ruff check src/app.py", name="lint", paths=".")),
+		mypy,
+		name="ci",
+	)
+
+
+def test_backslash_changed_paths_are_normalized() -> None:
+	fmt = Task("ruff format {paths}", name="fmt", paths=".")
+	assert _cmd(scope_to_changed(fmt, ("src\\a.py",))) == "ruff format src/a.py"
+
+
+def test_paths_with_spaces_are_shell_quoted_in_string_command() -> None:
+	fmt = Task("ruff format {paths}", name="fmt", paths=".")
+	assert _cmd(scope_to_changed(fmt, ("a b.py",))) == "ruff format 'a b.py'"

--- a/tests/main/test_dispatch.py
+++ b/tests/main/test_dispatch.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Any
 
 import pytest
 
-from camas import Config, Parallel, Sequential, Task
+from camas import Claude, Config, Parallel, Sequential, Task
 from camas.core import timings
 from camas.core.color import WHITE
 from camas.core.completion import RunResult
@@ -209,12 +209,15 @@ def test_interrupted_run_prints_banner_and_exits_130(
 	assert "Ctrl-C (3) received - exiting" in capsys.readouterr().out
 
 
-def test_dispatch_under_no_timings_runs_nothing(capsys: pytest.CaptureFixture[str]) -> None:
+def test_dispatch_under_no_timings_runs_untimed(capsys: pytest.CaptureFixture[str]) -> None:
+	noop = ("python", "-c", "pass")
 	with pytest.raises(SystemExit, match="0"):
-		dispatch(_state({"check": Parallel(Task("a"), Task("b"))}), ["check", "--under", "1s"])
+		dispatch(
+			_state({"check": Parallel(Task(noop, name="a"), Task(noop, name="b"))}),
+			["check", "--under", "1s"],
+		)
 	out = capsys.readouterr().out
-	assert "2 untimed" in out
-	assert "Nothing fits the budget" in out
+	assert "2 unmeasured" in out
 
 
 def test_dispatch_under_rejects_passthrough(capsys: pytest.CaptureFixture[str]) -> None:
@@ -250,7 +253,7 @@ def test_run_under_dry_run_shows_plan(tmp_path: Path, capsys: pytest.CaptureFixt
 	)
 	assert code == 0
 	out = capsys.readouterr().out
-	assert "selected 2 leaf(s)" in out
+	assert "running 2 leaf(s)" in out
 	assert "over budget: slow ~9.00s" in out
 
 
@@ -264,9 +267,30 @@ def test_run_under_executes_selected(tmp_path: Path, capsys: pytest.CaptureFixtu
 		source, 1.0, camas_dir=camas, effects=(), jobs=None, dry_run=False, passthrough=()
 	)
 	assert code == 0
-	assert (
-		"untimed (run the task normally once to record an estimate): b" in capsys.readouterr().out
+	assert "unmeasured (running to record an estimate): b" in capsys.readouterr().out
+
+
+def test_run_under_all_over_budget_runs_nothing(
+	tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+	camas = _camas_with_timings(tmp_path, [("slow", 9.0)])
+	code = run_under(
+		Parallel(Task("echo slow", name="slow")),
+		0.5,
+		camas_dir=camas,
+		effects=(),
+		jobs=None,
+		dry_run=False,
+		passthrough=(),
 	)
+	assert code == 0
+	assert "All leaves exceed the budget — nothing to run." in capsys.readouterr().out
+
+
+def test_dispatch_fix_resolves_agent_fix() -> None:
+	fix = Task(("python", "-c", "pass"), name="fix", mutates=True)
+	with pytest.raises(SystemExit, match="0"):
+		dispatch(_state({}, Config(agent=Claude(fix=fix))), ["fix", "--effects", "()"])
 
 
 def test_dispatch_paths_scopes_to_changed(capsys: pytest.CaptureFixture[str]) -> None:

--- a/tests/main/test_dispatch.py
+++ b/tests/main/test_dispatch.py
@@ -7,11 +7,11 @@ from typing import TYPE_CHECKING, Any
 
 import pytest
 
-from camas import Claude, Config, Parallel, Sequential, Task
+from camas import Config, Parallel, Sequential, Task
 from camas.core import timings
 from camas.core.color import WHITE
 from camas.core.completion import RunResult
-from camas.main.dispatch import dispatch, print_interrupt_banner, run_under
+from camas.main.dispatch import dispatch, fix_cli, print_interrupt_banner, run_under
 from camas.main.state import LoadOk
 
 if TYPE_CHECKING:
@@ -287,10 +287,53 @@ def test_run_under_all_over_budget_runs_nothing(
 	assert "All leaves exceed the budget — nothing to run." in capsys.readouterr().out
 
 
-def test_dispatch_fix_resolves_agent_fix() -> None:
-	fix = Task(("python", "-c", "pass"), name="fix", mutates=True)
-	with pytest.raises(SystemExit, match="0"):
-		dispatch(_state({}, Config(agent=Claude(fix=fix))), ["fix", "--effects", "()"])
+_TIDY = (
+	"from camas import Claude, Config, Task\n"
+	'tidy = Task(("python", "-c", "import pathlib; pathlib.Path(\'fixed.txt\').write_text(\'done\')"),'
+	' name="tidy", mutates=True, paths={scope!r})\n'
+	"_ = Config(agent=Claude(fix=tidy))\n"
+)
+
+
+def test_fix_cli_runs_registered_agent_fix(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+	# the registered node is named "tidy", not "fix" — fix_cli resolves Config.agent.fix by reference
+	(tmp_path / "tasks.py").write_text(_TIDY.format(scope="."))
+	monkeypatch.chdir(tmp_path)
+	assert fix_cli(["--paths", "x.py"]) == 0
+	assert (tmp_path / "fixed.txt").read_text() == "done"
+
+
+def test_fix_cli_no_paths_runs_the_full_node(
+	tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+	(tmp_path / "tasks.py").write_text(_TIDY.format(scope="."))
+	monkeypatch.chdir(tmp_path)
+	assert fix_cli([]) == 0
+	assert (tmp_path / "fixed.txt").read_text() == "done"
+
+
+def test_fix_cli_noop_without_config(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+	monkeypatch.chdir(tmp_path)
+	assert fix_cli(["--paths", "x.py"]) == 0
+
+
+def test_fix_cli_noop_without_registered_fix(
+	tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+	(tmp_path / "tasks.py").write_text(
+		"from camas import Config, Task\n_ = Config(default_task=Task('echo hi'))\n"
+	)
+	monkeypatch.chdir(tmp_path)
+	assert fix_cli(["--paths", "x.py"]) == 0
+
+
+def test_fix_cli_noop_when_scope_covers_nothing(
+	tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+	(tmp_path / "tasks.py").write_text(_TIDY.format(scope="src"))
+	monkeypatch.chdir(tmp_path)
+	assert fix_cli(["--paths", "docs/readme.md"]) == 0
+	assert not (tmp_path / "fixed.txt").exists()
 
 
 def test_dispatch_paths_scopes_to_changed(capsys: pytest.CaptureFixture[str]) -> None:

--- a/tests/main/test_dispatch.py
+++ b/tests/main/test_dispatch.py
@@ -267,3 +267,26 @@ def test_run_under_executes_selected(tmp_path: Path, capsys: pytest.CaptureFixtu
 	assert (
 		"untimed (run the task normally once to record an estimate): b" in capsys.readouterr().out
 	)
+
+
+def test_dispatch_paths_scopes_to_changed(capsys: pytest.CaptureFixture[str]) -> None:
+	task = Task("ruff check {paths}", name="lint", paths=".")
+	with pytest.raises(SystemExit, match="0"):
+		dispatch(_state({"lint": task}), ["--dry-run", "lint", "--paths", "src/app.py"])
+	assert "ruff check src/app.py" in capsys.readouterr().out
+
+
+def test_dispatch_paths_no_match_skips(capsys: pytest.CaptureFixture[str]) -> None:
+	task = Task("cargo check {paths}", name="rust", paths="rust")
+	with pytest.raises(SystemExit, match="0"):
+		dispatch(_state({"rust": task}), ["rust", "--paths", "src/app.py"])
+	out = capsys.readouterr().out
+	assert "src/app.py" in out
+	assert "nothing to run" in out
+
+
+def test_dispatch_paths_empty_skips(capsys: pytest.CaptureFixture[str]) -> None:
+	task = Task("ruff check {paths}", name="lint", paths=".")
+	with pytest.raises(SystemExit, match="0"):
+		dispatch(_state({"lint": task}), ["lint", "--paths", ""])
+	assert "(no paths given)" in capsys.readouterr().out

--- a/tests/main/test_expression.py
+++ b/tests/main/test_expression.py
@@ -9,8 +9,14 @@ from pathlib import Path
 import pytest
 
 from camas import AgentFormat, Parallel, Sequential, Task
-from camas.main.expression import parse_expression
+from camas.main.expression import parse_expression, to_expression
 from camas.v0.task import Group
+
+
+def test_to_expression_marks_callable_paths() -> None:
+	"""A callable scope has no source, so it renders as a non-parseable marker (preview only)."""
+	rendered = to_expression(Task("ruff {paths}", paths=lambda c: c))
+	assert rendered == 'Task("ruff {paths}", paths=<callable>)'
 
 
 @pytest.mark.parametrize(

--- a/tests/main/test_expression.py
+++ b/tests/main/test_expression.py
@@ -19,6 +19,22 @@ def test_to_expression_marks_callable_paths() -> None:
 	assert rendered == 'Task("ruff {paths}", paths=<callable>)'
 
 
+def test_to_expression_round_trips_every_field() -> None:
+	"""The full round-trip #85 asked for: every constructor field survives to_expression →
+	parse_expression (a callable scope is the sole non-round-trippable, by design)."""
+	task = Task(
+		"ruff check {paths}",
+		name="lint",
+		env={"CI": "1"},
+		cwd="rust",
+		help="lint it",
+		mutates=True,
+		paths=".",
+		agent_format=AgentFormat("--out sarif", "sarif"),
+	)
+	assert parse_expression(to_expression(task)) == task
+
+
 @pytest.mark.parametrize(
 	("expr", "expected"),
 	[

--- a/tests/main/test_expression.py
+++ b/tests/main/test_expression.py
@@ -153,6 +153,7 @@ def test_eval_node_threads_every_public_constructor_kwarg() -> None:
 		"help": ("help='h'", "help", "h"),
 		"mutates": ("mutates=True", "mutates", True),
 		"matrix": ("matrix={'X': ('1',)}", "matrix", {"X": ("1",)}),
+		"paths": ("paths='.'", "paths", "."),
 	}
 	for cls, prefix, variadic in (
 		(Task, "Task('c', ", "cmd"),

--- a/tests/main/test_expression.py
+++ b/tests/main/test_expression.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 import pytest
 
-from camas import Parallel, Sequential, Task
+from camas import AgentFormat, Parallel, Sequential, Task
 from camas.main.expression import parse_expression
 from camas.v0.task import Group
 
@@ -154,6 +154,11 @@ def test_eval_node_threads_every_public_constructor_kwarg() -> None:
 		"mutates": ("mutates=True", "mutates", True),
 		"matrix": ("matrix={'X': ('1',)}", "matrix", {"X": ("1",)}),
 		"paths": ("paths='.'", "paths", "."),
+		"agent_format": (
+			"agent_format=AgentFormat('--x', 'sarif')",
+			"agent_format",
+			AgentFormat("--x", "sarif"),
+		),
 	}
 	for cls, prefix, variadic in (
 		(Task, "Task('c', ", "cmd"),
@@ -166,6 +171,27 @@ def test_eval_node_threads_every_public_constructor_kwarg() -> None:
 
 
 # Parser-side fluent syntax: strings inside literals and the README one-liner.
+
+
+def test_eval_node_rejects_unknown_agent_format_kind() -> None:
+	with pytest.raises(SystemExit, match="2"):
+		parse_expression("Task('c', agent_format=AgentFormat('--x', 'bogus'))")
+
+
+def test_eval_node_rejects_incomplete_agent_format() -> None:
+	with pytest.raises(SystemExit, match="2"):
+		parse_expression("Task('c', agent_format=AgentFormat('--x'))")
+
+
+def test_eval_node_rejects_non_agent_format_value() -> None:
+	with pytest.raises(SystemExit, match="2"):
+		parse_expression("Task('c', agent_format='sarif')")
+
+
+def test_eval_node_accepts_agent_format_tuple_shorthand() -> None:
+	node = parse_expression("Task('c', agent_format=('--x', 'sarif'))")
+	assert isinstance(node, Task)
+	assert node.agent_format == AgentFormat("--x", "sarif")
 
 
 def test_parse_top_level_tuple_with_bare_strings() -> None:

--- a/tests/main/test_init.py
+++ b/tests/main/test_init.py
@@ -75,13 +75,13 @@ def test_dispatch_init_under_load_err(tmp_path: Path, monkeypatch: pytest.Monkey
 def test_starter_loads_with_config_default(tmp_path: Path) -> None:
 	write_starter_tasks_py(tmp_path)
 	loaded = load_tasks_from_py(tmp_path / "tasks.py")
-	assert set(loaded.tasks) == {"hello", "greet", "ci", "fix"}
+	assert set(loaded.tasks) == {"hello", "greet", "ci", "autofix"}
 	assert loaded.scope_effects == {}
 	assert loaded.config is not None
 	assert loaded.config.default_task == loaded.tasks["ci"]
 	assert isinstance(loaded.config.default_task, Sequential)
 	assert loaded.config.agent is not None
-	assert loaded.config.agent.fix == loaded.tasks["fix"]
+	assert loaded.config.agent.fix == loaded.tasks["autofix"]
 
 
 def test_starter_runs_to_completion(tmp_path: Path) -> None:

--- a/tests/main/test_init.py
+++ b/tests/main/test_init.py
@@ -75,11 +75,13 @@ def test_dispatch_init_under_load_err(tmp_path: Path, monkeypatch: pytest.Monkey
 def test_starter_loads_with_config_default(tmp_path: Path) -> None:
 	write_starter_tasks_py(tmp_path)
 	loaded = load_tasks_from_py(tmp_path / "tasks.py")
-	assert set(loaded.tasks) == {"hello", "greet", "ci"}
+	assert set(loaded.tasks) == {"hello", "greet", "ci", "fix"}
 	assert loaded.scope_effects == {}
 	assert loaded.config is not None
 	assert loaded.config.default_task == loaded.tasks["ci"]
 	assert isinstance(loaded.config.default_task, Sequential)
+	assert loaded.config.agent is not None
+	assert loaded.config.agent.fix == loaded.tasks["fix"]
 
 
 def test_starter_runs_to_completion(tmp_path: Path) -> None:

--- a/tests/mcp/test_catalog.py
+++ b/tests/mcp/test_catalog.py
@@ -59,8 +59,8 @@ def test_expand_inlines_every_matrix_leaf() -> None:
 	resp = to_list_response({"m": node}, None, expand=True)
 	assert resp.tasks[0].matrix_axes == {"PY": ["3.13", "3.14"]}
 	assert resp.tasks[0].command_preview == (
-		'Parallel(Task("test 3.13", name="test 3.13 [PY=3.13]"), '
-		'Task("test 3.14", name="test 3.14 [PY=3.14]"), name="m")'
+		"Parallel(Task(\"test 3.13\", name=\"test 3.13 [PY=3.13]\", env={'PY': '3.13'}), "
+		'Task("test 3.14", name="test 3.14 [PY=3.14]", env={\'PY\': \'3.14\'}), name="m")'
 	)
 
 

--- a/tests/mcp/test_gate_cli.py
+++ b/tests/mcp/test_gate_cli.py
@@ -1,0 +1,171 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2026 JP Hutchins
+
+"""The headless ``camas mcp gate`` CLI verb: arg parsing, the PostToolBatch-event stdin
+delivery, the verdict JSON + exit code, and the residual-to-stderr block path."""
+
+from __future__ import annotations
+
+import io
+import json
+from typing import TYPE_CHECKING
+
+from camas.mcp import serve, wire
+
+if TYPE_CHECKING:
+	from pathlib import Path
+
+	import pytest
+
+_TASKS = (
+	"from camas import Config, Task\n\ncheck = Task(\n"
+	'\t("python", "-c", "import pathlib, sys; sys.exit({marker!r} in pathlib.Path(\'sample.py\').read_text())"),\n'
+	'\tname="check",\n)\n_ = Config(default_task=check)\n'
+)
+
+
+def _chdir_project(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, marker: str) -> None:
+	monkeypatch.delenv("CLAUDE_PROJECT_DIR", raising=False)
+	monkeypatch.chdir(tmp_path)
+	(tmp_path / "tasks.py").write_text(_TASKS.format(marker=marker))
+
+
+def test_parse_gate_args() -> None:
+	args = serve.parse_gate_args(
+		["check", "--paths", "a.py", "--paths", "b.py", "--under", "5", "--jobs", "2"]
+	)
+	assert args == serve.GateArgs(task="check", paths=("a.py", "b.py"), under=5.0, jobs=2)
+
+
+def test_parse_gate_args_defaults() -> None:
+	assert serve.parse_gate_args([]) == serve.GateArgs(task=None, paths=(), under=None, jobs=None)
+
+
+def test_rerun_command() -> None:
+	rerun = wire.GateRerun(task="check", paths=("a.py", "b.py"), under=5.0)
+	assert (
+		serve.rerun_command(rerun) == "camas mcp gate check --paths a.py --paths b.py --under 5.0"
+	)
+	assert serve.rerun_command(wire.GateRerun()) == "camas mcp gate"
+
+
+def test_gate_cli_green(
+	tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+	_chdir_project(tmp_path, monkeypatch, "FIXME")
+	(tmp_path / "sample.py").write_text("ok = 1\n")
+	assert serve.gate_cli(["--paths", "sample.py"]) == 0
+	out = json.loads(capsys.readouterr().out)
+	assert out["decision"] == "continue"
+	assert out["residual_class"] == "green"
+	assert out["rerun"]["paths"] == ["sample.py"]
+
+
+def test_gate_cli_block_prints_residual_to_stderr(
+	tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+	_chdir_project(tmp_path, monkeypatch, "FIXME")
+	(tmp_path / "sample.py").write_text("FIXME\n")
+	assert serve.gate_cli(["--paths", "sample.py"]) == 2
+	captured = capsys.readouterr()
+	assert json.loads(captured.out)["decision"] == "block"
+	assert "Re-gate this scope: camas mcp gate" in captured.err
+
+
+def test_gate_cli_reads_stdin_event(
+	tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+	_chdir_project(tmp_path, monkeypatch, "FIXME")
+	(tmp_path / "sample.py").write_text("ok\n")
+	event = json.dumps({"tool_calls": [{"tool_input": {"file_path": str(tmp_path / "sample.py")}}]})
+	monkeypatch.setattr("sys.stdin", io.StringIO(event))
+	assert serve.gate_cli([]) == 0
+	assert json.loads(capsys.readouterr().out)["rerun"]["paths"] == ["sample.py"]
+
+
+def test_gate_cli_no_check_node_errors(
+	tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+	monkeypatch.delenv("CLAUDE_PROJECT_DIR", raising=False)
+	monkeypatch.chdir(tmp_path)
+	assert serve.gate_cli([]) == 2
+	assert "no check node" in capsys.readouterr().err
+
+
+def test_gate_cli_load_error(
+	tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+	monkeypatch.delenv("CLAUDE_PROJECT_DIR", raising=False)
+	monkeypatch.chdir(tmp_path)
+	(tmp_path / "tasks.py").write_text("raise ValueError('boom')\n")
+	assert serve.gate_cli([]) == 2
+	assert "cannot load" in capsys.readouterr().err
+
+
+def test_gate_cli_unknown_task_errors(
+	tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+	_chdir_project(tmp_path, monkeypatch, "FIXME")
+	assert serve.gate_cli(["nope"]) == 2
+	assert "no task named 'nope'" in capsys.readouterr().err
+
+
+def test_gate_text_marks_truncated_diagnostic() -> None:
+	resp = wire.GateResponse(
+		decision="block",
+		residual_class="needs_reasoning",
+		diagnostics=(
+			wire.AgentEnvelope(
+				name="lint", exit_code=1, output_kind="raw", payload="x", truncated=True
+			),
+		),
+		rerun=wire.GateRerun(),
+	)
+	text = serve.gate_text(resp)
+	assert "… earlier output truncated" in text
+	assert "Re-gate this scope" in text
+
+
+def test_changed_from_stdin_extracts_edited_files(monkeypatch: pytest.MonkeyPatch) -> None:
+	event = json.dumps(
+		{
+			"tool_calls": [
+				{"tool_input": {"file_path": "a.py"}},
+				{"tool_input": {"file_path": "a.py"}},
+				{"tool_input": {"path": "b.py"}},
+				{"tool_input": {}},
+				"not-a-dict",
+			]
+		}
+	)
+	monkeypatch.setattr("sys.stdin", io.StringIO(event))
+	assert serve.changed_from_stdin() == ("a.py", "b.py")
+
+
+def test_changed_from_stdin_tty_is_empty(monkeypatch: pytest.MonkeyPatch) -> None:
+	class _Tty(io.StringIO):
+		def isatty(self) -> bool:
+			return True
+
+	monkeypatch.setattr("sys.stdin", _Tty("x"))
+	assert serve.changed_from_stdin() == ()
+
+
+def test_changed_from_stdin_empty(monkeypatch: pytest.MonkeyPatch) -> None:
+	monkeypatch.setattr("sys.stdin", io.StringIO("  "))
+	assert serve.changed_from_stdin() == ()
+
+
+def test_changed_from_stdin_bad_json(monkeypatch: pytest.MonkeyPatch) -> None:
+	monkeypatch.setattr("sys.stdin", io.StringIO("not json"))
+	assert serve.changed_from_stdin() == ()
+
+
+def test_changed_from_stdin_dict_without_tool_calls(monkeypatch: pytest.MonkeyPatch) -> None:
+	monkeypatch.setattr("sys.stdin", io.StringIO(json.dumps({"foo": "bar"})))
+	assert serve.changed_from_stdin() == ()
+
+
+def test_changed_from_stdin_non_dict_event(monkeypatch: pytest.MonkeyPatch) -> None:
+	monkeypatch.setattr("sys.stdin", io.StringIO(json.dumps([1, 2])))
+	assert serve.changed_from_stdin() == ()

--- a/tests/mcp/test_lazy_import.py
+++ b/tests/mcp/test_lazy_import.py
@@ -102,6 +102,23 @@ def test_entrypoint_mcp_gate_branch_invokes_gate_cli(monkeypatch: pytest.MonkeyP
 	assert calls == [["--paths", "a.py"]]
 
 
+def test_entrypoint_mcp_fix_branch_invokes_fix_cli(monkeypatch: pytest.MonkeyPatch) -> None:
+	from camas.main import dispatch, main
+
+	calls: list[list[str]] = []
+
+	def fake_fix_cli(argv: list[str]) -> int:
+		calls.append(argv)
+		return 0
+
+	monkeypatch.setattr(dispatch, "fix_cli", fake_fix_cli)
+	monkeypatch.setattr("sys.argv", ["camas", "mcp", "fix", "--paths", "a.py"])
+	with pytest.raises(SystemExit) as exc:
+		main()
+	assert exc.value.code == 0
+	assert calls == [["--paths", "a.py"]]
+
+
 def test_entrypoint_mcp_gate_branch_missing_extra_exits_with_feature_hint(
 	monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:

--- a/tests/mcp/test_lazy_import.py
+++ b/tests/mcp/test_lazy_import.py
@@ -84,6 +84,79 @@ def test_entrypoint_mcp_branch_reraises_non_mcp_missing_import(
 	assert exc.value.name == "pydantic"
 
 
+def test_entrypoint_mcp_gate_branch_invokes_gate_cli(monkeypatch: pytest.MonkeyPatch) -> None:
+	from camas.main import main
+	from camas.mcp import serve
+
+	calls: list[list[str]] = []
+
+	def fake_gate_cli(argv: list[str]) -> int:
+		calls.append(argv)
+		return 0
+
+	monkeypatch.setattr(serve, "gate_cli", fake_gate_cli)
+	monkeypatch.setattr("sys.argv", ["camas", "mcp", "gate", "--paths", "a.py"])
+	with pytest.raises(SystemExit) as exc:
+		main()
+	assert exc.value.code == 0
+	assert calls == [["--paths", "a.py"]]
+
+
+def test_entrypoint_mcp_gate_branch_missing_extra_exits_with_feature_hint(
+	monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+	from camas.main import main
+
+	original_import = __import__
+
+	def fake_import(
+		name: str,
+		globals: Mapping[str, object] | None = None,
+		locals: Mapping[str, object] | None = None,
+		fromlist: Sequence[str] = (),
+		level: int = 0,
+	) -> object:
+		if name == "mcp":
+			raise ModuleNotFoundError("No module named 'mcp'", name="mcp")
+		return original_import(name, globals, locals, fromlist, level)
+
+	for module in ("camas.mcp.serve", "mcp"):
+		monkeypatch.delitem(sys.modules, module, raising=False)
+	monkeypatch.setattr("sys.argv", ["camas", "mcp", "gate"])
+	with patch("builtins.__import__", fake_import), pytest.raises(SystemExit) as exc:
+		main()
+
+	assert exc.value.code == 2
+	assert "camas mcp gate: requires feature camas[mcp]" in capsys.readouterr().err
+
+
+def test_entrypoint_mcp_gate_branch_reraises_non_mcp_missing_import(
+	monkeypatch: pytest.MonkeyPatch,
+) -> None:
+	from camas.main import main
+
+	original_import = __import__
+
+	def fake_import(
+		name: str,
+		globals: Mapping[str, object] | None = None,
+		locals: Mapping[str, object] | None = None,
+		fromlist: Sequence[str] = (),
+		level: int = 0,
+	) -> object:
+		if name == "pydantic":
+			raise ModuleNotFoundError("No module named 'pydantic'", name="pydantic")
+		return original_import(name, globals, locals, fromlist, level)
+
+	for module in ("camas.mcp.serve", "pydantic"):
+		monkeypatch.delitem(sys.modules, module, raising=False)
+	monkeypatch.setattr("sys.argv", ["camas", "mcp", "gate"])
+	with patch("builtins.__import__", fake_import), pytest.raises(ModuleNotFoundError) as exc:
+		main()
+
+	assert exc.value.name == "pydantic"
+
+
 def test_camas_list_does_not_import_mcp_stack(tmp_path: Path) -> None:
 	"""The MCP server's heavy deps must never load on the ``camas <task>`` hot path."""
 	from textwrap import dedent

--- a/tests/mcp/test_result.py
+++ b/tests/mcp/test_result.py
@@ -5,12 +5,12 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from camas import Parallel, Sequential, Task
+from camas import AgentFormat, Parallel, Sequential, Task
 from camas.core.completion import RunResult, TaskResult
 from camas.core.execution import run
 from camas.mcp import wire
-from camas.mcp.result import to_run_response
-from camas.v0.completion import Stopped
+from camas.mcp.result import agent_envelopes, to_agent_envelope, to_run_response
+from camas.v0.completion import Finished, Skipped, Stopped
 
 if TYPE_CHECKING:
 	from camas.mcp.result import Verbosity
@@ -85,3 +85,36 @@ def test_stopped_leaf_maps_to_wire_stopped() -> None:
 	assert isinstance(comp, wire.Stopped)
 	assert comp.output == ["bye"]
 	assert (resp.passed, resp.failed, resp.skipped, resp.interrupt_count) == (0, 1, 0, 1)
+
+
+def test_agent_envelope_finished_carries_verbatim_payload() -> None:
+	task = Task(
+		"ruff check .", name="lint", agent_format=AgentFormat("--output-format sarif", "sarif")
+	)
+	env = to_agent_envelope(task, TaskResult("lint", Finished(1, 0.1, (b"E1\n", b"E2\n"))))
+	assert (env.name, env.exit_code, env.output_kind) == ("lint", 1, "sarif")
+	assert env.payload == "E1\nE2"
+	assert env.truncated is False
+
+
+def test_agent_envelope_skipped_has_empty_payload() -> None:
+	env = to_agent_envelope(Task("x", name="x"), TaskResult("x", Skipped(1, "dep")))
+	assert env.exit_code == 1
+	assert env.payload == ""
+
+
+def test_agent_envelope_stopped_carries_partial_output() -> None:
+	env = to_agent_envelope(
+		Task("x", name="x"), TaskResult("x", Stopped(130, 0.1, (b"partial\n",)))
+	)
+	assert env.exit_code == 130
+	assert env.payload == "partial"
+
+
+async def test_agent_envelopes_are_failures_only() -> None:
+	node = Parallel(
+		Task(("python", "-c", "pass"), name="ok"),
+		Task(("python", "-c", "raise SystemExit(1)"), name="bad"),
+	)
+	envelopes = agent_envelopes(node, await run(node, interactive=False))
+	assert tuple(e.name for e in envelopes) == ("bad",)

--- a/tests/mcp/test_serve.py
+++ b/tests/mcp/test_serve.py
@@ -164,7 +164,7 @@ def test_tools_rich_includes_title_annotations_and_schema() -> None:
 	assert tool_gate.title == "SA-delegation gate"
 	assert tool_gate.outputSchema is not None
 	assert tool_gate.annotations is not None
-	assert tool_gate.annotations.destructiveHint is True
+	assert tool_gate.annotations.readOnlyHint is True
 
 
 def test_list_call_text_lists_tasks_and_markers(tmp_path: Path) -> None:
@@ -558,7 +558,7 @@ async def test_run_call_under_selects_runs_and_reports(tmp_path: Path) -> None:
 	result = await serve.run_call(session, {"under": 1.0})
 	assert result.isError is False
 	text = _text(result)
-	assert "Time budget 1.00s — selected 2 leaf(s)" in text
+	assert "Time budget 1.00s — running 2 leaf(s)" in text
 	assert "over budget: slow ~9.00s" in text
 	assert "PASSED" in text
 	assert result.structuredContent is not None
@@ -593,10 +593,9 @@ async def test_run_call_under_reports_untimed(tmp_path: Path) -> None:
 	b = Task(("python", "-c", "print('b')"), name="b")
 	session = _session({"p": Parallel(a, b, name="p")}, None, tmp_path, rich=True)
 	result = await serve.run_call(session, {"task": "p", "under": 1.0})
-	assert "untimed (run the task normally once to record an estimate): b" in _text(result)
+	assert "unmeasured (running to record an estimate): b" in _text(result)
 	assert result.structuredContent is not None
-	excluded = result.structuredContent["budget"]["excluded"]
-	assert next(e for e in excluded if e["name"] == "b")["reason"] == "untimed"
+	assert "b" in result.structuredContent["budget"]["unmeasured"]
 
 
 async def test_run_call_under_no_task_no_default_errors(tmp_path: Path) -> None:
@@ -634,7 +633,7 @@ async def test_run_call_under_applies_matrix_override(tmp_path: Path) -> None:
 		session, {"task": "m", "under": 1.0, "matrix_overrides": {"PY": ["3.13"]}}
 	)
 	assert result.isError is False
-	assert "Nothing ran" in _text(result)
+	assert "running 1 leaf(s)" in _text(result)
 
 
 async def test_run_call_under_bad_matrix_override_errors(tmp_path: Path) -> None:

--- a/tests/mcp/test_serve.py
+++ b/tests/mcp/test_serve.py
@@ -125,7 +125,7 @@ def test_task_names_empty_on_load_error(tmp_path: Path) -> None:
 
 
 def test_tools_default_omits_rich_fields() -> None:
-	tool_list, tool_run, tool_check, tool_docs = serve.tools(
+	tool_list, tool_run, tool_check, tool_docs, tool_gate = serve.tools(
 		("a", "b"), Compat(emit_structured=False)
 	)
 	assert (tool_list.title, tool_list.outputSchema, tool_list.annotations) == (None, None, None)
@@ -137,10 +137,14 @@ def test_tools_default_omits_rich_fields() -> None:
 	assert tool_docs.inputSchema == serve.NO_ARGS_SCHEMA
 	assert tool_list.inputSchema["properties"]["expand_matrix"]["type"] == "boolean"
 	assert tool_list.inputSchema["additionalProperties"] is False
+	assert (tool_gate.title, tool_gate.outputSchema, tool_gate.annotations) == (None, None, None)
+	assert _task_enum(tool_gate.inputSchema) == ["a", "b"]
 
 
 def test_tools_rich_includes_title_annotations_and_schema() -> None:
-	tool_list, tool_run, tool_check, tool_docs = serve.tools((), Compat(emit_structured=True))
+	tool_list, tool_run, tool_check, tool_docs, tool_gate = serve.tools(
+		(), Compat(emit_structured=True)
+	)
 	assert tool_list.title == "List camas tasks"
 	assert tool_list.annotations is not None
 	assert tool_list.annotations.readOnlyHint is True
@@ -157,6 +161,10 @@ def test_tools_rich_includes_title_annotations_and_schema() -> None:
 	assert tool_docs.outputSchema is not None
 	assert tool_docs.annotations is not None
 	assert tool_docs.annotations.readOnlyHint is True
+	assert tool_gate.title == "SA-delegation gate"
+	assert tool_gate.outputSchema is not None
+	assert tool_gate.annotations is not None
+	assert tool_gate.annotations.destructiveHint is True
 
 
 def test_list_call_text_lists_tasks_and_markers(tmp_path: Path) -> None:
@@ -826,6 +834,7 @@ async def test_in_memory_round_trip(tmp_path: Path) -> None:
 			"camas_run",
 			"camas_check",
 			"camas_docs",
+			"camas_gate",
 		}
 		catalog = await client.call_tool("camas_list", {})
 		assert "lint" in _text(catalog)
@@ -917,3 +926,54 @@ async def test_run_via_client_picks_up_new_task_without_check(tmp_path: Path) ->
 
 def _text(result: types.CallToolResult) -> str:
 	return "\n".join(block.text for block in result.content if isinstance(block, types.TextContent))
+
+
+GATE_FIX = Task(("python", "-c", "print('fixed')"), name="fmt", mutates=True)
+
+
+async def test_gate_call_load_error(tmp_path: Path) -> None:
+	session = Session(
+		LoadErr(source=tmp_path / "tasks.py", exception=RuntimeError("boom")), tmp_path, Compat()
+	)
+	result = await serve.call(session, "camas_gate", {})
+	assert result.isError
+
+
+async def test_gate_call_invalid_args(tmp_path: Path) -> None:
+	node = Parallel(GATE_FIX, PASS)
+	session = _session({"all": node}, Config(default_task=node), tmp_path)
+	result = await serve.call(session, "camas_gate", {"bogus": 1})
+	assert result.isError
+	assert "invalid camas_gate arguments" in _text(result)
+
+
+async def test_gate_call_no_task_no_default_errors(tmp_path: Path) -> None:
+	session = _session({"x": PASS}, None, tmp_path)
+	result = await serve.call(session, "camas_gate", {})
+	assert result.isError
+
+
+async def test_gate_call_continue_when_checks_pass(tmp_path: Path) -> None:
+	node = Parallel(GATE_FIX, PASS)
+	session = _session({"all": node}, Config(default_task=node), tmp_path)
+	result = await serve.call(session, "camas_gate", {})
+	assert not result.isError
+	assert "CONTINUE" in _text(result)
+
+
+async def test_gate_call_block_when_check_fails(tmp_path: Path) -> None:
+	node = Parallel(GATE_FIX, FAIL)
+	session = _session({"all": node}, Config(default_task=node), tmp_path)
+	result = await serve.call(session, "camas_gate", {"task": "all"})
+	text = _text(result)
+	assert not result.isError
+	assert "BLOCK" in text
+	assert "bad" in text
+
+
+async def test_gate_call_with_budget_reports_partition(tmp_path: Path) -> None:
+	node = Parallel(GATE_FIX, PASS)
+	session = _session({"all": node}, Config(default_task=node), tmp_path)
+	result = await serve.call(session, "camas_gate", {"under": 1.0})
+	assert not result.isError
+	assert "Time budget" in _text(result)

--- a/tests/plugin/test_gate_e2e.py
+++ b/tests/plugin/test_gate_e2e.py
@@ -1,0 +1,69 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2026 JP Hutchins
+
+"""End-to-end gate "sandbox": a real tasks.py in a tmp project, driven through the
+``camas_gate`` MCP tool (what the plugin's PostToolBatch hook calls), exercising the
+autofix-then-check-then-classify loop against files on disk. tmp_path is auto-removed."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from mcp import types
+
+from camas.main.tasks import load_tasks_from_py
+from camas.mcp import serve
+from camas.mcp.serve import Compat, Session
+
+if TYPE_CHECKING:
+	from pathlib import Path
+
+	import pytest
+
+# A fix leaf that deletes the literal "TODO" from sample.py, and a check that fails while a
+# marker is still present. Same fix in both; the check's marker decides autofixed vs residual.
+_FIX = (
+	"fix = Task(\n"
+	'\t("python", "-c", "import pathlib; p = pathlib.Path(\'sample.py\'); '
+	"p.write_text(p.read_text().replace('TODO', ''))\"),\n"
+	'\tname="fix",\n\tmutates=True,\n)\n'
+)
+
+
+def _tasks_py(marker: str) -> str:
+	return (
+		"from camas import Config, Sequential, Task\n\n" + _FIX + "check = Task(\n"
+		f'\t("python", "-c", "import pathlib, sys; sys.exit(\'{marker}\' in pathlib.Path(\'sample.py\').read_text())"),\n'
+		'\tname="check",\n)\n'
+		"_ = Config(default_task=Sequential(fix, check))\n"
+	)
+
+
+def _text(result: types.CallToolResult) -> str:
+	return "".join(c.text for c in result.content if isinstance(c, types.TextContent))
+
+
+def _session(tmp_path: Path, marker: str) -> Session:
+	(tmp_path / "tasks.py").write_text(_tasks_py(marker))
+	return Session(load_tasks_from_py(tmp_path / "tasks.py"), tmp_path, Compat())
+
+
+async def test_gate_autofix_edits_a_real_file_then_passes(
+	tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+	monkeypatch.chdir(tmp_path)
+	(tmp_path / "sample.py").write_text("TODO\nvalue = 1\n")
+	result = await serve.call(_session(tmp_path, "TODO"), "camas_gate", {})
+	assert not result.isError
+	assert "autofixed" in _text(result)
+	assert "TODO" not in (tmp_path / "sample.py").read_text()
+
+
+async def test_gate_blocks_on_a_residual_the_fixer_cannot_resolve(
+	tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+	monkeypatch.chdir(tmp_path)
+	(tmp_path / "sample.py").write_text("FIXME\nvalue = 1\n")
+	result = await serve.call(_session(tmp_path, "FIXME"), "camas_gate", {})
+	assert not result.isError
+	assert "needs_reasoning" in _text(result)

--- a/tests/plugin/test_gate_e2e.py
+++ b/tests/plugin/test_gate_e2e.py
@@ -2,8 +2,9 @@
 # SPDX-FileCopyrightText: 2026 JP Hutchins
 
 """End-to-end gate "sandbox": a real tasks.py in a tmp project, driven through the
-``camas_gate`` MCP tool (what the plugin's PostToolBatch hook calls), exercising the
-autofix-then-check-then-classify loop against files on disk. tmp_path is auto-removed."""
+``camas_gate`` MCP tool (what the plugin's PostToolBatch hook calls). The gate is check-only —
+it runs the project's check node over the workspace and classifies green vs needs_reasoning,
+and it never mutates. tmp_path is auto-removed."""
 
 from __future__ import annotations
 
@@ -20,22 +21,14 @@ if TYPE_CHECKING:
 
 	import pytest
 
-# A fix leaf that deletes the literal "TODO" from sample.py, and a check that fails while a
-# marker is still present. Same fix in both; the check's marker decides autofixed vs residual.
-_FIX = (
-	"fix = Task(\n"
-	'\t("python", "-c", "import pathlib; p = pathlib.Path(\'sample.py\'); '
-	"p.write_text(p.read_text().replace('TODO', ''))\"),\n"
-	'\tname="fix",\n\tmutates=True,\n)\n'
-)
-
 
 def _tasks_py(marker: str) -> str:
+	# A read-only check that fails while `marker` is present in sample.py — the gate's check node.
 	return (
-		"from camas import Config, Sequential, Task\n\n" + _FIX + "check = Task(\n"
+		"from camas import Config, Task\n\ncheck = Task(\n"
 		f'\t("python", "-c", "import pathlib, sys; sys.exit(\'{marker}\' in pathlib.Path(\'sample.py\').read_text())"),\n'
 		'\tname="check",\n)\n'
-		"_ = Config(default_task=Sequential(fix, check))\n"
+		"_ = Config(default_task=check)\n"
 	)
 
 
@@ -48,18 +41,17 @@ def _session(tmp_path: Path, marker: str) -> Session:
 	return Session(load_tasks_from_py(tmp_path / "tasks.py"), tmp_path, Compat())
 
 
-async def test_gate_autofix_edits_a_real_file_then_passes(
+async def test_gate_is_green_when_the_check_passes(
 	tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
 	monkeypatch.chdir(tmp_path)
-	(tmp_path / "sample.py").write_text("TODO\nvalue = 1\n")
-	result = await serve.call(_session(tmp_path, "TODO"), "camas_gate", {})
+	(tmp_path / "sample.py").write_text("value = 1\n")
+	result = await serve.call(_session(tmp_path, "FIXME"), "camas_gate", {})
 	assert not result.isError
-	assert "autofixed" in _text(result)
-	assert "TODO" not in (tmp_path / "sample.py").read_text()
+	assert "green" in _text(result)
 
 
-async def test_gate_blocks_on_a_residual_the_fixer_cannot_resolve(
+async def test_gate_blocks_on_a_failing_check_without_mutating(
 	tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
 	monkeypatch.chdir(tmp_path)
@@ -67,3 +59,4 @@ async def test_gate_blocks_on_a_residual_the_fixer_cannot_resolve(
 	result = await serve.call(_session(tmp_path, "FIXME"), "camas_gate", {})
 	assert not result.isError
 	assert "needs_reasoning" in _text(result)
+	assert (tmp_path / "sample.py").read_text() == "FIXME\nvalue = 1\n"

--- a/tests/plugin/test_shipped_plugin.py
+++ b/tests/plugin/test_shipped_plugin.py
@@ -1,0 +1,52 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2026 JP Hutchins
+
+"""The camas Claude Code plugin is shipped as committed files (distributed via the repo's
+marketplace), not unit-tested machinery — so these guard that the static artifacts are
+well-formed and self-consistent: the hook targets the real gate tool, and the marketplace
+points at the plugin that exists."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from camas.mcp.serve import ToolName
+
+_REPO = Path(__file__).resolve().parents[2]
+_PLUGIN = _REPO / "agent" / "claude" / "plugin"
+
+
+def test_plugin_manifest_is_named_camas() -> None:
+	assert json.loads((_PLUGIN / ".claude-plugin" / "plugin.json").read_text())["name"] == "camas"
+
+
+def test_bundled_mcp_server_launches_camas_mcp() -> None:
+	server = json.loads((_PLUGIN / ".mcp.json").read_text())["mcpServers"]["camas"]
+	assert (server["command"], server["args"]) == ("camas", ["mcp"])
+
+
+def test_gate_hook_targets_the_real_gate_tool() -> None:
+	hooks = json.loads((_PLUGIN / "hooks" / "hooks.json").read_text())["hooks"]
+	hook = hooks["PostToolBatch"][0]["hooks"][0]
+	assert hook["type"] == "mcp_tool"
+	assert hook["server"] == "camas"
+	assert hook["tool"] == ToolName.GATE.value
+
+
+def test_filechanged_hook_runs_the_deterministic_autofix() -> None:
+	hooks = json.loads((_PLUGIN / "hooks" / "hooks.json").read_text())["hooks"]
+	fc = hooks["FileChanged"][0]["hooks"][0]
+	assert fc["type"] == "command"
+	assert "camas fix" in fc["command"]
+
+
+def test_marketplace_points_at_the_shipped_plugin() -> None:
+	catalog = json.loads((_REPO / ".claude-plugin" / "marketplace.json").read_text())
+	entry = next(p for p in catalog["plugins"] if p["name"] == "camas")
+	assert (_REPO / entry["source"]).resolve() == _PLUGIN.resolve()
+
+
+def test_plugin_ships_the_fixer_and_skill() -> None:
+	assert "name: camas-fixer" in (_PLUGIN / "agents" / "camas-fixer.md").read_text()
+	assert "name: gate" in (_PLUGIN / "skills" / "gate" / "SKILL.md").read_text()

--- a/tests/plugin/test_shipped_plugin.py
+++ b/tests/plugin/test_shipped_plugin.py
@@ -35,7 +35,7 @@ def test_filechanged_hook_runs_the_deterministic_autofix() -> None:
 	hooks = json.loads((_PLUGIN / "hooks" / "hooks.json").read_text())["hooks"]
 	fc = hooks["FileChanged"][0]["hooks"][0]
 	assert fc["type"] == "command"
-	assert "camas fix" in fc["command"]
+	assert "camas mcp fix" in fc["command"]
 
 
 def test_marketplace_points_at_the_shipped_plugin() -> None:

--- a/tests/plugin/test_shipped_plugin.py
+++ b/tests/plugin/test_shipped_plugin.py
@@ -11,8 +11,6 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-from camas.mcp.serve import ToolName
-
 _REPO = Path(__file__).resolve().parents[2]
 _PLUGIN = _REPO / "agent" / "claude" / "plugin"
 
@@ -26,12 +24,11 @@ def test_bundled_mcp_server_launches_camas_mcp() -> None:
 	assert (server["command"], server["args"]) == ("camas", ["mcp"])
 
 
-def test_gate_hook_targets_the_real_gate_tool() -> None:
+def test_gate_hook_runs_camas_mcp_gate() -> None:
 	hooks = json.loads((_PLUGIN / "hooks" / "hooks.json").read_text())["hooks"]
 	hook = hooks["PostToolBatch"][0]["hooks"][0]
-	assert hook["type"] == "mcp_tool"
-	assert hook["server"] == "camas"
-	assert hook["tool"] == ToolName.GATE.value
+	assert hook["type"] == "command"
+	assert "camas mcp gate" in hook["command"]
 
 
 def test_filechanged_hook_runs_the_deterministic_autofix() -> None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -5,10 +5,12 @@ from __future__ import annotations
 
 import pytest
 
-from camas import Config, Task
+from camas import Claude, Config, Task
 
 DEFAULT = Task("default", name="default")
 GH = Task("gh", name="gh")
+FIX = Task("fix", name="fix", mutates=True)
+CHECK = Task("check", name="check")
 
 
 @pytest.mark.parametrize(
@@ -45,3 +47,17 @@ def test_effects_returns_per_environment_override() -> None:
 	config = Config(default_effects=local, default_github_effects=gh)
 	assert config.effects(github=False) is local
 	assert config.effects(github=True) is gh
+
+
+def test_gate_check_prefers_agent_check_else_bare_task() -> None:
+	assert (
+		Config(default_task=DEFAULT, agent=Claude(fix=FIX, check=CHECK)).gate_check(github=False)
+		is CHECK
+	)
+	assert Config(default_task=DEFAULT, agent=Claude(fix=FIX)).gate_check(github=False) is DEFAULT
+	assert Config(default_task=DEFAULT).gate_check(github=False) is DEFAULT
+
+
+def test_gate_fix_is_the_agent_fix_node_or_none() -> None:
+	assert Config(agent=Claude(fix=FIX)).gate_fix() is FIX
+	assert Config(default_task=DEFAULT).gate_fix() is None

--- a/tests/test_v0.py
+++ b/tests/test_v0.py
@@ -19,7 +19,7 @@ from camas.v0.leaf_state import Completed, LeafState, Running, Waiting
 from camas.v0.task import Group, Parallel, Sequential, Task, TaskNode
 from camas.v0.task_event import CompletedEvent, OutputEvent, StartedEvent, TaskEvent
 
-HEADLINE: Final = frozenset({"Config", "Effect", "Parallel", "Sequential", "Task"})
+HEADLINE: Final = frozenset({"AgentFormat", "Config", "Effect", "Parallel", "Sequential", "Task"})
 """The unversioned definers re-exported by both ``camas`` and ``camas.v0``."""
 
 PUBLIC_API: Final = (

--- a/tests/test_v0.py
+++ b/tests/test_v0.py
@@ -13,19 +13,23 @@ import pytest
 import camas
 import camas.v0
 from camas.v0.completion import Completion, Finished, Skipped
-from camas.v0.config import Config
+from camas.v0.config import Agent, Claude, Config
 from camas.v0.effect import Effect
 from camas.v0.leaf_state import Completed, LeafState, Running, Waiting
 from camas.v0.task import Group, Parallel, Sequential, Task, TaskNode
 from camas.v0.task_event import CompletedEvent, OutputEvent, StartedEvent, TaskEvent
 
-HEADLINE: Final = frozenset({"AgentFormat", "Config", "Effect", "Parallel", "Sequential", "Task"})
+HEADLINE: Final = frozenset(
+	{"Agent", "AgentFormat", "Claude", "Config", "Effect", "Parallel", "Sequential", "Task"}
+)
 """The unversioned definers re-exported by both ``camas`` and ``camas.v0``."""
 
 PUBLIC_API: Final = (
 	Completion,
 	Finished,
 	Skipped,
+	Agent,
+	Claude,
 	Config,
 	Effect,
 	Completed,


### PR DESCRIPTION
Integrates the **SA-delegation gate** epic onto `main`: a Claude Code plugin that, in any repo, runs fast checks off the main agent's context and surfaces only the residual that needs reasoning. The deterministic auto-fixers run on `FileChanged` (zero model tokens); the gate is **read-only** and **binary**. Full vision and verified constraints live in #77; this PR also carries a post-review redesign (see the review threads on this PR).

## Architecture — two deterministic layers, both declared in `Config.agent`

- **Fix — `FileChanged`, scoped.** `camas fix --paths <file>` runs `Config.agent.fix` (the declared, behavior-preserving auto-fixers) over the changed file. Zero model tokens. The fix node is *declared*, never derived from `mutates` (mutators ≠ fixers — codegen/compilers exist).
- **Check — `PostToolBatch`, scoped.** `camas mcp gate` runs the check node (`Config.agent.check`, else the default task) over the just-edited files and returns a binary verdict — `green`, or `needs_reasoning` with the failing diagnostics. It never mutates.
- **Judgment loop.** On `needs_reasoning`, the cheap `camas-fixer` subagent loops fix → re-gate under a `maxTurns` cutoff, escalating to main only on exhaustion. The verdict carries a `rerun` handle (`{task, paths, under}`) — the self-describing re-gate command.

## Layers (each merged as its own reviewed PR)

| Ticket | PR | What |
|---|---|---|
| #78 | #81 | path-scoping — `{paths}` injection + `scope_to_changed` |
| #67 | #82 | deterministic autofix on `FileChanged` — `camas fix --paths` |
| #69 | #83 | the `camas_gate` MCP tool |
| #68 | #84 | AgentJSON — agent-only `agent_format` + failures-verbatim envelope |
| #80 | #87 | the `camas` plugin (repo marketplace): hooks + `camas-fixer` + `gate` skill |
| #79 | #88 | the judgment loop — cheap fixer, bounded, escalates |

## Post-review redesign (commit `7d38294`)

After two reviews on this PR (a line-level bug pass and an architecture pass) and maintainer direction, the gate was reshaped and the confirmed bugs fixed:

- **Gate → check-only / binary.** Dropped the in-gate autofix; `residual_class` is now `green | needs_reasoning` (`autofixed` removed); the gate runs the declared check node and never mutates.
- **`Config.agent` = `Claude(fix, check?)`** (sum-typed for a future CI backend); resolvers wire the two layers. The fix node is declared, not inferred from `mutates`.
- **`budget.py` untimed-runs.** Untimed leaves run (and get measured) instead of being skipped — fixes the chicken-and-egg where a skipped leaf stays forever untimed, and the empty-timings false-green.
- **`camas mcp gate` verb.** Headless, process-isolated gate (reads `--paths` or a `PostToolBatch` event on stdin; JSON to stdout + exit 0/2) — now the `PostToolBatch` hook, and the substrate for the benchmark and parallel fixers.
- **Fixes.** Absolute-path relativization at every boundary + cwd-rebasing for subdir tools like `cargo` (#3/#4); scoped/agent-format leaves reuse their unscoped recorded timing (#8-9); structured (`output_kind`) payloads pass verbatim, bypassing the tail-truncation (#5); `Skipped` siblings excluded from gate diagnostics (#11); truncation surfaced to the agent (#12); `to_expression` round-trips every Task field — `paths`/`agent_format` plus the pre-existing `env`/`cwd`/`help` drops (#7, fully closing #85); starter scaffold + `SKILL.md` + README rewritten to the two-layer model.

## Out of scope (noted follow-ups)

A benchmark trace for per-invocation token/duration accounting, a tiered-fixer ladder (`fixers` on `Claude`), and per-worktree `.camas` isolation for massive parallelism — all explicitly deferred; the architecture is positioned for them without an overhaul.

## Verification

Each layer merged green; this integrated branch is green at `7d38294` — ruff format + lint, all 5 typecheckers, the full suite, and 100% coverage, across the OS × Python 3.10–3.15 matrix.

Closes #77
Closes #78
Closes #67
Closes #69
Closes #68
Closes #80
Closes #79
Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)
