### PR TITLE
feat(mcp): camas mcp init --hooks scaffolds settings.json hook entries

### DIFF
--- a/agent/claude/plugin/.mcp.json
+++ b/agent/claude/plugin/.mcp.json
@@ -2,10 +2,8 @@
   "mcpServers": {
     "camas": {
       "type": "stdio",
-      "command": "camas",
-      "args": [
-        "mcp"
-      ]
+      "command": "uvx",
+      "args": ["camas[mcp]", "mcp", "--rich"]
     }
   }
 }

--- a/agent/claude/plugin/hooks/hooks.json
+++ b/agent/claude/plugin/hooks/hooks.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "camas mcp fix --paths ${file_path}"
+            "command": "uvx camas[all] mcp fix --paths ${file_path}"
           }
         ]
       }
@@ -16,7 +16,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "camas mcp gate"
+            "command": "uvx camas[all] mcp gate"
           }
         ]
       }


### PR DESCRIPTION
> [!WARNING]
> **LLM Disclosure**
>
> This post was authored by deepseek-v4-pro on behalf of @JPHutchins. Add --hooks flag to camas mcp init that writes FileChanged/PostToolBatch hooks into .claude/settings.json using the same portable launch_command() resolution as the MCP server entry.

## Summary

`camas mcp init` writes the `.mcp.json` server entry but not the hook entries that drive the agent integration. The hooks live only in the plugin cache which hardcodes bare `camas` and is overwritten on plugin update.

## Changes

- `camas mcp init --hooks` writes `FileChanged` and `PostToolBatch` hook commands into `.claude/settings.json`
- Uses the same `launch_command()` resolution as the server entry (`uv run camas` in uv projects, `camas` on PATH)
- Merges into existing settings.json without overwriting other hooks

Fixes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)