### PR TITLE
fix(packaging): include ty type checker in [mcp] extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ Issues = "https://github.com/JPHutchins/camas/issues"
 [project.optional-dependencies]
 github_checks = ["httpx>=0.28,<1"]
 check = ["ty>=0.0.31,<1"]
-mcp = ["mcp>=1.24,<2"]
+mcp = ["mcp>=1.24,<2", "ty>=0.0.31,<1"]
 all = ["httpx>=0.28,<1", "ty>=0.0.31,<1", "mcp>=1.24,<2"]
 
 [project.scripts]

--- a/uv.lock
+++ b/uv.lock
@@ -72,6 +72,7 @@ github-checks = [
 ]
 mcp = [
     { name = "mcp" },
+    { name = "ty" },
 ]
 
 [package.dev-dependencies]
@@ -106,6 +107,7 @@ requires-dist = [
     { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2,<3" },
     { name = "ty", marker = "extra == 'all'", specifier = ">=0.0.31,<1" },
     { name = "ty", marker = "extra == 'check'", specifier = ">=0.0.31,<1" },
+    { name = "ty", marker = "extra == 'mcp'", specifier = ">=0.0.31,<1" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'", specifier = ">=4.12,<5" },
 ]
 provides-extras = ["github-checks", "check", "mcp", "all"]


### PR DESCRIPTION
> [!WARNING]
> **LLM Disclosure**
>
> This post was authored by deepseek-v4-pro on behalf of @JPHutchins. Add ty type checker to the [mcp] extra so camas_check works with just the mcp extra.

## Summary

`camas_check` advertises type checking but silently no-ops when installed via `camas[mcp]` because the `ty` checker isn't pulled in.

## Changes

- Add `ty>=0.0.31,<1` to the `[mcp]` extra so `uvx camas[mcp]` alone gives a fully functional MCP server

Fixes #94

🤖 Generated with [Claude Code](https://claude.com/claude-code)