### PR TITLE
docs: guide running the CI node before pushing

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,14 @@ _ = Config(
 
 `Config` is discovered by type, so the binding's name never matters — `_` by convention. Defining two is an error.
 
+Because `github_task` reproduces CI, running it before a push catches a CI failure locally. If it is a named task, a one-line git hook guards every push:
+
+```sh
+echo 'exec camas check' > .git/hooks/pre-push && chmod +x .git/hooks/pre-push
+```
+
+`git push --no-verify` still bypasses it deliberately. An LLM agent needs no hook — `camas_list` reports the CI task as `github_default`, so it runs `camas_run` with that name before pushing.
+
 ## Time budget (`--under`)
 
 Once camas has timed a task's leaves (the `.camas/` cache, surfaced by `camas --list`), `camas --under=<duration>` runs only the leaves whose estimate fits a wall-clock budget — the fast inner-loop subset, picked for you instead of by hand.

--- a/src/camas/__init__.py
+++ b/src/camas/__init__.py
@@ -51,7 +51,10 @@ real ordering (a mutating step, or one that consumes a prior's output).
 ``_ = Config(default_task=...)`` and bare ``camas`` runs that task
 (``github_task`` takes over under GitHub Actions) — so a CI step is just
 ``camas`` (or ``uv run camas``), which won't go stale if you change
-``github_task``.
+``github_task``. That same ``github_task`` reproduces CI locally — run it
+before you push to catch a CI failure first: ``camas_list`` surfaces it as
+``github_default`` for an agent to ``camas_run``, and a named CI task
+doubles as a one-line git ``pre-push`` hook.
 
 These five are the unversioned alias for the latest API generation; to
 pin a generation, import from its namespace (``camas.v0``). See the


### PR DESCRIPTION
> [!WARNING]
> **LLM Disclosure**
>
> This PR was authored by claude-opus-4-8 on behalf of @JPHutchins, who decided during triage that #113 resolves as guidance (no new command) — the CI node is already addressable by name.

Closes #113.

## Why no command

The `github_task` **is** the authoritative CI SSOT, and it is already addressable **by name** — so nothing new is needed to run it locally, identical to CI:

- **Agent:** `camas_list` reports `github_default` (the CI task's name); the agent runs `camas_run task=<that>` over the whole tree before pushing. Works today.
- **Human:** a named CI task doubles as a one-line git `pre-push` hook (`exec camas <task>`); `--no-verify` still bypasses.

Adding a `camas pre-push` (or `camas mcp pre-push`) verb would only wrap `camas <named-task>`, so this ships the guidance instead of a command — no new `camas`/`camas mcp` surface.

## Changes (docs only)

- **`src/camas/__init__.py`** (the `camas_docs` tutorial) — extends the `Config`/`github_task` paragraph: that node reproduces CI locally; run it before pushing; `camas_list` surfaces it as `github_default` for `camas_run`; a named CI task doubles as a git `pre-push` hook.
- **`README.md`** (Config section) — the human-facing one-liner:
  ```sh
  echo 'exec camas check' > .git/hooks/pre-push && chmod +x .git/hooks/pre-push
  ```

## Validation

- `camas_run task=check` → 8/8 green (includes the doctests over the edited docstring + ruff format/lint).
- `camas_run task=coverage` → 100%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C4BSx9623GnyfigqjnEjFX
