### PR TITLE
feat(mcp): camas mcp init --hooks scaffolds settings.json hook entries

### DIFF
--- a/src/camas/mcp/cli.py
+++ b/src/camas/mcp/cli.py
@@ -13,7 +13,9 @@ camas mcp — serve this project's tasks to AI agents over the Model Context Pro
 
 Usage:
   camas mcp [--rich]        run the MCP stdio server (an MCP client launches this)
-  camas mcp init [--rich]   write this project's .mcp.json entry for the camas server
+  camas mcp init [--rich] [--hooks]
+                              write this project's .mcp.json entry for the camas server;
+                              with --hooks also write hook entries to .claude/settings.json
   camas mcp fix [--paths P]… run the registered agent fix node (Config.agent.fix) over the
                               changed paths — the FileChanged autofix; no-op if unregistered
   camas mcp gate [task]     run the gate once, headless — print the verdict as JSON, exit
@@ -38,8 +40,10 @@ def main(argv: list[str]) -> None:
 		print(HELP)
 		return
 	if argv and argv[0] == "init":
-		from .scaffold import write_mcp_json
+		from .scaffold import write_hooks, write_mcp_json
 
+		if "--hooks" in argv:
+			sys.exit(write_hooks(argv[1:]))
 		sys.exit(write_mcp_json(argv[1:]))
 	if argv and argv[0] == "fix":
 		from ..main.dispatch import fix_cli

--- a/src/camas/mcp/scaffold.py
+++ b/src/camas/mcp/scaffold.py
@@ -10,13 +10,41 @@ import shlex
 import shutil
 import sys
 from pathlib import Path
-from typing import Any, Final, cast
+from typing import Any, Final, Literal, cast
+
+from pydantic import BaseModel, ConfigDict, Field
 
 from ..core.timings import ensure_camas_dir
 from ..v0.config import DEFAULT_CAMAS_DIR
 
 SERVER_NAME: Final = "camas"
 SETTINGS_PATH: Final = Path(".claude/settings.json")
+
+
+class HookCommand(BaseModel):
+	"""A single hook command entry in ``.claude/settings.json``."""
+
+	model_config = ConfigDict(extra="forbid")
+
+	type: Literal["command"]
+	command: str
+
+
+class HookGroup(BaseModel):
+	"""A group of hooks that fire on the same event, with an optional matcher."""
+
+	model_config = ConfigDict(extra="forbid")
+
+	hooks: list[HookCommand]
+	matcher: str | None = None
+
+
+class SettingsFile(BaseModel):
+	"""A ``.claude/settings.json`` file — validated, with extra fields preserved."""
+
+	model_config = ConfigDict(extra="allow")
+
+	hooks: dict[str, list[HookGroup]] = Field(default_factory=dict)
 
 
 def write_mcp_json(argv: list[str]) -> int:
@@ -104,46 +132,53 @@ def write_hooks(argv: list[str]) -> int:
 	using the same ``launch_command()`` resolution as the MCP server entry.
 	"""
 	settings_path = Path.cwd() / SETTINGS_PATH
-	existing = parse_json_object(settings_path) if settings_path.exists() else {}
-	if existing is None:
-		print(f"error: {settings_path} is not a readable JSON object", file=sys.stderr)
+	try:
+		raw: object = json.loads(settings_path.read_text(encoding="utf-8"))
+	except OSError:
+		raw = {}
+	except json.JSONDecodeError:
+		print(f"error: {settings_path} is not valid JSON", file=sys.stderr)
+		return 2
+	if not isinstance(raw, dict):
+		print(f"error: {settings_path} is not a JSON object", file=sys.stderr)
+		return 2
+	try:
+		settings = SettingsFile.model_validate(raw)
+	except Exception as e:
+		print(f"error: {settings_path}: {e}", file=sys.stderr)
 		return 2
 	launcher = launch_command_str(rich="--rich" in argv)
 	if launcher is None:
 		print(
-			f"error: cannot write portable hooks — no uv.lock found and camas is not "
+			"error: cannot write portable hooks — no uv.lock found and camas is not "
 			"on PATH.\n  Add camas to a uv project (uv add camas) or install it on PATH, "
 			"then retry.",
 			file=sys.stderr,
 		)
 		return 2
-	hooks = existing.setdefault("hooks", {})
-	if not isinstance(hooks, dict):
-		print(f"error: {settings_path} has a non-object 'hooks'", file=sys.stderr)
-		return 2
-	hooks["FileChanged"] = [
-		{
-			"hooks": [
-				{
-					"type": "command",
-					"command": f"{launcher} fix --paths ${{file_path}}",
-				}
+	settings.hooks["FileChanged"] = [
+		HookGroup(
+			hooks=[
+				HookCommand(
+					type="command",
+					command=f"{launcher} fix --paths ${{file_path}}",
+				)
 			]
-		}
+		)
 	]
-	hooks["PostToolBatch"] = [
-		{
-			"matcher": "Edit|Write|MultiEdit|NotebookEdit",
-			"hooks": [
-				{
-					"type": "command",
-					"command": f"{launcher} gate",
-				}
+	settings.hooks["PostToolBatch"] = [
+		HookGroup(
+			matcher="Edit|Write|MultiEdit|NotebookEdit",
+			hooks=[
+				HookCommand(
+					type="command",
+					command=f"{launcher} gate",
+				)
 			],
-		}
+		)
 	]
 	settings_path.parent.mkdir(parents=True, exist_ok=True)
-	settings_path.write_text(json.dumps(existing, indent=2) + "\n", encoding="utf-8")
+	settings_path.write_text(settings.model_dump_json(indent=2) + "\n", encoding="utf-8")
 	print(
 		f"Wrote camas hooks to {settings_path}\n"
 		f"  FileChanged:    {launcher} fix --paths ${{file_path}}\n"

--- a/src/camas/mcp/scaffold.py
+++ b/src/camas/mcp/scaffold.py
@@ -126,7 +126,7 @@ def write_hooks(argv: list[str]) -> int:
 			"hooks": [
 				{
 					"type": "command",
-					"command": f"{launcher} mcp fix --paths ${{file_path}}",
+					"command": f"{launcher} fix --paths ${{file_path}}",
 				}
 			]
 		}
@@ -137,16 +137,17 @@ def write_hooks(argv: list[str]) -> int:
 			"hooks": [
 				{
 					"type": "command",
-					"command": f"{launcher} mcp gate",
+					"command": f"{launcher} gate",
 				}
 			],
 		}
 	]
+	settings_path.parent.mkdir(parents=True, exist_ok=True)
 	settings_path.write_text(json.dumps(existing, indent=2) + "\n", encoding="utf-8")
 	print(
 		f"Wrote camas hooks to {settings_path}\n"
-		f"  FileChanged:    {launcher} mcp fix --paths ${{file_path}}\n"
-		f"  PostToolBatch:  {launcher} mcp gate\n"
+		f"  FileChanged:    {launcher} fix --paths ${{file_path}}\n"
+		f"  PostToolBatch:  {launcher} gate\n"
 		f"\nReload Claude Code for hooks to take effect."
 	)
 	return 0

--- a/src/camas/mcp/scaffold.py
+++ b/src/camas/mcp/scaffold.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import json
+import shlex
 import shutil
 import sys
 from pathlib import Path
@@ -15,6 +16,7 @@ from ..core.timings import ensure_camas_dir
 from ..v0.config import DEFAULT_CAMAS_DIR
 
 SERVER_NAME: Final = "camas"
+SETTINGS_PATH: Final = Path(".claude/settings.json")
 
 
 def write_mcp_json(argv: list[str]) -> int:
@@ -80,9 +82,71 @@ def portability_note(command: str) -> str:
 
 
 def parse_json_object(path: Path) -> dict[str, Any] | None:
-	"""Parse an existing ``.mcp.json`` as a JSON object; ``None`` if unreadable or not one."""
+	"""Parse an existing JSON file as a JSON object; ``None`` if unreadable or not one."""
 	try:
 		loaded: object = json.loads(path.read_text(encoding="utf-8"))
 	except (OSError, json.JSONDecodeError):
 		return None
 	return cast("dict[str, Any]", loaded) if isinstance(loaded, dict) else None
+
+
+def launch_command_str(*, rich: bool) -> str | None:
+	"""The most portable launch command as a single shell string, or ``None``."""
+	pair = launch_command(rich=rich)
+	if pair is None:
+		return None
+	cmd, args = pair
+	return shlex.join((cmd, *args))
+
+
+def write_hooks(argv: list[str]) -> int:
+	"""Write ``FileChanged`` / ``PostToolBatch`` hook entries into ``.claude/settings.json``
+	using the same ``launch_command()`` resolution as the MCP server entry.
+	"""
+	settings_path = Path.cwd() / SETTINGS_PATH
+	existing = parse_json_object(settings_path) if settings_path.exists() else {}
+	if existing is None:
+		print(f"error: {settings_path} is not a readable JSON object", file=sys.stderr)
+		return 2
+	launcher = launch_command_str(rich="--rich" in argv)
+	if launcher is None:
+		print(
+			f"error: cannot write portable hooks — no uv.lock found and camas is not "
+			"on PATH.\n  Add camas to a uv project (uv add camas) or install it on PATH, "
+			"then retry.",
+			file=sys.stderr,
+		)
+		return 2
+	hooks = existing.setdefault("hooks", {})
+	if not isinstance(hooks, dict):
+		print(f"error: {settings_path} has a non-object 'hooks'", file=sys.stderr)
+		return 2
+	hooks["FileChanged"] = [
+		{
+			"hooks": [
+				{
+					"type": "command",
+					"command": f"{launcher} mcp fix --paths ${{file_path}}",
+				}
+			]
+		}
+	]
+	hooks["PostToolBatch"] = [
+		{
+			"matcher": "Edit|Write|MultiEdit|NotebookEdit",
+			"hooks": [
+				{
+					"type": "command",
+					"command": f"{launcher} mcp gate",
+				}
+			],
+		}
+	]
+	settings_path.write_text(json.dumps(existing, indent=2) + "\n", encoding="utf-8")
+	print(
+		f"Wrote camas hooks to {settings_path}\n"
+		f"  FileChanged:    {launcher} mcp fix --paths ${{file_path}}\n"
+		f"  PostToolBatch:  {launcher} mcp gate\n"
+		f"\nReload Claude Code for hooks to take effect."
+	)
+	return 0

--- a/tests/mcp/test_scaffold.py
+++ b/tests/mcp/test_scaffold.py
@@ -211,15 +211,23 @@ def test_write_hooks_errors_on_malformed_settings(
 	assert write_hooks([]) == 2
 
 
+def test_write_hooks_errors_on_non_object_root(
+	tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+	monkeypatch.chdir(tmp_path)
+	monkeypatch.setattr("shutil.which", _which("camas"))
+	(tmp_path / ".claude").mkdir(parents=True)
+	(tmp_path / ".claude" / "settings.json").write_text("[]")
+	assert write_hooks([]) == 2
+
+
 def test_write_hooks_errors_on_non_object_hooks(
 	tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
 	monkeypatch.chdir(tmp_path)
 	monkeypatch.setattr("shutil.which", _which("camas"))
 	(tmp_path / ".claude").mkdir(parents=True)
-	(tmp_path / ".claude" / "settings.json").write_text(
-		json.dumps({"hooks": "not an object"})
-	)
+	(tmp_path / ".claude" / "settings.json").write_text(json.dumps({"hooks": "not an object"}))
 	assert write_hooks([]) == 2
 
 

--- a/tests/mcp/test_scaffold.py
+++ b/tests/mcp/test_scaffold.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from camas.mcp.scaffold import write_mcp_json
+from camas.mcp.scaffold import launch_command_str, write_hooks, write_mcp_json
 
 if TYPE_CHECKING:
 	from collections.abc import Callable
@@ -149,3 +149,103 @@ def test_mcp_unexpected_arg_errors(capsys: pytest.CaptureFixture[str]) -> None:
 		main(["serve"])
 	assert exc.value.code == 2
 	assert "unexpected argument" in capsys.readouterr().err
+
+
+def test_launch_command_str_uv_project(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+	monkeypatch.chdir(tmp_path)
+	(tmp_path / "uv.lock").write_text("")
+	monkeypatch.setattr("shutil.which", _which("uv", "camas"))
+	assert launch_command_str(rich=False) == "uv run camas mcp"
+
+
+def test_launch_command_str_camas_on_path(monkeypatch: pytest.MonkeyPatch) -> None:
+	monkeypatch.setattr("shutil.which", _which("camas"))
+	assert launch_command_str(rich=False) == "camas mcp"
+
+
+def test_launch_command_str_rich(monkeypatch: pytest.MonkeyPatch) -> None:
+	monkeypatch.setattr("shutil.which", _which("camas"))
+	assert launch_command_str(rich=True) == "camas mcp --rich"
+
+
+def test_launch_command_str_none_when_no_launcher(monkeypatch: pytest.MonkeyPatch) -> None:
+	monkeypatch.setattr("shutil.which", _which())
+	assert launch_command_str(rich=False) is None
+
+
+def test_write_hooks_writes_settings_json(
+	tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+	monkeypatch.chdir(tmp_path)
+	monkeypatch.setattr("shutil.which", _which("camas"))
+	assert write_hooks([]) == 0
+	settings = json.loads((tmp_path / ".claude" / "settings.json").read_text())
+	file_changed = settings["hooks"]["FileChanged"][0]["hooks"][0]
+	assert file_changed["type"] == "command"
+	assert file_changed["command"] == "camas mcp fix --paths ${file_path}"
+	post_tool = settings["hooks"]["PostToolBatch"][0]["hooks"][0]
+	assert post_tool["type"] == "command"
+	assert post_tool["command"] == "camas mcp gate"
+	assert "Wrote camas hooks" in capsys.readouterr().out
+
+
+def test_write_hooks_errors_when_no_launcher(
+	tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+	monkeypatch.chdir(tmp_path)
+	monkeypatch.setattr("shutil.which", _which())
+	assert write_hooks([]) == 2
+	err = capsys.readouterr().err
+	assert "not on PATH" in err
+	assert "uv add camas" in err
+	assert not (tmp_path / ".claude" / "settings.json").exists()
+
+
+def test_write_hooks_errors_on_malformed_settings(
+	tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+	monkeypatch.chdir(tmp_path)
+	monkeypatch.setattr("shutil.which", _which("camas"))
+	(tmp_path / ".claude").mkdir(parents=True)
+	(tmp_path / ".claude" / "settings.json").write_bytes(b"\x00not json")
+	assert write_hooks([]) == 2
+
+
+def test_write_hooks_errors_on_non_object_hooks(
+	tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+	monkeypatch.chdir(tmp_path)
+	monkeypatch.setattr("shutil.which", _which("camas"))
+	(tmp_path / ".claude").mkdir(parents=True)
+	(tmp_path / ".claude" / "settings.json").write_text(
+		json.dumps({"hooks": "not an object"})
+	)
+	assert write_hooks([]) == 2
+
+
+def test_write_hooks_merges_existing_settings(
+	tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+	monkeypatch.chdir(tmp_path)
+	monkeypatch.setattr("shutil.which", _which("camas"))
+	(tmp_path / ".claude").mkdir(parents=True)
+	(tmp_path / ".claude" / "settings.json").write_text(
+		json.dumps({"other_key": "value", "hooks": {}})
+	)
+	assert write_hooks([]) == 0
+	settings = json.loads((tmp_path / ".claude" / "settings.json").read_text())
+	assert settings["other_key"] == "value"
+	assert "FileChanged" in settings["hooks"]
+
+
+def test_mcp_cli_init_hooks_routes_to_write_hooks(
+	tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+	from camas.mcp.cli import main
+
+	monkeypatch.chdir(tmp_path)
+	monkeypatch.setattr("shutil.which", _which("camas"))
+	with pytest.raises(SystemExit) as exc:
+		main(["init", "--hooks"])
+	assert exc.value.code == 0
+	assert (tmp_path / ".claude" / "settings.json").exists()


### PR DESCRIPTION
> [!WARNING]
> **LLM Disclosure**
>
> This post was authored by deepseek-v4-pro on behalf of @JPHutchins. Add --hooks flag to camas mcp init for writing FileChanged/PostToolBatch hooks.

## Summary

`camas mcp init` writes the `.mcp.json` server entry but not the hook entries that drive the agent integration. The hooks live only in the plugin cache which hardcodes bare `camas` and is overwritten on plugin update.

## Changes

- `camas mcp init --hooks` writes `FileChanged` and `PostToolBatch` hook commands into `.claude/settings.json`
- Uses the same `launch_command()` resolution as the server entry (`uv run camas` in uv projects, `camas` on PATH)
- Merges into existing settings.json without overwriting other hooks

Fixes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)