### PR TITLE
fix(plugin): use portable uvx launcher in .mcp.json and hooks.json

### DIFF
--- a/agent/claude/plugin/.mcp.json
+++ b/agent/claude/plugin/.mcp.json
@@ -2,10 +2,8 @@
   "mcpServers": {
     "camas": {
       "type": "stdio",
-      "command": "camas",
-      "args": [
-        "mcp"
-      ]
+      "command": "uvx",
+      "args": ["camas[mcp]", "mcp", "--rich"]
     }
   }
 }

--- a/agent/claude/plugin/hooks/hooks.json
+++ b/agent/claude/plugin/hooks/hooks.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "camas mcp fix --paths ${file_path}"
+            "command": "uvx camas[all] mcp fix --paths ${file_path}"
           }
         ]
       }
@@ -16,7 +16,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "camas mcp gate"
+            "command": "uvx camas[all] mcp gate"
           }
         ]
       }

--- a/tests/plugin/test_shipped_plugin.py
+++ b/tests/plugin/test_shipped_plugin.py
@@ -19,23 +19,26 @@ def test_plugin_manifest_is_named_camas() -> None:
 	assert json.loads((_PLUGIN / ".claude-plugin" / "plugin.json").read_text())["name"] == "camas"
 
 
-def test_bundled_mcp_server_launches_camas_mcp() -> None:
+def test_bundled_mcp_server_is_a_portable_stdio_entry() -> None:
 	server = json.loads((_PLUGIN / ".mcp.json").read_text())["mcpServers"]["camas"]
-	assert (server["command"], server["args"]) == ("camas", ["mcp"])
+	assert server["type"] == "stdio"
+	assert server["command"] in ("camas", "uvx", "uv")
+	assert "mcp" in server["args"]
 
 
-def test_gate_hook_runs_camas_mcp_gate() -> None:
+def test_gate_hook_runs_mcp_gate() -> None:
 	hooks = json.loads((_PLUGIN / "hooks" / "hooks.json").read_text())["hooks"]
 	hook = hooks["PostToolBatch"][0]["hooks"][0]
 	assert hook["type"] == "command"
-	assert "camas mcp gate" in hook["command"]
+	assert "mcp gate" in hook["command"]
 
 
-def test_filechanged_hook_runs_the_deterministic_autofix() -> None:
+def test_filechanged_hook_runs_mcp_fix() -> None:
 	hooks = json.loads((_PLUGIN / "hooks" / "hooks.json").read_text())["hooks"]
 	fc = hooks["FileChanged"][0]["hooks"][0]
 	assert fc["type"] == "command"
-	assert "camas mcp fix" in fc["command"]
+	assert "mcp fix" in fc["command"]
+	assert "${file_path}" in fc["command"]
 
 
 def test_marketplace_points_at_the_shipped_plugin() -> None:


### PR DESCRIPTION
> [!WARNING]
> **LLM Disclosure**
>
> This post was authored by deepseek-v4-pro on behalf of @JPHutchins. Fix the plugin JSON files to use portable uvx launchers instead of bare camas.

## Summary

The plugin's `.mcp.json` assumed a global `camas` binary and omitted the `[mcp]` extra. The `hooks.json` hardcoded bare `camas` which fails when camas isn't on PATH — the exact setup `camas mcp init` produces for uv projects.

## Changes

- **`.mcp.json`**: use `uvx camas[mcp] mcp --rich` — portable, pulls the MCP extra
- **`hooks.json`**: use `uvx camas[all] mcp fix|gate` — portable, all extras

Fixes #92, fixes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)