### PR TITLE
docs(tutorial): document the Claude Code agent integration (closes #95)

### DIFF
--- a/src/camas/__init__.py
+++ b/src/camas/__init__.py
@@ -57,6 +57,21 @@ These five are the unversioned alias for the latest API generation; to
 pin a generation, import from its namespace (``camas.v0``). See the
 README's Versioning section.
 
+``Config(agent=Claude(fix=..., check=...))`` wires the Claude Code
+plugin's gate. ``fix`` is the deterministic, behavior-preserving autofix
+node the ``FileChanged`` hook runs over each changed file (scope it with
+``{paths}``; zero model tokens) — declared, not inferred from
+``mutates=``, since a mutating leaf may be a compiler or codegen rather
+than a fixer. ``check`` is the node the gate validates (``None`` defers
+to ``default_task``/``github_task``), scoped by ``--paths`` and
+time-boxed by ``--under``; the plugin delegates it to a background
+``camas-fixer`` subagent that drives the changed scope to green off the
+main agent's context, rather than blocking on a hook. A checking leaf
+may add ``agent_format=("--output-format sarif", "sarif")`` (kinds:
+``sarif``, ``rdjson``, ``lsp``, ``junit``, ``tap``, ``raw``) so the gate
+collects machine-readable diagnostics — appended only on gate runs, not
+human runs.
+
 **LLM agents:** prefer the MCP::
 
     $ camas mcp [--help | --rich]

--- a/src/camas/main/starter.py
+++ b/src/camas/main/starter.py
@@ -57,7 +57,8 @@ autofix = Task('python -c "" {paths}', name="autofix", mutates=True, paths=".")
 # Config is discovered by type, under any binding name (here `_`): bare `camas` runs
 # default_task — or github_task under GitHub Actions, falling back to default_task when unset.
 # agent= wires the Claude Code plugin: agent.fix is the registered FileChanged autofix node
-# above; the gate checks default_task (override with Claude(fix=..., check=...)).
+# above; the gate checks default_task (override with Claude(fix=..., check=...)). A checking
+# leaf can add agent_format=("--output-format sarif", "sarif") for machine-readable gate output.
 _ = Config(default_task=ci, agent=Claude(fix=autofix))
 
 # The PEP 723 standalone flow (see the docstring): running this file directly


### PR DESCRIPTION
> [!WARNING]
> **LLM Disclosure**
>
> This post was authored by claude-opus-4-8 on behalf of @JPHutchins, who asked me to knock out a batch of low-hanging issues. This is the tutorial/agent-integration docs for #95.

## What

The `camas_docs` tutorial (the `camas/__init__.py` docstring) never mentioned the Claude agent integration — even though the MCP server instructions tell agents to read `camas_docs` *before* authoring `tasks.py`. An agent following that guidance wrote a plain task tree and silently omitted the gate wiring.

Added a concise section to the tutorial covering:

- `Config(agent=Claude(fix=..., check=...))` — what `fix` and `check` are, and that `fix` is *declared*, not inferred from `mutates=`.
- `agent_format=(args, kind)` (`sarif | rdjson | lsp | junit | tap | raw`) — the agent-only structured-output variant the gate appends, non-discoverable otherwise.

Also surfaced `agent_format` in the `--init` starter's agent comment. The starter already wires `Config(agent=Claude(fix=…))` (that landed with the gate epic), so that half of the issue was already closed.

## Written to the *current* model, not the issue's

The issue describes a "two-hook gate (FileChanged + PostToolBatch)". That model is stale — #114 removed the PostToolBatch hook; the check is now delegated to the background `camas-fixer` subagent. The new tutorial text documents that reality instead of re-enshrining the removed hook — which is exactly the SSOT drift this issue was itself an instance of.

> This branch previously carried a pre-#114 commit (`208812b`, 2026-06-28) that documented the PostToolBatch gate; this PR supersedes it with the current model.

## Verify

- `camas_run check` → **8/8 green**; `camas_run coverage` → **100%** (doctests included).

Closes #95.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C4BSx9623GnyfigqjnEjFX
