### PR TITLE
fix(nix): derive package extras from pyproject to prevent drift

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -16,6 +16,10 @@
       ];
       forAllSystems = lib.genAttrs systems;
 
+      extraNames = builtins.attrNames (lib.importTOML ./pyproject.toml).project.optional-dependencies;
+      perExtra = builtins.filter (extra: extra != "all") extraNames;
+      withExtraName = extra: "with-${lib.replaceStrings [ "_" ] [ "-" ] extra}";
+
       version = "0.0.0+${self.shortRev or self.dirtyShortRev or "unknown"}";
 
       mkCamas =
@@ -36,42 +40,21 @@
         in
         {
           default = mkCamas pkgs { };
-          with-github-checks = mkCamas pkgs { extras = [ "github_checks" ]; };
-          with-check = mkCamas pkgs { extras = [ "check" ]; };
-          with-mcp = mkCamas pkgs { extras = [ "mcp" ]; };
-          all = mkCamas pkgs {
-            extras = [
-              "github_checks"
-              "check"
-              "mcp"
-            ];
-          };
+          all = mkCamas pkgs { extras = [ "all" ]; };
           interpreted = mkCamas pkgs { withMypyC = false; };
         }
+        // lib.listToAttrs (
+          map (extra: lib.nameValuePair (withExtraName extra) (mkCamas pkgs { extras = [ extra ]; })) perExtra
+        )
       );
 
-      apps = forAllSystems (system: {
-        default = {
+      apps = forAllSystems (
+        system:
+        lib.mapAttrs (_: pkg: {
           type = "app";
-          program = "${self.packages.${system}.default}/bin/camas";
-        };
-        with-github-checks = {
-          type = "app";
-          program = "${self.packages.${system}.with-github-checks}/bin/camas";
-        };
-        with-check = {
-          type = "app";
-          program = "${self.packages.${system}.with-check}/bin/camas";
-        };
-        all = {
-          type = "app";
-          program = "${self.packages.${system}.all}/bin/camas";
-        };
-        interpreted = {
-          type = "app";
-          program = "${self.packages.${system}.interpreted}/bin/camas";
-        };
-      });
+          program = "${pkg}/bin/camas";
+        }) self.packages.${system}
+      );
 
       devShells = forAllSystems (
         system:
@@ -109,13 +92,10 @@
                 nixfmt --check ${./flake.nix} ${./nix/package.nix}
                 touch $out
               '';
-
-          package = self.packages.${system}.default;
-          package-with-github-checks = self.packages.${system}.with-github-checks;
-          package-with-check = self.packages.${system}.with-check;
-          package-all = self.packages.${system}.all;
-          package-interpreted = self.packages.${system}.interpreted;
         }
+        // lib.mapAttrs' (
+          name: pkg: lib.nameValuePair ("package" + lib.optionalString (name != "default") "-${name}") pkg
+        ) self.packages.${system}
       );
 
       formatter = forAllSystems (

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,11 +1,14 @@
 # Canonical camas Nix derivation. Consumed by:
-#   1. this repo's flake.nix (passes `src = ../.` and a git-rev-based version)
+#   1. this repo's flake.nix (passes `src = ./.` and a git-rev-based version)
 #   2. (future) nixpkgs `pkgs/by-name/ca/camas/package.nix`, which inlines this
 #      file's body with `src = fetchFromGitHub {...}` and a hardcoded `version`
 #      matching the released tag.
 #
-# When publishing to nixpkgs, copy this file's body and replace the two args
-# below with let-bindings. Keep the rest identical.
+# optional-dependencies mirrors pyproject.toml's [project.optional-dependencies]
+# by reading it from `src` at eval time, so the extras never drift. That read is
+# a plain path lookup here (src = ./.); a nixpkgs port whose src is a fetcher
+# would turn it into import-from-derivation, so when porting, inline
+# optional-dependencies as a literal alongside a hardcoded `src` and `version`.
 {
   lib,
   python3Packages,
@@ -16,16 +19,35 @@
 }:
 
 let
-  optional-dependencies = {
-    github_checks = [ python3Packages.httpx ];
-    check = [ python3Packages.ty ];
-    mcp = [ python3Packages.mcp ];
-    all = lib.concatAttrValues (lib.removeAttrs optional-dependencies [ "all" ]);
-  };
+  pname = "camas";
+
+  pyprojectExtras = (lib.importTOML (src + "/pyproject.toml")).project.optional-dependencies;
+
+  parseSpec =
+    spec:
+    if lib.hasPrefix "${pname}[" spec then
+      {
+        self = lib.splitString "," (lib.removeSuffix "]" (lib.removePrefix "${pname}[" spec));
+      }
+    else
+      { pkg = builtins.head (builtins.match "([A-Za-z0-9._-]+).*" spec); };
+
+  resolveExtra =
+    extra:
+    lib.unique (
+      lib.concatMap (
+        spec:
+        let
+          parsed = parseSpec spec;
+        in
+        if parsed ? self then lib.concatMap resolveExtra parsed.self else [ python3Packages.${parsed.pkg} ]
+      ) pyprojectExtras.${extra}
+    );
+
+  optional-dependencies = lib.mapAttrs (extra: _: resolveExtra extra) pyprojectExtras;
 in
 python3Packages.buildPythonApplication {
-  pname = "camas";
-  inherit version src;
+  inherit pname version src;
   pyproject = true;
 
   env = {


### PR DESCRIPTION
## Problem

The flake and `nix/package.nix` hardcoded the Python optional-dependency extras, so they drifted from `pyproject.toml`:

- **`ctrf` extra (msgspec) was missing entirely** — no `with-ctrf` package, app, or check, and it was absent from `all`.
- The `all` **package** in the flake manually listed `[github_checks check mcp]`, so it also omitted `ctrf`.
- `with-mcp` had a package but **no app and no check**.
- The `mcp` extra resolved to just `[mcp]`, but `pyproject.toml` declares `mcp = ["mcp>=1.24,<2", "camas[check]"]`, so it should also pull `ty`.

## Fix

Make `pyproject.toml`'s `[project.optional-dependencies]` the single source of truth for Nix:

- **`nix/package.nix`** reads the table at eval time (`lib.importTOML`) and resolves each extra — including `camas[...]` self-references (recursively, deduped) — into its nixpkgs packages.
- **`flake.nix`** derives its per-extra `packages`, `apps`, and `checks` from the same table. `apps` and `checks` are now generated from `packages`, so every package automatically gets a matching app and build check.

Adding or removing an extra in `pyproject.toml` now propagates to Nix automatically — no manual list to keep in sync.

## Result

```
packages: all default interpreted with-check with-ctrf with-github-checks with-mcp
apps:     all default interpreted with-check with-ctrf with-github-checks with-mcp
checks:   nixfmt package package-all package-interpreted package-with-check
          package-with-ctrf package-with-github-checks package-with-mcp
```

Resolved dependencies (verified against the built derivation's `passthru.optional-dependencies`):

```
github_checks = [ httpx ]
ctrf          = [ msgspec ]
check         = [ ty ]
mcp           = [ mcp ty ]      # follows camas[check]
all           = [ httpx msgspec ty mcp ]
```

## Notes on the nixpkgs port

For the flake, `src = ./.` is a path, so reading `pyproject.toml` is a plain eval-time lookup (no import-from-derivation). A future nixpkgs port whose `src` is a fetcher would turn that read into IFD, so the header comment in `package.nix` now documents inlining the resolved `optional-dependencies` alongside a hardcoded `src`/`version`.

## Validation

- `nix eval` of `packages`/`apps`/`checks` attribute names ✓
- All five package variants (`default`, `all`, `with-ctrf`, `with-mcp`, `interpreted`) evaluate to valid `.drv` paths ✓
- Built derivation's `passthru.optional-dependencies` matches the table above ✓
- `nixfmt --check flake.nix nix/package.nix` passes ✓

Full build coverage across Linux/macOS runs in CI via `nix flake check`.

> [!WARNING]
> **LLM Disclosure**
>
> This post was authored by claude-opus-4-8[1m] on behalf of @JPHutchins, who asked to fix Nix/pyproject extras drift and make the extras auto-derived so Nix can see what extras are available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)