### PR TITLE
fix(plugin): launch bundled config portably via uvx (closes #92, #96)

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,15 +210,15 @@ _ = Config(agent=Claude(fix=Sequential(py, web)))
 
 `--paths` works on any task — `camas check --paths src/a.py`. Without it, every `{paths}` resolves to its full-run default (`ruff format src`); with it, each leaf runs only over the changed files it covers, and a leaf that covers none is dropped (`--paths` is repeatable, or comma-separated).
 
-For the Claude Code plugin, you **register** the auto-fix node — whatever you named it — to `Config.agent.fix`; the FileChanged hook runs *that* node over the just-changed file, zero model tokens. Install the plugin (`/plugin marketplace add JPHutchins/camas`), or wire the hook by hand:
+For the Claude Code plugin, you **register** the auto-fix node — whatever you named it — to `Config.agent.fix`; the FileChanged hook runs *that* node over the just-changed file, zero model tokens. Install the plugin (`/plugin marketplace add JPHutchins/camas`), run `camas mcp init --hooks` (which writes the hook with the launcher it resolves for your project), or wire it by hand:
 
 ```jsonc
 // .claude/settings.json
 { "hooks": { "FileChanged": [
-  { "hooks": [{ "type": "command", "command": "camas mcp fix --paths ${file_path}" }] } ] } }
+  { "hooks": [{ "type": "command", "command": "uvx 'camas[mcp]' mcp fix --paths ${file_path}" }] } ] } }
 ```
 
-`camas mcp fix` runs the registered `Config.agent.fix` node (not a task named `fix` — that's just `camas fix`, your own task); with no fix registered it is a clean no-op, so the hook is harmless without it.
+`camas mcp fix` runs the registered `Config.agent.fix` node (not a task named `fix` — that's just `camas fix`, your own task); with no fix registered it is a clean no-op, so the hook is harmless without it. The `uvx 'camas[mcp]'` launcher needs only `uv` on PATH (no global camas install); with `camas` already installed, bare `camas mcp fix …` works too.
 
 ## Effects plugins
 

--- a/agent/claude/plugin/.mcp.json
+++ b/agent/claude/plugin/.mcp.json
@@ -2,8 +2,9 @@
   "mcpServers": {
     "camas": {
       "type": "stdio",
-      "command": "camas",
+      "command": "uvx",
       "args": [
+        "camas[mcp]",
         "mcp"
       ]
     }

--- a/agent/claude/plugin/hooks/hooks.json
+++ b/agent/claude/plugin/hooks/hooks.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "camas mcp fix --paths ${file_path}"
+            "command": "uvx 'camas[mcp]' mcp fix --paths ${file_path}"
           }
         ]
       }

--- a/tests/plugin/test_shipped_plugin.py
+++ b/tests/plugin/test_shipped_plugin.py
@@ -21,7 +21,7 @@ def test_plugin_manifest_is_named_camas() -> None:
 
 def test_bundled_mcp_server_launches_camas_mcp() -> None:
 	server = json.loads((_PLUGIN / ".mcp.json").read_text())["mcpServers"]["camas"]
-	assert (server["command"], server["args"]) == ("camas", ["mcp"])
+	assert (server["command"], server["args"]) == ("uvx", ["camas[mcp]", "mcp"])
 
 
 def test_post_tool_batch_hook_is_absent() -> None:
@@ -33,7 +33,7 @@ def test_filechanged_hook_runs_the_deterministic_autofix() -> None:
 	hooks = json.loads((_PLUGIN / "hooks" / "hooks.json").read_text())["hooks"]
 	fc = hooks["FileChanged"][0]["hooks"][0]
 	assert fc["type"] == "command"
-	assert "camas mcp fix" in fc["command"]
+	assert fc["command"] == "uvx 'camas[mcp]' mcp fix --paths ${file_path}"
 
 
 def test_marketplace_points_at_the_shipped_plugin() -> None:


### PR DESCRIPTION
> [!WARNING]
> **LLM Disclosure**
>
> This post was authored by claude-opus-4-8 on behalf of @JPHutchins, who asked me to triage and knock out a batch of low-hanging issues. This is the plugin-config-portability fix for #92 and #96.

## What

The plugin's bundled `.mcp.json` and `hooks/hooks.json` hardcoded a bare `camas`, which fails whenever `camas` isn't on `PATH` — including the exact setup the plugin targets (uv projects that only ever run camas ephemerally). The MCP server never connected (`No such file or directory` / `requires feature camas[mcp]`) and the FileChanged hook errored (`/bin/sh: camas: not found`).

Both now launch via **`uvx 'camas[mcp]'`** — zero prior install, needs only `uv` on PATH:

| file | before | after |
|------|--------|-------|
| `agent/claude/plugin/.mcp.json` | `camas mcp` | `uvx camas[mcp] mcp` |
| `agent/claude/plugin/hooks/hooks.json` | `camas mcp fix …` | `uvx 'camas[mcp]' mcp fix --paths ${file_path}` |

`[mcp]` (not `[all]`) is sufficient: #103 already put `ty` in the `[mcp]` extra, so `camas_check` gets its type checker. `[all]` only adds httpx, which the server / fix / gate don't use.

The README hand-wire example is updated to the same portable form and now points at `camas mcp init --hooks` (the resolved-launcher path from #108) as the canonical way to wire it.

## Not pursued: a plugin-owned install

#96 floated "could the plugin install camas in its own environment?" Researched against current Claude Code docs: there is no auto-triggered install lifecycle (the Setup hook only fires on explicit `claude --init-only`), and a bundled venv is undocumented/unsupported. `${CLAUDE_PLUGIN_ROOT}` exists but camas isn't bundled there. `uvx` is the idiomatic, portable answer.

## Verify

- `camas_run check` → **8/8 green**; `camas_run coverage` → **100%**.
- `tests/plugin/test_shipped_plugin.py` updated to assert the portable invocations.

Closes #92.
Closes #96.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C4BSx9623GnyfigqjnEjFX
