### PR TITLE
docs: add Claude agent integration to tutorial and --init starter

### DIFF
--- a/src/camas/__init__.py
+++ b/src/camas/__init__.py
@@ -329,6 +329,39 @@ https://github.com/JPHutchins/camas/blob/main/tests
 
 Effect protocol: subclass ``Effect`` (see ``examples/effect-plugin/``). Per-task
 help: ``camas <task> --help``.
+
+**Agent integration** (the camas Claude Code plugin)::
+
+    from camas import Claude, Config
+    from camas.v0.task import AgentFormat
+
+    # The deterministic, behavior-preserving autofix node the FileChanged
+    # hook runs on every edit (scoped, zero tokens). Mutates=True so
+    # --under runs it first; paths= so it scopes to the changed file.
+    autofix = Parallel(
+        Task("ruff format {paths}", mutates=True, paths="."),
+        Task("ruff check --fix {paths}", mutates=True, paths="."),
+    )
+
+    # The check node the PostToolBatch gate runs. When a leaf carries
+    # agent_format=, the gate appends those flags (machine-readable output
+    # like sarif or junit) so the agent gets structured diagnostics; a
+    # human ``camas lint`` never sees these extra flags.
+    checks = Parallel(
+        Task("ruff check .",
+             agent_format=AgentFormat("--output-format sarif", "sarif")),
+        Task("pytest",
+             agent_format=AgentFormat("--junitxml=-", "junit")),
+    )
+
+    _ = Config(default_task=checks, agent=Claude(fix=autofix))
+    # agent.check defaults to default_task; set explicitly to gate a
+    # different node: agent=Claude(fix=autofix, check=fast_checks)
+
+The plugin's ``FileChanged`` hook runs ``camas mcp fix --paths <file>`` on
+every edit. ``PostToolBatch`` runs ``camas mcp gate`` after tool batches,
+scoping the check node to the changed files and time-boxing by ``--under``.
+The gate is read-only (it never mutates); the fixers do all mutation.
 """
 
 import typing

--- a/src/camas/main/starter.py
+++ b/src/camas/main/starter.py
@@ -52,12 +52,30 @@ ci = Sequential(
 # free. Replace the placeholder with your real fixers, e.g.:
 #   autofix = Task("ruff check --fix {paths}", mutates=True, paths=".")
 #   autofix = Parallel(Task("ruff format {paths}", mutates=True), Task("ruff check --fix {paths}", mutates=True), paths=".")
+#
+# Mark mutating leaves mutates=True so --under runs them first in sequence (fast inner loop).
+# paths= lets {paths} be injected with the changed file — the scope the FileChanged hook passes.
 autofix = Task('python -c "" {paths}', name="autofix", mutates=True, paths=".")
+
+# AgentFormat appends structured-output flags when the GATE runs a leaf — the agent reads
+# machine-readable diagnostics (sarif, junit, etc.) instead of scraped text. A human
+# `camas lint` never sees these extra flags, so the cmd shown in --list stays clean.
+#   from camas.v0.task import AgentFormat
+#   lint = Task("ruff check .", agent_format=AgentFormat("--output-format sarif", "sarif"))
 
 # Config is discovered by type, under any binding name (here `_`): bare `camas` runs
 # default_task — or github_task under GitHub Actions, falling back to default_task when unset.
-# agent= wires the Claude Code plugin: agent.fix is the registered FileChanged autofix node
-# above; the gate checks default_task (override with Claude(fix=..., check=...)).
+#
+# agent= wires the Claude Code plugin's two-hook gate:
+#   fix:   the deterministic autofix node above — the FileChanged hook runs it on every edit
+#          (`camas mcp fix --paths <file>`). Declared explicitly, never derived from mutates=
+#          (a mutating leaf may be codegen, not a fixer).
+#   check: the node the PostToolBatch gate checks (`camas mcp gate`). None (the default)
+#          defers to default_task; set it to a different node for a faster gate subset.
+#
+# The gate scopes check leaves to the changed paths, appends their agent_format args (if any),
+# time-boxes by --under, and classifies the residual green vs needs_reasoning. The gate never
+# mutates — all mutation lives in the fix node on FileChanged.
 _ = Config(default_task=ci, agent=Claude(fix=autofix))
 
 # The PEP 723 standalone flow (see the docstring): running this file directly


### PR DESCRIPTION
> [!WARNING]
> **LLM Disclosure**
>
> This post was authored by deepseek-v4-pro on behalf of @JPHutchins. Add Claude agent integration documentation to the camas_docs tutorial and --init starter template.

## Summary

The `camas_docs` tutorial and `camas --init` starter never mentioned the Claude/agent integration — `Config(agent=Claude(fix=..., check=...))`, `AgentFormat`, or the two-hook gate model.

## Changes

- **starter.py**: Added agent integration comments explaining `Claude(fix=, check=)`, `AgentFormat`, and the two-hook model
- **\_\_init\_\_.py tutorial**: Added a section on the agent integration with a worked example

Fixes #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)