### PR TITLE
feat(mcp): add --dry-run to camas mcp gate and mcp fix

### DIFF
--- a/src/camas/main/dispatch.py
+++ b/src/camas/main/dispatch.py
@@ -22,7 +22,7 @@ from ..core import timings
 from ..core.budget import plan_under
 from ..core.execution import run
 from ..core.matrix import expand_matrix, matrix_axes, override_matrix
-from ..core.render import print_tree
+from ..core.render import print_tree, render_tree_lines
 from ..core.scope import scope_to_changed, to_changed, with_default_paths
 from ..core.task import task_label
 from ..v0.config import Config
@@ -153,6 +153,12 @@ def fix_cli(argv: list[str]) -> int:
 		metavar="PATH",
 		help="changed path to scope to (repeatable)",
 	)
+	parser.add_argument(
+		"--dry-run",
+		action="store_true",
+		default=False,
+		help="print the resolved path-scoped leaf plan without executing",
+	)
 	args = parser.parse_args(argv)
 	state, _ = resolve_tasks_source([])
 	if not isinstance(state, LoadOk) or state.config is None:
@@ -164,6 +170,13 @@ def fix_cli(argv: list[str]) -> int:
 	changed = to_changed(args.paths, base)
 	expanded = expand_matrix(node)
 	scoped = scope_to_changed(expanded, changed) if changed else with_default_paths(expanded)
+	if args.dry_run:
+		if scoped is None:
+			print("No leaves cover the changed paths — nothing would run.")
+		else:
+			plan = "\n".join(render_tree_lines(scoped, show_cmd=True, color=False))
+			print(f"Dry run — resolved path-scoped plan, nothing executed:\n{plan}")
+		return 0
 	if scoped is None:
 		return 0
 	return finish_run(asyncio.run(run(scoped, effects=(), jobs=None)))

--- a/src/camas/mcp/serve.py
+++ b/src/camas/mcp/serve.py
@@ -967,7 +967,9 @@ def parse_gate_args(argv: list[str]) -> GateArgs:
 		help="print the resolved path-scoped leaf plan without executing",
 	)
 	ns = parser.parse_args(argv)
-	return GateArgs(task=ns.task, paths=tuple(ns.paths), under=ns.under, jobs=ns.jobs, dry_run=ns.dry_run)
+	return GateArgs(
+		task=ns.task, paths=tuple(ns.paths), under=ns.under, jobs=ns.jobs, dry_run=ns.dry_run
+	)
 
 
 def _event_get(obj: object, key: str) -> object:
@@ -1031,9 +1033,7 @@ def run_gate_cli(
 	changed = to_changed(args.paths or changed_from_stdin(), base)
 	if args.dry_run:
 		expanded = expand_matrix(node)
-		scoped = (
-			scope_to_changed(expanded, changed) if changed else with_default_paths(expanded)
-		)
+		scoped = scope_to_changed(expanded, changed) if changed else with_default_paths(expanded)
 		if scoped is None:
 			print("No leaves cover the changed paths — nothing would run.")
 		else:

--- a/src/camas/mcp/serve.py
+++ b/src/camas/mcp/serve.py
@@ -29,9 +29,9 @@ from ..core import timings
 from ..core.budget import plan_under
 from ..core.execution import run
 from ..core.gate import run_gate
-from ..core.matrix import override_matrix
+from ..core.matrix import expand_matrix, override_matrix
 from ..core.render import render_tree_lines, strip_ansi
-from ..core.scope import to_changed
+from ..core.scope import scope_to_changed, to_changed, with_default_paths
 from ..core.task import task_label
 from ..main.argv import apply_passthrough
 from ..main.format import format_load_error_hint
@@ -938,6 +938,7 @@ class GateArgs(NamedTuple):
 	paths: tuple[str, ...]
 	under: float | None
 	jobs: int | None
+	dry_run: bool = False
 
 
 def parse_gate_args(argv: list[str]) -> GateArgs:
@@ -959,8 +960,14 @@ def parse_gate_args(argv: list[str]) -> GateArgs:
 		"--under", type=float, default=None, metavar="SECONDS", help="wall-clock budget"
 	)
 	parser.add_argument("--jobs", type=int, default=None, metavar="N", help="max concurrent leaves")
+	parser.add_argument(
+		"--dry-run",
+		action="store_true",
+		default=False,
+		help="print the resolved path-scoped leaf plan without executing",
+	)
 	ns = parser.parse_args(argv)
-	return GateArgs(task=ns.task, paths=tuple(ns.paths), under=ns.under, jobs=ns.jobs)
+	return GateArgs(task=ns.task, paths=tuple(ns.paths), under=ns.under, jobs=ns.jobs, dry_run=ns.dry_run)
 
 
 def _event_get(obj: object, key: str) -> object:
@@ -1022,6 +1029,17 @@ def run_gate_cli(
 		print(f"camas mcp gate: {e}", file=sys.stderr)
 		return 2
 	changed = to_changed(args.paths or changed_from_stdin(), base)
+	if args.dry_run:
+		expanded = expand_matrix(node)
+		scoped = (
+			scope_to_changed(expanded, changed) if changed else with_default_paths(expanded)
+		)
+		if scoped is None:
+			print("No leaves cover the changed paths — nothing would run.")
+		else:
+			plan = "\n".join(render_tree_lines(scoped, show_cmd=True, color=False))
+			print(f"Dry run — resolved path-scoped plan, nothing executed:\n{plan}")
+		return 0
 	camas_dir = (config if config is not None else Config()).camas_path(base)
 	outcome = asyncio.run(
 		run_gate(node, changed, under=args.under, jobs=args.jobs, timings=timings.load(camas_dir))

--- a/tests/main/test_dispatch.py
+++ b/tests/main/test_dispatch.py
@@ -336,6 +336,28 @@ def test_fix_cli_noop_when_scope_covers_nothing(
 	assert not (tmp_path / "fixed.txt").exists()
 
 
+def test_fix_cli_dry_run_shows_plan(
+	tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+	(tmp_path / "tasks.py").write_text(_TIDY.format(scope="."))
+	monkeypatch.chdir(tmp_path)
+	assert fix_cli(["--paths", "x.py", "--dry-run"]) == 0
+	out = capsys.readouterr().out
+	assert "Dry run" in out
+	assert not (tmp_path / "fixed.txt").exists()
+
+
+def test_fix_cli_dry_run_no_match(
+	tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+	(tmp_path / "tasks.py").write_text(_TIDY.format(scope="src"))
+	monkeypatch.chdir(tmp_path)
+	assert fix_cli(["--paths", "docs/readme.md", "--dry-run"]) == 0
+	out = capsys.readouterr().out
+	assert "No leaves cover" in out
+	assert "nothing would run" in out
+
+
 def test_dispatch_paths_scopes_to_changed(capsys: pytest.CaptureFixture[str]) -> None:
 	task = Task("ruff check {paths}", name="lint", paths=".")
 	with pytest.raises(SystemExit, match="0"):

--- a/tests/mcp/test_gate_cli.py
+++ b/tests/mcp/test_gate_cli.py
@@ -169,3 +169,30 @@ def test_changed_from_stdin_dict_without_tool_calls(monkeypatch: pytest.MonkeyPa
 def test_changed_from_stdin_non_dict_event(monkeypatch: pytest.MonkeyPatch) -> None:
 	monkeypatch.setattr("sys.stdin", io.StringIO(json.dumps([1, 2])))
 	assert serve.changed_from_stdin() == ()
+
+
+def test_gate_cli_dry_run_shows_plan(
+	tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+	_chdir_project(tmp_path, monkeypatch, "FIXME")
+	(tmp_path / "sample.py").write_text("ok = 1\n")
+	assert serve.gate_cli(["--paths", "sample.py", "--dry-run"]) == 0
+	out = capsys.readouterr().out
+	assert "Dry run" in out
+	assert "check" in out
+
+
+def test_gate_cli_dry_run_no_match(
+	tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+	monkeypatch.delenv("CLAUDE_PROJECT_DIR", raising=False)
+	monkeypatch.chdir(tmp_path)
+	(tmp_path / "tasks.py").write_text(
+		"from camas import Config, Task\n"
+		'check = Task("echo scope-miss", name="check", paths="src")\n'
+		"_ = Config(default_task=check)\n"
+	)
+	assert serve.gate_cli(["--paths", "unrelated.txt", "--dry-run"]) == 0
+	out = capsys.readouterr().out
+	assert "No leaves cover" in out
+	assert "nothing would run" in out


### PR DESCRIPTION
> [!WARNING]
> **LLM Disclosure**
>
> This post was authored by deepseek-v4-pro on behalf of @JPHutchins. Add --dry-run flag to camas mcp gate and fix for previewing resolved path-scoped leaf plans.

## Summary

Scoped runs (`camas mcp gate --paths`, `camas mcp fix --paths`) were silent on success with no way to see which leaves were selected. `--dry-run` now prints the resolved path-scoped leaf plan without executing.

## Changes

- `camas mcp fix --dry-run`: resolves the fix node, scopes to changed paths, prints the plan
- `camas mcp gate --dry-run`: resolves the check node, scopes to changed paths, prints the plan

Example:
```
$ camas mcp gate --dry-run --paths src/x.ts
Dry run — resolved path-scoped plan, nothing executed:
ts_check:
  npm run lint   (src/)
  npm run test   (src/)
rust_check: pruned (no changed paths under scope)
```

Fixes #102

🤖 Generated with [Claude Code](https://claude.com/claude-code)