### PR TITLE
fix(plugin): disable PostToolBatch hook (synchronous API blocks agent)

### DIFF
--- a/agent/claude/plugin/hooks/hooks.json
+++ b/agent/claude/plugin/hooks/hooks.json
@@ -5,18 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "camas mcp fix --paths ${file_path}"
-          }
-        ]
-      }
-    ],
-    "PostToolBatch": [
-      {
-        "matcher": "Edit|Write|MultiEdit|NotebookEdit",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "camas mcp gate"
+            "command": "uvx camas[all] mcp fix --paths ${file_path}"
           }
         ]
       }

--- a/agent/claude/plugin/hooks/hooks.json
+++ b/agent/claude/plugin/hooks/hooks.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "uvx camas[all] mcp fix --paths ${file_path}"
+            "command": "camas mcp fix --paths ${file_path}"
           }
         ]
       }

--- a/tests/plugin/test_shipped_plugin.py
+++ b/tests/plugin/test_shipped_plugin.py
@@ -24,11 +24,9 @@ def test_bundled_mcp_server_launches_camas_mcp() -> None:
 	assert (server["command"], server["args"]) == ("camas", ["mcp"])
 
 
-def test_gate_hook_runs_camas_mcp_gate() -> None:
+def test_post_tool_batch_hook_is_absent() -> None:
 	hooks = json.loads((_PLUGIN / "hooks" / "hooks.json").read_text())["hooks"]
-	hook = hooks["PostToolBatch"][0]["hooks"][0]
-	assert hook["type"] == "command"
-	assert "camas mcp gate" in hook["command"]
+	assert "PostToolBatch" not in hooks
 
 
 def test_filechanged_hook_runs_the_deterministic_autofix() -> None:


### PR DESCRIPTION
> [!WARNING]
> **LLM Disclosure**
>
> This post was authored by deepseek-v4-pro on behalf of @JPHutchins. Disable the synchronous PostToolBatch hook as a first step — cannot use a blocking API.

## Summary

The PostToolBatch command hook is synchronous by contract — it runs to completion before the agent continues. The intended design of spawning scoped fixer subagents in parallel with the main agent is unreachable with a synchronous command hook.

This is the first step: disable the PostToolBatch hook. The full fix requires the main agent to have a means of starting camas fixer subagents with scoped paths working in parallel.

## Changes

- Remove the `PostToolBatch` hook from `hooks.json`, keeping only the `FileChanged` autofix hook

Related: #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)