### PR TITLE
fix(plugin): gate is agent-orchestrated, not a PostToolBatch hook (closes #97)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
     {
       "name": "camas",
       "source": "./agent/claude/plugin",
-      "description": "The camas gate \u2014 deterministic autofix on every change, plus residual-only surfacing after each batch."
+      "description": "The camas gate \u2014 deterministic autofix on every change, plus a cheap fixer subagent that drives changed files to green off the main agent's context."
     }
   ]
 }

--- a/agent/claude/plugin/.claude-plugin/plugin.json
+++ b/agent/claude/plugin/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "camas",
-  "description": "The camas gate: applies the deterministic fixes for free after each change, and surfaces only the residual that needs reasoning.",
+  "description": "The camas gate: applies deterministic fixes for free on every change, and the check-and-fix loop is delegated to a cheap fixer subagent, so only the residual that needs reasoning reaches the main agent.",
   "version": "0.1.0"
 }

--- a/agent/claude/plugin/agents/camas-fixer.md
+++ b/agent/claude/plugin/agents/camas-fixer.md
@@ -1,20 +1,20 @@
 ---
 name: camas-fixer
-description: Resolves a camas gate `needs_reasoning` residual on a cheap model, off the main agent's context — fixes the scoped files and re-gates that same scope in a loop within a bounded turn budget, then hands any unresolved residual back. Invoke it when the gate surfaces a residual, passing the gate's rerun scope (its changed paths).
+description: Drives a scope of changed files to a green camas gate on a cheap model, off the main agent's context — gates the scope, fixes what fails, and re-gates in a bounded loop, then hands back any residual it cannot settle. Delegate to it after a batch of edits with the changed paths as its scope; spawn one per independent scope to run them in parallel, and run it in the background so it never blocks your reasoning.
 model: haiku
 maxTurns: 5
 tools: Read, Edit, Bash, mcp__camas__camas_gate
 ---
 
-You resolve camas gate residuals cheaply, so the main agent spends no reasoning on what a
-fix-and-recheck loop can settle. You are given the failing diagnostics and the scope that
-produced them — the gate's `rerun` handle: the changed paths (and task) it ran over. Loop:
+You drive a scope of changed files to a green camas gate cheaply, so the main agent spends no
+reasoning on what a fix-and-recheck loop can settle. You are given the changed paths to work
+over (and, when the main agent already ran the gate, its failing diagnostics). Loop:
 
-1. Read the diagnostics, edit the code to fix the underlying cause, and re-gate the SAME scope:
-   run `camas mcp gate --paths <the changed paths you were given>` (do not widen the scope —
-   re-gate exactly what was handed to you).
+1. Gate the scope: run `camas mcp gate --paths <the changed paths you were given>` to see what
+   fails — do not widen the scope, gate exactly what was handed to you.
 2. If it comes back green (exit 0), you are done — say so.
-3. If it still fails, refine and re-gate. Repeat until green or you run out of turns.
+3. If it still fails, read the diagnostics, edit the code to fix the underlying cause, and
+   re-gate the same scope. Repeat until green or you run out of turns.
 
 Never change behavior, and never mask a diagnostic — do not suppress, disable, loosen, or
 ignore a check to make the gate pass. A green gate must mean the code is actually correct.

--- a/agent/claude/plugin/skills/gate/SKILL.md
+++ b/agent/claude/plugin/skills/gate/SKILL.md
@@ -1,29 +1,28 @@
 ---
 name: gate
-description: How the camas gate works — the two deterministic layers, how a needs_reasoning residual is delegated to the cheap fixer, and the no-masking rule.
+description: Keep the workspace green while you edit — the free FileChanged autofix, and delegating the check-and-fix loop to the camas-fixer subagent so residuals never spend your reasoning. Read after a batch of edits and before declaring work done.
 ---
 
-The camas gate keeps the workspace green as you edit, in two deterministic layers — both
-driven by what the project declares in `Config.agent`:
+The camas gate keeps the workspace green as you edit, in two layers — both driven by what the
+project declares in `Config.agent`:
 
-- **Fix (FileChanged, scoped).** On every file change, a `FileChanged` hook runs
-  `camas mcp fix --paths <file>` — which runs the node the project *registered* as
-  `Config.agent.fix` (its mutating, behavior-preserving auto-fixers: formatters, `--fix`
-  linters, named whatever the author chose), scoped to that file, at zero model tokens. It
-  never asks you anything; with no fix registered it is a no-op.
-- **Check (PostToolBatch, scoped).** After each batch of edits, a `PostToolBatch` hook runs
-  `camas mcp gate` over the just-edited files. The gate is read-only — it does NOT fix — it
-  runs the project's check node (`Config.agent.check`, else the default task) scoped to those
-  files and returns a binary verdict: `green` (the checks pass) or `needs_reasoning` (a check
-  still fails), with the failing diagnostics.
+- **Fix (automatic, free).** A `FileChanged` hook runs `camas mcp fix --paths <file>` on every
+  file change — the node the project registered as `Config.agent.fix` (its mutating,
+  behavior-preserving auto-fixers: formatters, `--fix` linters), scoped to that file, at zero
+  model tokens. It never asks you anything; with no fix registered it is a no-op.
+- **Check (you delegate — there is no check hook).** The check node (`Config.agent.check`,
+  else the default task) is read-only: it runs the project's checks and classifies the result
+  `green` or `needs_reasoning`. After a batch of edits, and before you declare work done,
+  **delegate the check-and-fix loop to the `camas-fixer` subagent** rather than running the
+  checks and chasing residuals in your own context.
 
-When the gate returns `needs_reasoning`, delegate it to the `camas-fixer` subagent before
-reasoning about the failure yourself — and hand it the gate's **`rerun`** handle (its
-`{task, paths, under}`, also printed as the `camas mcp gate …` re-run command). That tells the
-fixer exactly which scope to re-gate: it loops fix → `camas mcp gate --paths <those paths>` on
-a cheap model, off your context, within a bounded turn budget, so the loop never costs your
-tokens. It hands back only what it could not settle: if its final message says the gate is
-green, the work is done; if it quotes remaining diagnostics, those actually need your reasoning.
+Delegate by spawning `camas-fixer` with the changed paths as its scope. It gates that scope,
+fixes what it can, and re-gates in a loop on a cheap model, in its own context window — so the
+loop costs you no reasoning and only its final result returns. Run it in the background and
+keep working; for independent changed scopes, spawn one fixer per scope so they run in
+parallel. Each fixer hands back only what it could not settle: a green result means that scope
+is done; a result quoting remaining diagnostics is the residual that needs your reasoning —
+take it from there.
 
-Never mask a residual — yours or the fixer's: do not suppress, disable, or loosen a check to
+Never mask a residual — yours or a fixer's: do not suppress, disable, or loosen a check to
 make the gate pass. A green gate must mean the work is actually correct.

--- a/src/camas/core/gate.py
+++ b/src/camas/core/gate.py
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: 2026 JP Hutchins
 
 """The SA-delegation gate: scope the check node to the changed paths, run the checks, and
-classify the residual ``green`` vs ``needs_reasoning`` for a ``PostToolBatch`` hook. The gate
+classify the residual ``green`` vs ``needs_reasoning``. The gate
 never mutates — the deterministic fixers run separately on ``FileChanged`` (``camas fix``).
 """
 
@@ -51,7 +51,7 @@ class GateOutcome(NamedTuple):
 
 
 def decision_of(residual_class: ResidualClass) -> Decision:
-	"""The ``PostToolBatch`` routing for a class: a surviving residual blocks, else continue.
+	"""The routing for a residual class: a surviving residual blocks, else continue.
 
 	>>> decision_of("green"), decision_of("needs_reasoning")
 	('continue', 'block')

--- a/src/camas/core/scope.py
+++ b/src/camas/core/scope.py
@@ -43,7 +43,7 @@ def to_changed(raw: Iterable[str], base: Path) -> tuple[str, ...]:
 	"""Normalize externally-supplied changed paths to the repo-relative POSIX form
 	:func:`scope_to_changed` matches: resolve each against ``base`` (a hook's ``${file_path}``
 	is absolute), drop any that fall outside it. The boundary every changed set passes through —
-	the CLI ``--paths``, the gate request, and the ``PostToolBatch`` event all carry raw paths.
+	the CLI ``--paths``, the ``camas_gate`` request, and a hook's files all carry raw paths.
 
 	>>> import tempfile, os
 	>>> d = Path(tempfile.mkdtemp()); _ = (d / "src").mkdir()

--- a/src/camas/mcp/cli.py
+++ b/src/camas/mcp/cli.py
@@ -19,8 +19,8 @@ Usage:
   camas mcp fix [--paths P]… run the registered agent fix node (Config.agent.fix) over the
                               changed paths — the FileChanged autofix; no-op if unregistered
   camas mcp gate [task]     run the gate once, headless — print the verdict as JSON, exit
-    [--paths P]… [--under N]  0 (continue) / 2 (block); scope to --paths or a PostToolBatch
-                              event on stdin (the command-hook entry; parallel + benchmark)
+    [--paths P]… [--under N]  0 (continue) / 2 (block); scope to --paths or a piped
+                              PostToolBatch event (the camas-fixer subagent + benchmark)
 
 Options:
   --rich        emit the 2025-11-25 tool fields (title, annotations, outputSchema) and

--- a/src/camas/mcp/scaffold.py
+++ b/src/camas/mcp/scaffold.py
@@ -128,8 +128,8 @@ def launch_command_str(*, rich: bool) -> str | None:
 
 
 def write_hooks(argv: list[str]) -> int:
-	"""Write ``FileChanged`` / ``PostToolBatch`` hook entries into ``.claude/settings.json``
-	using the same ``launch_command()`` resolution as the MCP server entry.
+	"""Write the ``FileChanged`` autofix hook into ``.claude/settings.json`` using the same
+	``launch_command()`` resolution as the MCP server entry.
 	"""
 	settings_path = Path.cwd() / SETTINGS_PATH
 	try:
@@ -166,23 +166,11 @@ def write_hooks(argv: list[str]) -> int:
 			]
 		)
 	]
-	settings.hooks["PostToolBatch"] = [
-		HookGroup(
-			matcher="Edit|Write|MultiEdit|NotebookEdit",
-			hooks=[
-				HookCommand(
-					type="command",
-					command=f"{launcher} gate",
-				)
-			],
-		)
-	]
 	settings_path.parent.mkdir(parents=True, exist_ok=True)
 	settings_path.write_text(settings.model_dump_json(indent=2) + "\n", encoding="utf-8")
 	print(
-		f"Wrote camas hooks to {settings_path}\n"
+		f"Wrote the camas FileChanged autofix hook to {settings_path}\n"
 		f"  FileChanged:    {launcher} fix --paths ${{file_path}}\n"
-		f"  PostToolBatch:  {launcher} gate\n"
-		f"\nReload Claude Code for hooks to take effect."
+		f"\nReload Claude Code for the hook to take effect."
 	)
 	return 0

--- a/src/camas/mcp/serve.py
+++ b/src/camas/mcp/serve.py
@@ -349,7 +349,7 @@ def tools(task_names: tuple[str, ...], compat: Compat) -> Tools:
 			compat,
 			name=ToolName.GATE.value,
 			description=textwrap.dedent("""\
-				The SA-delegation gate, for a PostToolBatch hook: scope THIS project's checks to the
+				The SA-delegation gate: scope THIS project's checks to the
 				files just changed, run them, and return a binary verdict. It does not mutate — the
 				deterministic fixers run separately on FileChanged (camas fix). residual_class is
 				'green' (decision 'continue') when the checks pass, or 'needs_reasoning' (decision
@@ -987,7 +987,7 @@ def _event_get(obj: object, key: str) -> object:
 
 
 def changed_from_stdin() -> tuple[str, ...]:
-	"""The edited files in a ``PostToolBatch`` event piped on stdin (the command-hook delivery),
+	"""The edited files in a ``PostToolBatch`` event piped on stdin (e.g. a hand-wired hook),
 	de-duplicated in order; ``()`` when stdin is a tty, empty, or not such an event.
 	"""
 	if sys.stdin.isatty():
@@ -1014,8 +1014,8 @@ def gate_cli(argv: list[str]) -> int:
 	"""Run the gate once, headless: scope this project's checks to the changed paths (``--paths``,
 	else the files in a ``PostToolBatch`` event on stdin), print the ``GateResponse`` as JSON to
 	stdout, and exit ``0`` (continue) / ``2`` (block) — on a block the agent-facing summary goes
-	to stderr. The process-isolated, machine-readable gate entry: the ``PostToolBatch`` command
-	hook, parallel fixers, and the benchmark all drive it.
+	to stderr. The process-isolated, machine-readable gate entry that the camas-fixer subagent
+	(via Bash) and the benchmark drive.
 	"""
 	args = parse_gate_args(argv)
 	base = project_base()

--- a/src/camas/mcp/wire.py
+++ b/src/camas/mcp/wire.py
@@ -225,7 +225,7 @@ class GateRequest(BaseModel):
 
 	paths: list[str] = Field(
 		default_factory=list,
-		description="Changed paths to scope the gate to — a FileChanged/PostToolBatch hook's "
+		description="Changed paths to scope the gate to — the camas-fixer subagent passes the "
 		"edited files. Empty gates the whole task; each leaf's {paths} is injected with the "
 		"files it covers and leaves covering nothing are dropped.",
 	)
@@ -274,7 +274,7 @@ class GateResponse(BaseModel):
 	"""The SA-delegation gate's verdict: how to route the batch, and the residual that decided it."""
 
 	decision: Literal["continue", "block"]
-	"""``block`` when a residual needs reasoning (a PostToolBatch hook surfaces it), else ``continue``."""
+	"""``block`` when a residual needs reasoning, else ``continue`` when the checks pass."""
 	residual_class: Literal["green", "needs_reasoning"]
 	diagnostics: tuple[AgentEnvelope, ...] | None = None
 	"""The failing leaves as AgentJSON envelopes (failures-only); null when the checks pass."""

--- a/tests/mcp/test_scaffold.py
+++ b/tests/mcp/test_scaffold.py
@@ -183,10 +183,8 @@ def test_write_hooks_writes_settings_json(
 	file_changed = settings["hooks"]["FileChanged"][0]["hooks"][0]
 	assert file_changed["type"] == "command"
 	assert file_changed["command"] == "camas mcp fix --paths ${file_path}"
-	post_tool = settings["hooks"]["PostToolBatch"][0]["hooks"][0]
-	assert post_tool["type"] == "command"
-	assert post_tool["command"] == "camas mcp gate"
-	assert "Wrote camas hooks" in capsys.readouterr().out
+	assert "PostToolBatch" not in settings["hooks"]
+	assert "FileChanged autofix hook" in capsys.readouterr().out
 
 
 def test_write_hooks_errors_when_no_launcher(

--- a/tests/plugin/test_gate_e2e.py
+++ b/tests/plugin/test_gate_e2e.py
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: 2026 JP Hutchins
 
 """End-to-end gate "sandbox": a real tasks.py in a tmp project, driven through the
-``camas_gate`` MCP tool (what the plugin's PostToolBatch hook calls). The gate is check-only —
+``camas_gate`` MCP tool (what the camas-fixer subagent runs). The gate is check-only —
 it runs the project's check node over the workspace and classifies green vs needs_reasoning,
 and it never mutates. tmp_path is auto-removed."""
 


### PR DESCRIPTION
## What

`#107` disabled the synchronous `PostToolBatch` gate hook — correctly: a Claude Code command hook runs to completion before the agent continues, and `decision:"block"` halts it, so it can't express the parallel-background-fixer model. But the docs (and `camas mcp init --hooks`) still **described and installed** that hook. This aligns everything with the chosen design (`#101`): **the main agent delegates the check-and-fix loop to background `camas-fixer` subagents, scoped to the changed paths, off its own context** — there is no check hook.

## Changes

- **`camas mcp init --hooks` no longer writes the `PostToolBatch` gate hook** (only the `FileChanged` autofix). This removes the install path that hit `#97` (invalid `decision:"continue"` errored every green run) and the `#101` stall. (`scaffold.py` + test.)
- **Plugin agent docs rewritten to the background-subagent model** (`SKILL.md`, `camas-fixer.md`): no check hook; after a batch of edits, delegate to `camas-fixer` with the changed paths, run it in the background, spawn one per independent scope to parallelize. Context-isolation, parallelism, and backgrounding verified against current Claude Code docs.
- **Plugin manifests** (`plugin.json`, `marketplace.json`): dropped "residual surfacing after each batch" (the removed hook) for the delegated fixer subagent.
- **De-hooked the gate descriptions/docstrings** that framed it as PostToolBatch-driven (`serve.py`, `wire.py`, `cli.py`, `core/gate.py`, `core/scope.py`). The gate's *behavior* is unchanged; only the framing.

## Validation

`camas run check` (format, lint, mypy, pyright, ty, zuban, pyrefly, tests + doctests) and `camas run coverage` (100%) both green.

Closes #97. Closes #101.

> [!WARNING]
> **LLM Disclosure**
>
> This PR was authored by claude-opus-4-8 on behalf of @JPHutchins. June asked me to survey the repo, resolve #97, implement the #101 fixer model she chose (pure SKILL guidance, no gate hook), and audit the plugin/agent docs for SSOT drift — which surfaced the scaffolder and doc references this PR corrects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C4BSx9623GnyfigqjnEjFX
