### PR TITLE
fix(mcp): dry_run with no task previews the default task

### DIFF
--- a/src/camas/mcp/serve.py
+++ b/src/camas/mcp/serve.py
@@ -421,7 +421,7 @@ async def run_for(
 	if req.under is not None:
 		return await run_budget(session, tasks, config, req, req.under)
 	try:
-		name, node = resolve_run_node(tasks, req)
+		name, node = resolve_run_node(tasks, req, config)
 	except ValueError as e:
 		return error_result(str(e))
 	if req.dry_run:
@@ -435,16 +435,25 @@ async def run_for(
 	)
 
 
-def resolve_run_node(tasks: Mapping[str, TaskNode], req: wire.RunRequest) -> tuple[str, TaskNode]:
+def resolve_run_node(
+	tasks: Mapping[str, TaskNode], req: wire.RunRequest, config: Config | None = None
+) -> tuple[str, TaskNode]:
 	"""The ``(name, node)`` to run: looked up by name, then matrix-overridden and
 	passthrough-appended.
 
+	When ``dry_run=true`` and ``task`` is omitted, resolves the project's default task
+	so a bare dry-run previews it without erroring.
+
 	Raises:
-		ValueError: when ``req.task`` is omitted (only ``under`` may omit it), names no
-			task, an override targets an unknown matrix axis, or passthrough args are
-			applied to a non-leaf task.
+		ValueError: when ``req.task`` is omitted outside a dry-run, names no task, an
+			override targets an unknown matrix axis, or passthrough args are applied to
+			a non-leaf task.
 	"""
 	if req.task is None:
+		if req.dry_run and config is not None:
+			default = config.gate_check(github=False)
+			if default is not None:
+				return "default task", default
 		raise ValueError("camas_run requires 'task' (or pass 'under' to budget the default task)")
 	if req.task not in tasks:
 		known = ", ".join(sorted(tasks)) or "none"

--- a/src/camas/mcp/wire.py
+++ b/src/camas/mcp/wire.py
@@ -164,7 +164,8 @@ class RunRequest(BaseModel):
 	task: str | None = Field(
 		default=None,
 		description="Task name to run — one of the names returned by camas_list. May be "
-		"omitted only with 'under', which then budgets the project's default task.",
+		"omitted with 'under' (budgets the default task) or with 'dry_run' (previews "
+		"the default task).",
 	)
 	under: float | None = Field(
 		default=None,

--- a/tests/mcp/test_serve.py
+++ b/tests/mcp/test_serve.py
@@ -278,6 +278,25 @@ async def test_run_call_dry_run_names_anonymous_leaf_by_command(tmp_path: Path) 
 	assert result.structuredContent["leaves"][0]["cwd"] == "work"
 
 
+async def test_run_call_dry_run_no_task_previews_default(tmp_path: Path) -> None:
+	"""camas_run(dry_run=true) with no task resolves and previews the default task."""
+	default_task = Task(("python", "-c", "print('default')"), name="ci")
+	config = Config(default_task=default_task)
+	session = _session({"ci": default_task}, config, tmp_path)
+	result = await serve.run_call(session, {"dry_run": True})
+	assert result.isError is False
+	assert "fully-resolved plan" in _text(result)
+
+
+async def test_run_call_dry_run_no_task_no_default_errors(tmp_path: Path) -> None:
+	"""camas_run(dry_run=true) with no task and no config default still errors."""
+	config = Config()  # no default_task
+	session = _session({"ci": PASS}, config, tmp_path)
+	result = await serve.run_call(session, {"dry_run": True})
+	assert result.isError is True
+	assert "requires 'task'" in _text(result)
+
+
 async def test_run_call_log_path_in_structured_content_when_rich(tmp_path: Path) -> None:
 	session = _session({"bad": FAIL}, None, tmp_path, rich=True)
 	result = await serve.run_call(session, {"task": "bad"})


### PR DESCRIPTION
> [!WARNING]
> **LLM Disclosure**
>
> This post was authored by deepseek-v4-pro on behalf of @JPHutchins. Fix camas_run dry_run with no task to resolve and preview the default task.

## Summary

camas_run(dry_run=true) with no task errored out — it now previews the default task.

## Changes

- resolve_run_node resolves the default task when dry_run=true and task is None
- Updated RunRequest.task field description

Fixes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)