### PR TITLE
feat(mcp): add camas_init tool to scaffold tasks.py over the MCP (closes #73)

### DIFF
--- a/src/camas/main/init.py
+++ b/src/camas/main/init.py
@@ -24,18 +24,27 @@ def starter_text() -> str:
 	return (Path(__file__).parent / "starter.py").read_text(encoding="utf-8")
 
 
+def create_starter_tasks_py(directory: Path) -> Path:
+	"""Exclusive-create the starter ``tasks.py`` in ``directory`` and the camas directory beside
+	it; return the ``tasks.py`` path. Never overwrites — an existing ``tasks.py`` raises
+	``FileExistsError``; any other IO failure raises its ``OSError``.
+	"""
+	target: Final = directory / "tasks.py"
+	with target.open("x", encoding="utf-8") as f:
+		f.write(starter_text())
+	ensure_camas_dir(directory / DEFAULT_CAMAS_DIR)
+	return target
+
+
 def write_starter_tasks_py(directory: Path) -> int:
 	"""Write :func:`starter_text` to ``directory/tasks.py`` and create the camas
 	directory beside it — the exit code for ``camas --init``. Exclusive create: an
 	existing ``tasks.py`` is never touched, and any ``OSError`` (exists, permissions,
 	...) becomes a clean error exit.
 	"""
-	target: Final = directory / "tasks.py"
 	camas_dir: Final = directory / DEFAULT_CAMAS_DIR
 	try:
-		with target.open("x", encoding="utf-8") as f:
-			f.write(starter_text())
-		ensure_camas_dir(camas_dir)
+		target = create_starter_tasks_py(directory)
 	except OSError as e:
 		print(f"error: {e}", file=sys.stderr)
 		return 2

--- a/src/camas/mcp/serve.py
+++ b/src/camas/mcp/serve.py
@@ -35,6 +35,7 @@ from ..core.scope import scope_to_changed, to_changed, with_default_paths
 from ..core.task import task_label
 from ..main.argv import apply_passthrough
 from ..main.format import format_load_error_hint
+from ..main.init import create_starter_tasks_py, starter_text
 from ..main.state import EMPTY_STATE, LoadErr, LoadOk, TasksState
 from ..main.tasks import load_tasks, load_tasks_from_py
 from ..v0.completion import Finished, Skipped, Stopped
@@ -65,6 +66,7 @@ class ToolName(Enum):
 	CHECK = "camas_check"
 	DOCS = "camas_docs"
 	GATE = "camas_gate"
+	INIT = "camas_init"
 
 
 NO_ARGS_SCHEMA: Final[dict[str, Any]] = {
@@ -79,6 +81,9 @@ RUN_ANNOTATIONS: Final = types.ToolAnnotations(
 CHECK_ANNOTATIONS: Final = types.ToolAnnotations(readOnlyHint=True, openWorldHint=False)
 DOCS_ANNOTATIONS: Final = types.ToolAnnotations(readOnlyHint=True, openWorldHint=False)
 GATE_ANNOTATIONS: Final = types.ToolAnnotations(readOnlyHint=True, openWorldHint=False)
+INIT_ANNOTATIONS: Final = types.ToolAnnotations(
+	readOnlyHint=False, destructiveHint=False, idempotentHint=True, openWorldHint=False
+)
 
 
 class Compat(NamedTuple):
@@ -177,7 +182,7 @@ def build_server(session: Session) -> Server[object]:
 			validate the tasks definition after you edit it, and camas_docs for how to
 			author tasks. Call camas_list first; it is the source of truth for task names.
 			If the project has no tasks file yet, scaffold a commented starter with
-			`camas --init` before authoring one by hand.
+			camas_init (the MCP mirror of `camas --init`) before authoring one by hand.
 		""").strip(),
 	)
 
@@ -210,6 +215,8 @@ async def call(session: Session, name: str, arguments: dict[str, Any]) -> types.
 			return docs_call(session)
 		case ToolName.GATE:
 			return await gate_call(session, arguments)
+		case ToolName.INIT:
+			return init_call(session)
 		case _:
 			known = ", ".join(repr(tool.value) for tool in ToolName)
 			return error_result(f"unknown tool {name!r}; expected one of: {known}")
@@ -233,6 +240,7 @@ class Tools(NamedTuple):
 	validation: types.Tool
 	docs: types.Tool
 	gate: types.Tool
+	init: types.Tool
 
 
 def tool_def(
@@ -258,7 +266,7 @@ def tool_def(
 
 
 def tools(task_names: tuple[str, ...], compat: Compat) -> Tools:
-	"""The four tool definitions, with ``task_names`` spliced into ``camas_run``'s ``task`` enum."""
+	"""The six tool definitions, with ``task_names`` spliced into ``camas_run``'s ``task`` enum."""
 	return Tools(
 		discovery=tool_def(
 			compat,
@@ -362,6 +370,25 @@ def tools(task_names: tuple[str, ...], compat: Compat) -> Tools:
 			title="SA-delegation gate",
 			annotations=GATE_ANNOTATIONS,
 		),
+		init=tool_def(
+			compat,
+			name=ToolName.INIT.value,
+			description=textwrap.dedent("""\
+				Scaffold a commented starter tasks.py in THIS project's root when it has none — the
+				MCP mirror of `camas --init`, for driving camas purely over the MCP. Writes the same
+				worked template (leaf tasks, Sequential/Parallel composition, a matrix, a Config
+				default task, and the Claude agent integration) with cross-platform placeholder
+				commands, creates the .camas/ run-log and timing directory beside it, and returns the
+				path plus the file's content so you can edit from there. Refuses to overwrite an
+				existing tasks.py (returns status 'exists', file untouched). The tasks it creates are
+				immediately runnable via camas_run — no restart. Then read camas_docs and validate
+				edits with camas_check.
+			""").strip(),
+			input_schema=NO_ARGS_SCHEMA,
+			output_model=wire.InitResponse,
+			title="Scaffold a starter tasks.py",
+			annotations=INIT_ANNOTATIONS,
+		),
 	)
 
 
@@ -394,6 +421,22 @@ def docs_call(session: Session) -> types.CallToolResult:
 	"""Handle ``camas_docs``: the camas authoring tutorial."""
 	resp = to_docs_response()
 	return success(docs_text(resp), resp, session.compat)
+
+
+def init_call(session: Session) -> types.CallToolResult:
+	"""Handle ``camas_init``: scaffold a commented starter ``tasks.py`` in the project root,
+	refusing to overwrite an existing one, and re-resolve so the new tasks are immediately live.
+	"""
+	try:
+		created = create_starter_tasks_py(session.base)
+	except FileExistsError:
+		resp = wire.InitResponse(status="exists", path=str(session.base / "tasks.py"))
+		return success(init_text(resp), resp, session.compat)
+	except OSError as e:
+		return error_result(f"camas_init: could not scaffold tasks.py: {e}")
+	session.project = resolve_project_quiet(session.base)
+	resp = wire.InitResponse(status="created", path=str(created), content=starter_text())
+	return success(init_text(resp), resp, session.compat)
 
 
 async def run_call(session: Session, arguments: dict[str, Any]) -> types.CallToolResult:
@@ -738,7 +781,7 @@ def check_text(resp: wire.CheckResponse) -> str:
 		case "no_tasks":
 			return (
 				"camas_check: no tasks.py or [tool.camas.tasks] found in this project. "
-				"Run `camas --init` to scaffold a commented starter, or call camas_docs to author one."
+				"Call camas_init to scaffold a commented starter, or camas_docs to author one."
 			)
 		case _:
 			assert_never(resp.status)
@@ -755,13 +798,33 @@ def docs_text(resp: wire.DocsResponse) -> str:
 	)
 
 
+def init_text(resp: wire.InitResponse) -> str:
+	"""The load-bearing agent-facing summary for ``camas_init``."""
+	match resp.status:
+		case "created":
+			return (
+				f"Scaffolded a starter tasks.py at:\n  {resp.path}\n"
+				"Replace its placeholder commands with your real ones (see camas_docs), then "
+				"validate with camas_check and list with camas_list. The scaffolded file:\n\n"
+				f"{resp.content}"
+			)
+		case "exists":
+			return (
+				f"A tasks.py already exists at:\n  {resp.path}\nLeft untouched. "
+				"Use camas_list to see its tasks, or camas_docs + camas_check to edit it."
+			)
+		case _:
+			assert_never(resp.status)
+
+
 def success(
 	text: str,
 	model: wire.ListResponse
 	| wire.RunResponse
 	| wire.CheckResponse
 	| wire.DocsResponse
-	| wire.GateResponse,
+	| wire.GateResponse
+	| wire.InitResponse,
 	compat: Compat,
 	*,
 	links: tuple[types.ResourceLink, ...] = (),

--- a/src/camas/mcp/wire.py
+++ b/src/camas/mcp/wire.py
@@ -141,6 +141,20 @@ class DocsResponse(BaseModel):
 	"""The package ``__init__.py`` docstring: a worked, doctested authoring tutorial."""
 
 
+class InitResponse(BaseModel):
+	"""Outcome of scaffolding a starter ``tasks.py`` — created fresh, or an existing one left
+	untouched.
+	"""
+
+	status: Literal["created", "exists"]
+	path: str
+	"""The ``tasks.py`` path: the file written, or the existing one left in place."""
+	content: str | None = None
+	"""The scaffolded starter's content when ``status`` is ``created``; ``null`` when a
+	``tasks.py`` already existed.
+	"""
+
+
 class ListRequest(BaseModel):
 	"""Arguments to ``camas_list``."""
 

--- a/tests/mcp/test_init_tool.py
+++ b/tests/mcp/test_init_tool.py
@@ -1,0 +1,77 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2026 JP Hutchins
+
+"""camas_init: scaffold a starter tasks.py over the MCP, refusing to overwrite an existing one,
+and re-resolve so the new tasks are immediately live. tmp_path is auto-removed."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from mcp import types
+
+from camas.main.state import LoadOk
+from camas.mcp import serve
+from camas.mcp.serve import Compat, Session
+
+if TYPE_CHECKING:
+	from pathlib import Path
+
+	import pytest
+
+
+def _text(result: types.CallToolResult) -> str:
+	return "".join(c.text for c in result.content if isinstance(c, types.TextContent))
+
+
+def _session(base: Path, *, rich: bool = False) -> Session:
+	return Session(serve.resolve_project_quiet(base), base, Compat(emit_structured=rich))
+
+
+def test_init_scaffolds_tasks_py_and_camas_dir(tmp_path: Path) -> None:
+	result = serve.init_call(_session(tmp_path))
+	assert result.isError is False
+	assert (tmp_path / "tasks.py").exists()
+	assert (tmp_path / ".camas").is_dir()
+	text = _text(result)
+	assert "Scaffolded" in text
+	assert "from camas import" in text
+
+
+def test_init_makes_tasks_immediately_runnable(tmp_path: Path) -> None:
+	session = _session(tmp_path)
+	serve.init_call(session)
+	assert isinstance(session.project, LoadOk)
+	assert "ci" in session.project.tasks
+
+
+def test_init_refuses_to_overwrite(tmp_path: Path) -> None:
+	kept = "from camas import Task\nkeep = Task('echo keep')\n"
+	(tmp_path / "tasks.py").write_text(kept)
+	result = serve.init_call(_session(tmp_path))
+	assert result.isError is False
+	assert "already exists" in _text(result)
+	assert (tmp_path / "tasks.py").read_text() == kept
+
+
+def test_init_structured_when_rich(tmp_path: Path) -> None:
+	result = serve.init_call(_session(tmp_path, rich=True))
+	assert result.structuredContent is not None
+	assert result.structuredContent["status"] == "created"
+	assert result.structuredContent["path"].endswith("tasks.py")
+
+
+def test_init_reports_os_error(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+	def _boom(directory: Path) -> Path:
+		raise PermissionError("denied")
+
+	monkeypatch.setattr("camas.mcp.serve.create_starter_tasks_py", _boom)
+	result = serve.init_call(_session(tmp_path))
+	assert result.isError is True
+	assert "could not scaffold" in _text(result)
+
+
+async def test_call_routes_init(tmp_path: Path) -> None:
+	result = await serve.call(_session(tmp_path), "camas_init", {})
+	assert result.isError is False
+	assert (tmp_path / "tasks.py").exists()

--- a/tests/mcp/test_serve.py
+++ b/tests/mcp/test_serve.py
@@ -125,7 +125,7 @@ def test_task_names_empty_on_load_error(tmp_path: Path) -> None:
 
 
 def test_tools_default_omits_rich_fields() -> None:
-	tool_list, tool_run, tool_check, tool_docs, tool_gate = serve.tools(
+	tool_list, tool_run, tool_check, tool_docs, tool_gate, tool_init = serve.tools(
 		("a", "b"), Compat(emit_structured=False)
 	)
 	assert (tool_list.title, tool_list.outputSchema, tool_list.annotations) == (None, None, None)
@@ -139,10 +139,12 @@ def test_tools_default_omits_rich_fields() -> None:
 	assert tool_list.inputSchema["additionalProperties"] is False
 	assert (tool_gate.title, tool_gate.outputSchema, tool_gate.annotations) == (None, None, None)
 	assert _task_enum(tool_gate.inputSchema) == ["a", "b"]
+	assert (tool_init.title, tool_init.outputSchema, tool_init.annotations) == (None, None, None)
+	assert tool_init.inputSchema == serve.NO_ARGS_SCHEMA
 
 
 def test_tools_rich_includes_title_annotations_and_schema() -> None:
-	tool_list, tool_run, tool_check, tool_docs, tool_gate = serve.tools(
+	tool_list, tool_run, tool_check, tool_docs, tool_gate, tool_init = serve.tools(
 		(), Compat(emit_structured=True)
 	)
 	assert tool_list.title == "List camas tasks"
@@ -165,6 +167,10 @@ def test_tools_rich_includes_title_annotations_and_schema() -> None:
 	assert tool_gate.outputSchema is not None
 	assert tool_gate.annotations is not None
 	assert tool_gate.annotations.readOnlyHint is True
+	assert tool_init.title == "Scaffold a starter tasks.py"
+	assert tool_init.outputSchema is not None
+	assert tool_init.annotations is not None
+	assert tool_init.annotations.readOnlyHint is False
 
 
 def test_list_call_text_lists_tasks_and_markers(tmp_path: Path) -> None:
@@ -853,6 +859,7 @@ async def test_in_memory_round_trip(tmp_path: Path) -> None:
 			"camas_check",
 			"camas_docs",
 			"camas_gate",
+			"camas_init",
 		}
 		catalog = await client.call_tool("camas_list", {})
 		assert "lint" in _text(catalog)


### PR DESCRIPTION
> [!WARNING]
> **LLM Disclosure**
>
> This post was authored by claude-opus-4-8 on behalf of @JPHutchins, who asked me to knock out a batch of low-hanging issues. This is the camas_init MCP tool for #73.

## What

An agent driving camas purely over the MCP (stdio) could be *told* to run `camas --init`, but had no MCP affordance to actually scaffold a `tasks.py` — `camas_list` / `camas_run` / `camas_check` / `camas_docs` all assume one exists. In a project with no tasks file it either shelled out (defeating the "use the tools, not the raw commands" contract) or hand-authored from the API reference.

Adds **`camas_init`**, the MCP mirror of the CLI `camas --init`:

- Exclusive-creates the commented starter `tasks.py` in the project root + the `.camas/` dir beside it; **refuses to overwrite** an existing one (returns `status: "exists"`, file untouched).
- **Re-resolves the project** on success, so the newly-scaffolded tasks are immediately runnable via `camas_run` and the tool list updates — no server restart.
- Returns the `path` and the scaffolded **content**, so the agent can edit from there without an extra read.

The create logic is factored into `create_starter_tasks_py` in `main/init.py`, shared by the CLI (`write_starter_tasks_py`) and the tool — one scaffolder, no duplicated template. The server `instructions` and the `camas_check` "no tasks" verdict now point at `camas_init` instead of the CLI command.

## Verify

- `camas_run check` → **8/8 green**; `camas_run coverage` → **100%**.
- New `tests/mcp/test_init_tool.py`: created / refuse-overwrite / immediately-runnable / rich structured / OS-error / call-routing. Existing `serve.tools(...)` and round-trip tool-set tests updated for the sixth tool.

Closes #73.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C4BSx9623GnyfigqjnEjFX
