### PR TITLE
fix(agent): drive the autofix hook from PostToolBatch on stdin (#129)

### DIFF
--- a/.github/workflows/claude-code-harness.yaml
+++ b/.github/workflows/claude-code-harness.yaml
@@ -1,0 +1,61 @@
+name: Claude Code hook harness
+
+# Runs the opt-in Claude Code integration suite (tests/claude_code/) against a REAL headless
+# `claude -p`, to catch drift in the hook contract camas depends on — that PostToolBatch fires on
+# an edit and delivers the changed path on stdin, that ${file_path} is not interpolated, and that
+# the shipped autofix hook actually runs the registered fix node end to end.
+#
+# It uses the same DeepSeek backend the agentic review workflow does (ANTHROPIC_BASE_URL +
+# ANTHROPIC_AUTH_TOKEN=DEEPSEEK_API_KEY, a burner key with a hard spend cap), on the cheap
+# deepseek-v4-flash tier. The schedule catches a Claude Code release changing the contract even
+# when camas itself has not changed.
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "17 6 * * 1" # weekly, Monday — catch a Claude Code release changing the hook contract
+  push:
+    paths:
+      - "src/camas/**"
+      - "agent/claude/plugin/**"
+      - "tests/claude_code/**"
+      - ".github/workflows/claude-code-harness.yaml"
+
+jobs:
+  harness:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+
+      - uses: astral-sh/setup-uv@v8.2.0
+
+      - run: npm install -g @anthropic-ai/claude-code@2.1.197
+
+      # Lock egress AFTER trusted setup (whose downloads we don't want to fight) and BEFORE the
+      # headless run. Only the hosts the suite needs; a blocked host shows in this step's summary.
+      - name: Lock network egress
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: block
+          allowed-endpoints: >
+            api.deepseek.com:443
+            pypi.org:443
+            files.pythonhosted.org:443
+            github.com:443
+            objects.githubusercontent.com:443
+
+      - name: Run the Claude Code integration suite
+        env:
+          CAMAS_CC_E2E: "1"
+          CAMAS_CC_MODEL: deepseek-v4-flash
+          ANTHROPIC_BASE_URL: https://api.deepseek.com/anthropic
+          ANTHROPIC_AUTH_TOKEN: ${{ secrets.DEEPSEEK_API_KEY }}
+        run: |
+          [ -n "$ANTHROPIC_AUTH_TOKEN" ] || { echo "::error::DEEPSEEK_API_KEY secret is not set"; exit 1; }
+          uv run pytest tests/claude_code/ -v --no-cov -p no:cacheprovider

--- a/README.md
+++ b/README.md
@@ -226,15 +226,15 @@ _ = Config(agent=Claude(fix=Sequential(py, web)))
 
 `--paths` works on any task — `camas check --paths src/a.py`. Without it, every `{paths}` resolves to its full-run default (`ruff format src`); with it, each leaf runs only over the changed files it covers, and a leaf that covers none is dropped (`--paths` is repeatable, or comma-separated).
 
-For the Claude Code plugin, you **register** the auto-fix node — whatever you named it — to `Config.agent.fix`; the FileChanged hook runs *that* node over the just-changed file, zero model tokens. Install the plugin (`/plugin marketplace add JPHutchins/camas`), run `camas mcp init --hooks` (which writes the hook with the launcher it resolves for your project), or wire it by hand:
+For the Claude Code plugin, you **register** the auto-fix node — whatever you named it — to `Config.agent.fix`; the PostToolBatch hook runs *that* node over the just-changed files, zero model tokens. Install the plugin (`/plugin marketplace add JPHutchins/camas`), run `camas mcp init --hooks` (which writes the hook with the launcher it resolves for your project), or wire it by hand:
 
 ```jsonc
 // .claude/settings.json
-{ "hooks": { "FileChanged": [
-  { "hooks": [{ "type": "command", "command": "uvx 'camas[mcp]' mcp fix --paths ${file_path}" }] } ] } }
+{ "hooks": { "PostToolBatch": [
+  { "hooks": [{ "type": "command", "command": "uvx 'camas[mcp]' mcp fix" }] } ] } }
 ```
 
-`camas mcp fix` runs the registered `Config.agent.fix` node (not a task named `fix` — that's just `camas fix`, your own task); with no fix registered it is a clean no-op, so the hook is harmless without it. The `uvx 'camas[mcp]'` launcher needs only `uv` on PATH (no global camas install); with `camas` already installed, bare `camas mcp fix …` works too.
+`camas mcp fix` runs the registered `Config.agent.fix` node (not a task named `fix` — that's just `camas fix`, your own task); it reads the changed files from the PostToolBatch event on stdin (`--paths` still works for a manual run). With no fix registered it is a clean no-op, so the hook is harmless without it. The `uvx 'camas[mcp]'` launcher needs only `uv` on PATH (no global camas install); with `camas` already installed, bare `camas mcp fix …` works too.
 
 ## Effects plugins
 

--- a/agent/claude/plugin/hooks/hooks.json
+++ b/agent/claude/plugin/hooks/hooks.json
@@ -1,11 +1,11 @@
 {
   "hooks": {
-    "FileChanged": [
+    "PostToolBatch": [
       {
         "hooks": [
           {
             "type": "command",
-            "command": "uvx 'camas[mcp]' mcp fix --paths ${file_path}"
+            "command": "uvx 'camas[mcp]' mcp fix"
           }
         ]
       }

--- a/agent/claude/plugin/skills/gate/SKILL.md
+++ b/agent/claude/plugin/skills/gate/SKILL.md
@@ -1,15 +1,15 @@
 ---
 name: gate
-description: Keep the workspace green while you edit — the free FileChanged autofix, and delegating the check-and-fix loop to the camas-fixer subagent so residuals never spend your reasoning. Read after a batch of edits and before declaring work done.
+description: Keep the workspace green while you edit — the free PostToolBatch autofix, and delegating the check-and-fix loop to the camas-fixer subagent so residuals never spend your reasoning. Read after a batch of edits and before declaring work done.
 ---
 
 The camas gate keeps the workspace green as you edit, in two layers — both driven by what the
 project declares in `Config.agent`:
 
-- **Fix (automatic, free).** A `FileChanged` hook runs `camas mcp fix --paths <file>` on every
-  file change — the node the project registered as `Config.agent.fix` (its mutating,
-  behavior-preserving auto-fixers: formatters, `--fix` linters), scoped to that file, at zero
-  model tokens. It never asks you anything; with no fix registered it is a no-op.
+- **Fix (automatic, free).** A `PostToolBatch` hook runs `camas mcp fix` after each edit batch —
+  the node the project registered as `Config.agent.fix` (its mutating, behavior-preserving
+  auto-fixers: formatters, `--fix` linters), scoped to the just-changed files (delivered on
+  stdin), at zero model tokens. It never asks you anything; with no fix registered it is a no-op.
 - **Check (you delegate — there is no check hook).** The check node (`Config.agent.check`,
   else the default task) is read-only: it runs the project's checks and classifies the result
   `green` or `needs_reasoning`. After a batch of edits, and before you declare work done,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -218,7 +218,7 @@ project-excludes = [
 [tool.coverage.run]
 source = ["camas", "tests"]
 branch = true
-omit = ["tests/test_demos.py", "src/camas/__main__.py"]
+omit = ["tests/test_demos.py", "tests/claude_code/*", "src/camas/__main__.py"]
 
 [tool.coverage.report]
 fail_under = 100

--- a/src/camas/__init__.py
+++ b/src/camas/__init__.py
@@ -62,7 +62,7 @@ README's Versioning section.
 
 ``Config(agent=Claude(fix=..., check=...))`` wires the Claude Code
 plugin's gate. ``fix`` is the deterministic, behavior-preserving autofix
-node the ``FileChanged`` hook runs over each changed file (scope it with
+node the ``PostToolBatch`` hook runs over the changed files (scope it with
 ``{paths}``; zero model tokens) — declared, not inferred from
 ``mutates=``, since a mutating leaf may be a compiler or codegen rather
 than a fixer. ``check`` is the node the gate validates (``None`` defers

--- a/src/camas/core/gate.py
+++ b/src/camas/core/gate.py
@@ -3,7 +3,7 @@
 
 """The SA-delegation gate: scope the check node to the changed paths, run the checks, and
 classify the residual ``green`` vs ``needs_reasoning``. The gate
-never mutates — the deterministic fixers run separately on ``FileChanged`` (``camas fix``).
+never mutates — the deterministic fixers run separately on ``PostToolBatch`` (``camas mcp fix``).
 """
 
 from __future__ import annotations

--- a/src/camas/core/hook_event.py
+++ b/src/camas/core/hook_event.py
@@ -1,0 +1,53 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2026 JP Hutchins
+
+"""Parse a Claude Code ``PostToolBatch`` hook event piped on stdin into the changed paths.
+
+The autofix (``camas mcp fix``) and the gate (``camas mcp gate``) both read the just-edited
+files from the same event, so the parsing lives here — dependency-free (``json``/``sys`` only)
+so ``camas mcp fix`` works without the ``mcp`` extra.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import cast
+
+
+def _event_get(obj: object, key: str) -> object:
+	"""``obj[key]`` for a parsed-JSON object, else ``None`` — narrows JSON's ``Any`` to ``object``."""
+	return cast("dict[str, object]", obj).get(key) if isinstance(obj, dict) else None
+
+
+def stdin_changed() -> tuple[str, ...] | None:
+	"""The edited files in a ``PostToolBatch`` event piped on stdin (the Claude Code plugin's
+	autofix/gate hook), de-duplicated in order: a (possibly empty) tuple when such an event is
+	present, or ``None`` when stdin is a tty, empty, or not such an event — letting the caller
+	tell "the batch changed nothing" (empty tuple) from "no event, use my default" (``None``).
+	"""
+	if sys.stdin.isatty():
+		return None
+	raw = sys.stdin.read().strip()
+	if not raw:
+		return None
+	try:
+		event: object = json.loads(raw)
+	except json.JSONDecodeError:
+		return None
+	calls = _event_get(event, "tool_calls")
+	if not isinstance(calls, list):
+		return None
+	edited = (
+		_event_get(_event_get(call, "tool_input"), key)
+		for call in cast("list[object]", calls)
+		for key in ("file_path", "path", "notebook_path")
+	)
+	return tuple(dict.fromkeys(f for f in edited if isinstance(f, str)))
+
+
+def changed_from_stdin() -> tuple[str, ...]:
+	"""The edited files from a stdin ``PostToolBatch`` event, ``()`` when there is no such event
+	— the gate's view, where an empty changed set falls back to the whole check node.
+	"""
+	return stdin_changed() or ()

--- a/src/camas/core/scope.py
+++ b/src/camas/core/scope.py
@@ -41,8 +41,8 @@ PATHS_TOKEN: Final = "{paths}"
 
 def to_changed(raw: Iterable[str], base: Path) -> tuple[str, ...]:
 	"""Normalize externally-supplied changed paths to the repo-relative POSIX form
-	:func:`scope_to_changed` matches: resolve each against ``base`` (a hook's ``${file_path}``
-	is absolute), drop any that fall outside it. The boundary every changed set passes through —
+	:func:`scope_to_changed` matches: resolve each against ``base`` (a hook's stdin paths are
+	absolute), drop any that fall outside it. The boundary every changed set passes through —
 	the CLI ``--paths``, the ``camas_gate`` request, and a hook's files all carry raw paths.
 
 	>>> import tempfile, os

--- a/src/camas/main/dispatch.py
+++ b/src/camas/main/dispatch.py
@@ -21,6 +21,7 @@ else:  # pragma: no cover
 from ..core import timings
 from ..core.budget import plan_under
 from ..core.execution import run
+from ..core.hook_event import stdin_changed
 from ..core.matrix import expand_matrix, matrix_axes, override_matrix
 from ..core.render import print_tree, render_tree_lines
 from ..core.scope import scope_to_changed, to_changed, with_default_paths
@@ -138,10 +139,11 @@ def finish_run(result: RunResult) -> int:
 
 def fix_cli(argv: list[str]) -> int:
 	"""``camas mcp fix [--paths P]…``: run the project's *registered* agent fix node
-	(``Config.agent.fix`` — whatever the user named it), scoped to the changed paths. This is
-	the FileChanged autofix entry, in the ``camas mcp`` namespace so it never collides with a
-	user's own ``camas <task>``. A clean no-op (exit 0) when no fix node is registered — without
-	registration there is simply nothing for the hook to run.
+	(``Config.agent.fix`` — whatever the user named it), scoped to the changed paths — taken from
+	``--paths`` or, failing that, the ``PostToolBatch`` event piped on stdin (the Claude Code
+	autofix hook). In the ``camas mcp`` namespace so it never collides with a user's own
+	``camas <task>``. A clean no-op (exit 0) when no fix node is registered — without registration
+	there is simply nothing for the hook to run.
 	"""
 	parser = argparse.ArgumentParser(
 		prog="camas mcp fix", description="Run the registered agent fix node."
@@ -167,7 +169,10 @@ def fix_cli(argv: list[str]) -> int:
 	if node is None:
 		return 0
 	base = state.source.parent if state.source is not None else Path.cwd()
-	changed = to_changed(args.paths, base)
+	stdin = stdin_changed() if not args.paths else None
+	if not args.paths and stdin is not None and not stdin:
+		return 0
+	changed = to_changed(args.paths or (stdin or ()), base)
 	expanded = expand_matrix(node)
 	scoped = scope_to_changed(expanded, changed) if changed else with_default_paths(expanded)
 	if args.dry_run:

--- a/src/camas/main/parser.py
+++ b/src/camas/main/parser.py
@@ -322,7 +322,8 @@ def build_parser(state: TasksState = EMPTY_STATE) -> argparse.ArgumentParser:
 		metavar="PATH[,PATH...]",
 		help="scope the run to these changed paths (repeatable): inject them into each "
 		"leaf's {paths} and drop leaves that match none, e.g. camas check --paths src/a.py. "
-		"A FileChanged hook drives the agent fix node this way via camas mcp fix --paths <file>",
+		"A PostToolBatch hook drives the agent fix node this way, feeding camas mcp fix the "
+		"changed files on stdin",
 	)
 	return parser
 

--- a/src/camas/main/starter.py
+++ b/src/camas/main/starter.py
@@ -48,15 +48,15 @@ ci = Sequential(
 
 # Your deterministic, behavior-preserving auto-fixers, with {paths} so a run scopes to the
 # changed files. Register the node (named anything) to Config.agent.fix below; the camas Claude
-# Code plugin's FileChanged hook runs it on every edit via `camas mcp fix --paths <file>`, for
-# free. Replace the placeholder with your real fixers, e.g.:
+# Code plugin's PostToolBatch hook runs it after each edit batch via `camas mcp fix` (the changed
+# files arrive on stdin), for free. Replace the placeholder with your real fixers, e.g.:
 #   autofix = Task("ruff check --fix {paths}", mutates=True, paths=".")
 #   autofix = Parallel(Task("ruff format {paths}", mutates=True), Task("ruff check --fix {paths}", mutates=True), paths=".")
 autofix = Task('python -c "" {paths}', name="autofix", mutates=True, paths=".")
 
 # Config is discovered by type, under any binding name (here `_`): bare `camas` runs
 # default_task — or github_task under GitHub Actions, falling back to default_task when unset.
-# agent= wires the Claude Code plugin: agent.fix is the registered FileChanged autofix node
+# agent= wires the Claude Code plugin: agent.fix is the registered PostToolBatch autofix node
 # above; the gate checks default_task (override with Claude(fix=..., check=...)). A checking
 # leaf can add agent_format=("--output-format sarif", "sarif") for machine-readable gate output.
 _ = Config(default_task=ci, agent=Claude(fix=autofix))

--- a/src/camas/mcp/cli.py
+++ b/src/camas/mcp/cli.py
@@ -17,7 +17,8 @@ Usage:
                               write this project's .mcp.json entry for the camas server;
                               with --hooks also write hook entries to .claude/settings.json
   camas mcp fix [--paths P]… run the registered agent fix node (Config.agent.fix) over the
-                              changed paths — the FileChanged autofix; no-op if unregistered
+                              changed paths (--paths, else a piped PostToolBatch event) — the
+                              autofix hook; no-op if unregistered
   camas mcp gate [task]     run the gate once, headless — print the verdict as JSON, exit
     [--paths P]… [--under N]  0 (continue) / 2 (block); scope to --paths or a piped
                               PostToolBatch event (the camas-fixer subagent + benchmark)

--- a/src/camas/mcp/scaffold.py
+++ b/src/camas/mcp/scaffold.py
@@ -135,7 +135,7 @@ def launch_command_str(*, rich: bool) -> str | None:
 
 
 def write_hooks(argv: list[str]) -> int:
-	"""Write the ``FileChanged`` autofix hook into ``.claude/settings.json`` using
+	"""Write the ``PostToolBatch`` autofix hook into ``.claude/settings.json`` using
 	``launch_command()`` resolution (without ``--rich``, which the hook does not need).
 	"""
 	settings_path = Path.cwd() / SETTINGS_PATH
@@ -167,22 +167,22 @@ def write_hooks(argv: list[str]) -> int:
 		hooks=[
 			HookCommand(
 				type="command",
-				command=f"{launcher} fix --paths ${{file_path}}",
+				command=f"{launcher} fix",
 			)
 		]
 	)
-	existing = settings.hooks.get("FileChanged", [])
+	existing = settings.hooks.get("PostToolBatch", [])
 	kept: list[HookGroup] = []
 	for g in existing:
-		remaining = [h for h in g.hooks if "mcp fix --paths" not in h.command]
+		remaining = [h for h in g.hooks if "mcp fix" not in h.command]
 		if remaining:
 			kept.append(g.model_copy(update={"hooks": remaining}))
-	settings.hooks["FileChanged"] = [*kept, camas_hook]
+	settings.hooks["PostToolBatch"] = [*kept, camas_hook]
 	settings_path.parent.mkdir(parents=True, exist_ok=True)
 	settings_path.write_text(settings.model_dump_json(indent=2) + "\n", encoding="utf-8")
 	print(
-		f"Wrote the camas FileChanged autofix hook to {settings_path}\n"
-		f"  FileChanged:    {launcher} fix --paths ${{file_path}}\n"
+		f"Wrote the camas PostToolBatch autofix hook to {settings_path}\n"
+		f"  PostToolBatch:  {launcher} fix\n"
 		f"\nReload Claude Code for the hook to take effect."
 	)
 	return 0

--- a/src/camas/mcp/serve.py
+++ b/src/camas/mcp/serve.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 
 import argparse
 import asyncio
-import json
 import os
 import re
 import shlex
@@ -18,7 +17,7 @@ from dataclasses import dataclass, field
 from enum import Enum
 from importlib.metadata import version
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Final, NamedTuple, cast
+from typing import TYPE_CHECKING, Any, Final, NamedTuple
 
 from mcp import types
 from mcp.server.lowlevel import Server
@@ -29,6 +28,7 @@ from ..core import timings
 from ..core.budget import plan_under
 from ..core.execution import run
 from ..core.gate import run_gate
+from ..core.hook_event import changed_from_stdin
 from ..core.matrix import expand_matrix, override_matrix
 from ..core.render import render_tree_lines, strip_ansi
 from ..core.scope import scope_to_changed, to_changed, with_default_paths
@@ -359,7 +359,7 @@ def tools(task_names: tuple[str, ...], compat: Compat) -> Tools:
 			description=textwrap.dedent("""\
 				The SA-delegation gate: scope THIS project's checks to the
 				files just changed, run them, and return a binary verdict. It does not mutate — the
-				deterministic fixers run separately on FileChanged (camas fix). residual_class is
+				deterministic fixers run separately on PostToolBatch (camas mcp fix). residual_class is
 				'green' (decision 'continue') when the checks pass, or 'needs_reasoning' (decision
 				'block') when a check still fails — then diagnostics carries the failing leaves. Pass
 				paths=[…] (the changed files) to scope; omit to gate the whole check node. under=<seconds>
@@ -1042,35 +1042,6 @@ def parse_gate_args(argv: list[str]) -> GateArgs:
 	return GateArgs(
 		task=ns.task, paths=tuple(ns.paths), under=ns.under, jobs=ns.jobs, dry_run=ns.dry_run
 	)
-
-
-def _event_get(obj: object, key: str) -> object:
-	"""``obj[key]`` for a parsed-JSON object, else ``None`` — narrows JSON's ``Any`` to ``object``."""
-	return cast("dict[str, object]", obj).get(key) if isinstance(obj, dict) else None
-
-
-def changed_from_stdin() -> tuple[str, ...]:
-	"""The edited files in a ``PostToolBatch`` event piped on stdin (e.g. a hand-wired hook),
-	de-duplicated in order; ``()`` when stdin is a tty, empty, or not such an event.
-	"""
-	if sys.stdin.isatty():
-		return ()
-	raw = sys.stdin.read().strip()
-	if not raw:
-		return ()
-	try:
-		event: object = json.loads(raw)
-	except json.JSONDecodeError:
-		return ()
-	calls = _event_get(event, "tool_calls")
-	if not isinstance(calls, list):
-		return ()
-	edited = (
-		_event_get(_event_get(call, "tool_input"), key)
-		for call in cast("list[object]", calls)
-		for key in ("file_path", "path", "notebook_path")
-	)
-	return tuple(dict.fromkeys(f for f in edited if isinstance(f, str)))
 
 
 def gate_cli(argv: list[str]) -> int:

--- a/src/camas/v0/config.py
+++ b/src/camas/v0/config.py
@@ -23,7 +23,7 @@ class Claude(NamedTuple):
 	"""The Claude Code agent integration: the explicitly declared fix and check nodes."""
 
 	fix: TaskNode
-	"""The deterministic, behavior-preserving autofix node the FileChanged hook runs (scoped,
+	"""The deterministic, behavior-preserving autofix node the PostToolBatch hook runs (scoped,
 	zero tokens). Declared, not derived from ``mutates`` — a mutating leaf may be codegen or a
 	compiler, which is not a fixer.
 	"""

--- a/tests/claude_code/_probe.py
+++ b/tests/claude_code/_probe.py
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2026 JP Hutchins
+
+"""Hook probe for the Claude Code contract test: append a JSON record of exactly what a hook
+command received — its ``argv`` (post shell-expansion, so ``${file_path}`` interpolation is
+visible) and the stdin payload — to ``$CAMAS_PROBE_LOG``. Run as a subprocess by the hooks under
+test, never imported, so it is outside the coverage run.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+
+def main() -> int:
+	stdin_raw = "" if sys.stdin.isatty() else sys.stdin.read()
+	try:
+		stdin_json = json.loads(stdin_raw) if stdin_raw.strip() else None
+	except json.JSONDecodeError:
+		stdin_json = None
+	record = {"argv": sys.argv, "stdin_json": stdin_json}
+	with Path(os.environ["CAMAS_PROBE_LOG"]).open("a", encoding="utf-8") as fh:
+		fh.write(json.dumps(record) + "\n")
+	return 0
+
+
+if __name__ == "__main__":
+	sys.exit(main())

--- a/tests/claude_code/conftest.py
+++ b/tests/claude_code/conftest.py
@@ -1,0 +1,53 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2026 JP Hutchins
+
+"""Opt-in Claude Code integration suite: drives a real headless ``claude -p`` to pin down camas's
+assumptions about Claude Code hooks (which events fire on an edit, how the changed path is
+delivered) and to prove the shipped autofix hook end to end.
+
+Skipped unless ``CAMAS_CC_E2E`` is set and ``claude`` is on PATH. The model is ``CAMAS_CC_MODEL``
+(default ``sonnet`` for local runs); CI sets it to ``deepseek-v4-flash`` and points the Anthropic
+backend env (``ANTHROPIC_BASE_URL``/``ANTHROPIC_AUTH_TOKEN``) at DeepSeek, exactly as the agentic
+review workflow does. Excluded from coverage (see ``pyproject.toml`` ``[tool.coverage.run]``).
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+	from collections.abc import Callable
+	from pathlib import Path
+
+_ENABLED = bool(os.environ.get("CAMAS_CC_E2E")) and shutil.which("claude") is not None
+
+
+@pytest.fixture
+def run_headless() -> Callable[[Path, str], subprocess.CompletedProcess[str]]:
+	"""A callable that runs ``claude -p`` headless in a cwd, edits auto-approved, model from env.
+
+	Every test in this suite requests it, so requesting it is what opts a test into the real run —
+	unless ``CAMAS_CC_E2E`` is set with ``claude`` on PATH, requesting it skips the test.
+	"""
+	if not _ENABLED:
+		pytest.skip(
+			"set CAMAS_CC_E2E=1 with `claude` on PATH to run the Claude Code integration suite"
+		)
+
+	def _run(cwd: Path, prompt: str) -> subprocess.CompletedProcess[str]:
+		model = os.environ.get("CAMAS_CC_MODEL", "sonnet")
+		return subprocess.run(
+			["claude", "-p", prompt, "--model", model, "--permission-mode", "acceptEdits"],
+			cwd=cwd,
+			capture_output=True,
+			text=True,
+			timeout=300,
+			check=False,
+		)
+
+	return _run

--- a/tests/claude_code/test_autofix_e2e.py
+++ b/tests/claude_code/test_autofix_e2e.py
@@ -1,0 +1,64 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2026 JP Hutchins
+
+"""End-to-end proof of the shipped autofix hook: a real headless edit fires ``PostToolBatch``,
+which runs the registered ``Config.agent.fix`` node over the just-changed file (path delivered on
+stdin), with zero model tokens. The registered fixer rewrites ``BANANA`` to ``FIXED``; the edit
+writes ``BANANA``; a green run leaves ``FIXED`` on disk.
+
+The hook runs the *local* camas (``python -m camas``), not ``uvx`` from PyPI, so it exercises the
+working tree.
+"""
+
+from __future__ import annotations
+
+import shlex
+import sys
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+	from collections.abc import Callable
+	from pathlib import Path
+	from subprocess import CompletedProcess
+
+_PY = shlex.quote(sys.executable)
+
+_FIXER = (
+	"import pathlib, sys\n"
+	"for p in sys.argv[1:]:\n"
+	"    fp = pathlib.Path(p)\n"
+	'    fp.write_text(fp.read_text().replace("BANANA", "FIXED"))\n'
+)
+
+_TASKS = (
+	"from camas import Claude, Config, Task\n"
+	f'tidy = Task("{_PY} fixer.py {{paths}}", name="tidy", mutates=True, paths=".")\n'
+	"_ = Config(agent=Claude(fix=tidy))\n"
+)
+
+_HOOK_SETTINGS = (
+	'{ "hooks": { "PostToolBatch": [ { "hooks": [ '
+	f'{{ "type": "command", "command": "{_PY} -m camas mcp fix" }}'
+	" ] } ] } }"
+)
+
+
+def test_post_tool_batch_hook_runs_the_registered_autofix(
+	tmp_path: Path, run_headless: Callable[[Path, str], CompletedProcess[str]]
+) -> None:
+	(tmp_path / "tasks.py").write_text(_TASKS)
+	(tmp_path / "fixer.py").write_text(_FIXER)
+	(tmp_path / ".claude").mkdir()
+	(tmp_path / ".claude" / "settings.json").write_text(_HOOK_SETTINGS)
+
+	proc = run_headless(
+		tmp_path,
+		"Create a file named sample.txt containing exactly the word BANANA. Use the Write tool and nothing else.",
+	)
+	assert proc.returncode == 0, proc.stderr
+
+	sample = tmp_path / "sample.txt"
+	assert sample.exists(), "the edit did not happen"
+	content = sample.read_text()
+	assert "BANANA" not in content, f"the autofix did not rewrite the changed file: {content!r}"
+	assert "FIXED" in content, f"the autofix did not rewrite the changed file: {content!r}"

--- a/tests/claude_code/test_hook_contract.py
+++ b/tests/claude_code/test_hook_contract.py
@@ -1,0 +1,114 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2026 JP Hutchins
+
+"""The Claude Code hook contract camas relies on, verified against a real headless run:
+
+- ``PostToolBatch`` fires on an edit and carries the changed file at
+  ``tool_calls[].tool_input.file_path`` (what ``camas mcp fix`` reads from stdin).
+- ``${file_path}`` is NOT interpolated into a command hook — it shell-expands to nothing, which
+  is why the hook delivers the path on stdin instead of via ``--paths ${file_path}``.
+- ``FileChanged`` does NOT fire on Claude's own edits (it is a disk watcher), so the autofix hook
+  is on ``PostToolBatch``.
+
+If a future Claude Code changes any of these, this suite fails and camas's hook is revisited.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import TYPE_CHECKING, cast
+
+if TYPE_CHECKING:
+	from collections.abc import Callable
+	from subprocess import CompletedProcess
+
+	import pytest
+
+_PROBE = Path(__file__).parent / "_probe.py"
+
+
+def _settings() -> dict[str, object]:
+	def probe(event: str, extra: str = "") -> dict[str, str]:
+		return {"type": "command", "command": f'python3 "{_PROBE}" --event={event}{extra}'}
+
+	return {
+		"hooks": {
+			"FileChanged": [{"hooks": [probe("FileChanged", " --paths ${file_path}")]}],
+			"PostToolUse": [
+				{
+					"matcher": "Write|Edit|MultiEdit",
+					"hooks": [probe("PostToolUse", " --paths ${file_path}")],
+				}
+			],
+			"PostToolBatch": [{"hooks": [probe("PostToolBatch")]}],
+		}
+	}
+
+
+def _get(obj: object, key: str) -> object:
+	return cast("dict[str, object]", obj).get(key) if isinstance(obj, dict) else None
+
+
+def _argv(record: object) -> list[str]:
+	raw = _get(record, "argv")
+	return (
+		[a for a in cast("list[object]", raw) if isinstance(a, str)]
+		if isinstance(raw, list)
+		else []
+	)
+
+
+def _event(record: object) -> object:
+	return _get(_get(record, "stdin_json"), "hook_event_name")
+
+
+def _batch_file_paths(record: object) -> list[str]:
+	calls = _get(_get(record, "stdin_json"), "tool_calls")
+	if not isinstance(calls, list):
+		return []
+	paths = (_get(_get(call, "tool_input"), "file_path") for call in cast("list[object]", calls))
+	return [p for p in paths if isinstance(p, str)]
+
+
+def _records(log: Path) -> list[object]:
+	return [json.loads(line) for line in log.read_text().splitlines() if line.strip()]
+
+
+def test_post_tool_batch_is_the_edit_event_and_file_path_is_not_interpolated(
+	tmp_path: Path,
+	monkeypatch: pytest.MonkeyPatch,
+	run_headless: Callable[[Path, str], CompletedProcess[str]],
+) -> None:
+	(tmp_path / ".claude").mkdir()
+	(tmp_path / ".claude" / "settings.json").write_text(json.dumps(_settings()))
+	log = tmp_path / "probe.log"
+	log.touch()
+	monkeypatch.setenv("CAMAS_PROBE_LOG", str(log))
+
+	proc = run_headless(
+		tmp_path,
+		"Create a file named PROBE.txt containing exactly the word MANGO. "
+		"Use the Write tool and nothing else.",
+	)
+	assert proc.returncode == 0, proc.stderr
+
+	records = _records(log)
+	assert (tmp_path / "PROBE.txt").exists(), "the edit did not happen"
+
+	batch_paths = [p for r in records if _event(r) == "PostToolBatch" for p in _batch_file_paths(r)]
+	assert batch_paths, "PostToolBatch did not fire on an edit with a changed path"
+	assert any(p.endswith("PROBE.txt") for p in batch_paths), (
+		f"PostToolBatch carried no path to the edited file: {batch_paths}"
+	)
+
+	interpolated = [r for r in records if "--paths" in _argv(r)]
+	assert interpolated, "expected a hook whose command contained --paths ${file_path}"
+	assert all(_argv(r)[-1] == "--paths" for r in interpolated), (
+		f"${{file_path}} was interpolated instead of shell-expanding to nothing: "
+		f"{[_argv(r) for r in interpolated]}"
+	)
+
+	assert all(_event(r) != "FileChanged" for r in records), (
+		"FileChanged should not fire on Claude's edits"
+	)

--- a/tests/main/test_dispatch.py
+++ b/tests/main/test_dispatch.py
@@ -3,6 +3,8 @@
 
 from __future__ import annotations
 
+import io
+import json
 from typing import TYPE_CHECKING, Any
 
 import pytest
@@ -308,8 +310,30 @@ def test_fix_cli_no_paths_runs_the_full_node(
 ) -> None:
 	(tmp_path / "tasks.py").write_text(_TIDY.format(scope="."))
 	monkeypatch.chdir(tmp_path)
+	monkeypatch.setattr("sys.stdin", io.StringIO(""))
 	assert fix_cli([]) == 0
 	assert (tmp_path / "fixed.txt").read_text() == "done"
+
+
+def test_fix_cli_reads_stdin_post_tool_batch_event(
+	tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+	(tmp_path / "tasks.py").write_text(_TIDY.format(scope="."))
+	monkeypatch.chdir(tmp_path)
+	event = json.dumps({"tool_calls": [{"tool_input": {"file_path": str(tmp_path / "x.py")}}]})
+	monkeypatch.setattr("sys.stdin", io.StringIO(event))
+	assert fix_cli([]) == 0
+	assert (tmp_path / "fixed.txt").read_text() == "done"
+
+
+def test_fix_cli_empty_post_tool_batch_event_is_noop(
+	tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+	(tmp_path / "tasks.py").write_text(_TIDY.format(scope="."))
+	monkeypatch.chdir(tmp_path)
+	monkeypatch.setattr("sys.stdin", io.StringIO(json.dumps({"tool_calls": [{"tool_input": {}}]})))
+	assert fix_cli([]) == 0
+	assert not (tmp_path / "fixed.txt").exists()
 
 
 def test_fix_cli_noop_without_config(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/mcp/test_gate_cli.py
+++ b/tests/mcp/test_gate_cli.py
@@ -10,6 +10,7 @@ import io
 import json
 from typing import TYPE_CHECKING
 
+from camas.core.hook_event import changed_from_stdin
 from camas.mcp import serve, wire
 
 if TYPE_CHECKING:
@@ -139,7 +140,7 @@ def test_changed_from_stdin_extracts_edited_files(monkeypatch: pytest.MonkeyPatc
 		}
 	)
 	monkeypatch.setattr("sys.stdin", io.StringIO(event))
-	assert serve.changed_from_stdin() == ("a.py", "b.py")
+	assert changed_from_stdin() == ("a.py", "b.py")
 
 
 def test_changed_from_stdin_tty_is_empty(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -148,27 +149,27 @@ def test_changed_from_stdin_tty_is_empty(monkeypatch: pytest.MonkeyPatch) -> Non
 			return True
 
 	monkeypatch.setattr("sys.stdin", _Tty("x"))
-	assert serve.changed_from_stdin() == ()
+	assert changed_from_stdin() == ()
 
 
 def test_changed_from_stdin_empty(monkeypatch: pytest.MonkeyPatch) -> None:
 	monkeypatch.setattr("sys.stdin", io.StringIO("  "))
-	assert serve.changed_from_stdin() == ()
+	assert changed_from_stdin() == ()
 
 
 def test_changed_from_stdin_bad_json(monkeypatch: pytest.MonkeyPatch) -> None:
 	monkeypatch.setattr("sys.stdin", io.StringIO("not json"))
-	assert serve.changed_from_stdin() == ()
+	assert changed_from_stdin() == ()
 
 
 def test_changed_from_stdin_dict_without_tool_calls(monkeypatch: pytest.MonkeyPatch) -> None:
 	monkeypatch.setattr("sys.stdin", io.StringIO(json.dumps({"foo": "bar"})))
-	assert serve.changed_from_stdin() == ()
+	assert changed_from_stdin() == ()
 
 
 def test_changed_from_stdin_non_dict_event(monkeypatch: pytest.MonkeyPatch) -> None:
 	monkeypatch.setattr("sys.stdin", io.StringIO(json.dumps([1, 2])))
-	assert serve.changed_from_stdin() == ()
+	assert changed_from_stdin() == ()
 
 
 def test_gate_cli_dry_run_shows_plan(

--- a/tests/mcp/test_scaffold.py
+++ b/tests/mcp/test_scaffold.py
@@ -202,11 +202,11 @@ def test_write_hooks_writes_settings_json(
 	monkeypatch.setattr("shutil.which", _which("camas"))
 	assert write_hooks([]) == 0
 	settings = json.loads((tmp_path / ".claude" / "settings.json").read_text())
-	file_changed = settings["hooks"]["FileChanged"][0]["hooks"][0]
-	assert file_changed["type"] == "command"
-	assert file_changed["command"] == "camas mcp fix --paths ${file_path}"
-	assert "PostToolBatch" not in settings["hooks"]
-	assert "FileChanged autofix hook" in capsys.readouterr().out
+	post_tool_batch = settings["hooks"]["PostToolBatch"][0]["hooks"][0]
+	assert post_tool_batch["type"] == "command"
+	assert post_tool_batch["command"] == "camas mcp fix"
+	assert "FileChanged" not in settings["hooks"]
+	assert "PostToolBatch autofix hook" in capsys.readouterr().out
 
 
 def test_write_hooks_errors_when_no_launcher(
@@ -263,7 +263,7 @@ def test_write_hooks_merges_existing_settings(
 	assert write_hooks([]) == 0
 	settings = json.loads((tmp_path / ".claude" / "settings.json").read_text())
 	assert settings["other_key"] == "value"
-	assert "FileChanged" in settings["hooks"]
+	assert "PostToolBatch" in settings["hooks"]
 
 
 def test_write_hooks_rejects_matcher_null(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -274,7 +274,7 @@ def test_write_hooks_rejects_matcher_null(tmp_path: Path, monkeypatch: pytest.Mo
 		json.dumps(
 			{
 				"hooks": {
-					"FileChanged": [
+					"PostToolBatch": [
 						{
 							"hooks": [{"type": "command", "command": "echo hi"}],
 							"matcher": None,
@@ -297,7 +297,7 @@ def test_write_hooks_preserves_matcher_empty_string(
 		json.dumps(
 			{
 				"hooks": {
-					"FileChanged": [
+					"PostToolBatch": [
 						{
 							"hooks": [{"type": "command", "command": "echo hi"}],
 							"matcher": "",
@@ -309,11 +309,11 @@ def test_write_hooks_preserves_matcher_empty_string(
 	)
 	assert write_hooks([]) == 0
 	settings = json.loads((tmp_path / ".claude" / "settings.json").read_text())
-	fc = settings["hooks"]["FileChanged"]
-	assert len(fc) == 2
-	echo_group = next(g for g in fc if any("echo hi" in h["command"] for h in g["hooks"]))
+	ptb = settings["hooks"]["PostToolBatch"]
+	assert len(ptb) == 2
+	echo_group = next(g for g in ptb if any("echo hi" in h["command"] for h in g["hooks"]))
 	assert echo_group.get("matcher") == ""
-	assert any("fix --paths" in h["command"] for g in fc for h in g["hooks"])
+	assert any(h["command"] == "camas mcp fix" for g in ptb for h in g["hooks"])
 
 
 def test_mcp_cli_init_hooks_routes_to_write_hooks(
@@ -354,19 +354,13 @@ def test_write_hooks_removes_camas_only_groups(
 		json.dumps(
 			{
 				"hooks": {
-					"FileChanged": [
-						{
-							"hooks": [
-								{"type": "command", "command": "camas mcp fix --paths ${file_path}"}
-							]
-						}
-					]
+					"PostToolBatch": [{"hooks": [{"type": "command", "command": "camas mcp fix"}]}]
 				}
 			}
 		)
 	)
 	assert write_hooks([]) == 0
 	settings = json.loads((tmp_path / ".claude" / "settings.json").read_text())
-	fc = settings["hooks"]["FileChanged"]
-	assert len(fc) == 1
-	assert "fix --paths" in fc[0]["hooks"][0]["command"]
+	ptb = settings["hooks"]["PostToolBatch"]
+	assert len(ptb) == 1
+	assert ptb[0]["hooks"][0]["command"] == "camas mcp fix"

--- a/tests/plugin/test_shipped_plugin.py
+++ b/tests/plugin/test_shipped_plugin.py
@@ -24,16 +24,16 @@ def test_bundled_mcp_server_launches_camas_mcp() -> None:
 	assert (server["command"], server["args"]) == ("uvx", ["camas[mcp]", "mcp"])
 
 
-def test_post_tool_batch_hook_is_absent() -> None:
+def test_filechanged_hook_is_absent() -> None:
 	hooks = json.loads((_PLUGIN / "hooks" / "hooks.json").read_text())["hooks"]
-	assert "PostToolBatch" not in hooks
+	assert "FileChanged" not in hooks
 
 
-def test_filechanged_hook_runs_the_deterministic_autofix() -> None:
+def test_post_tool_batch_hook_runs_the_deterministic_autofix() -> None:
 	hooks = json.loads((_PLUGIN / "hooks" / "hooks.json").read_text())["hooks"]
-	fc = hooks["FileChanged"][0]["hooks"][0]
-	assert fc["type"] == "command"
-	assert fc["command"] == "uvx 'camas[mcp]' mcp fix --paths ${file_path}"
+	ptb = hooks["PostToolBatch"][0]["hooks"][0]
+	assert ptb["type"] == "command"
+	assert ptb["command"] == "uvx 'camas[mcp]' mcp fix"
 
 
 def test_marketplace_points_at_the_shipped_plugin() -> None:


### PR DESCRIPTION
> [!WARNING]
> **LLM Disclosure**
>
> This PR was authored by claude-opus-4-8[1m] on behalf of @JPHutchins, who asked me to fix #129 (the first child of the #128 cleanup epic) after verifying it empirically.

Closes #129.

## The bug (verified live against Claude Code 2.1.198)

A headless probe hook (logging its `argv` + stdin) driven by real `claude -p` edits showed the shipped autofix hook was **doubly broken**:

1. **`${file_path}` is not interpolated** into a command hook — Claude Code only substitutes `${CLAUDE_PROJECT_DIR}` / `${CLAUDE_PLUGIN_ROOT}` / `${CLAUDE_PLUGIN_DATA}`, and sets no `file_path` env var. `--paths ${file_path}` shell-expands to nothing, so `camas mcp fix --paths` hits argparse *"expected one argument"* → **exit 2**.
2. **`FileChanged` never fires on Claude's own edits** — it is a disk watcher. Across two edit sessions it fired **0 times**; only `PostToolUse`/`PostToolBatch` did.

So the flagship token-free autofix could never run.

## The fix (an alignment, not a patch)

`PostToolBatch` fires per edit-batch and carries the changed paths at `tool_calls[].tool_input.file_path` — the exact JSON shape `changed_from_stdin()` already parses, and the same event the gate/`camas-fixer` already consume.

- Retarget the hook to **`PostToolBatch`**, command `uvx 'camas[mcp]' mcp fix` (drop `--paths ${file_path}`); the path arrives on stdin. `--paths` stays for manual runs.
- `fix_cli` reads stdin exactly like `gate_cli`. `changed_from_stdin` (plus a new tri-state `stdin_changed`) moves into a dependency-light `core/hook_event.py` so `camas mcp fix` keeps working without the `mcp` extra.
- **Empty-batch no-op:** a `PostToolBatch` with no edits (a Read/Bash batch — very common) now no-ops instead of running the fixer over the whole repo. `stdin_changed()` distinguishes *no event* (`None` → full run, for a manual `camas mcp fix`) from *event with zero edits* (`()` → no-op).
- Updated the prose/docstrings that named `FileChanged`/`${file_path}` (README, `starter.py`, `SKILL.md`, `parser.py`, `config.py`, `__init__.py`, `cli.py`, `scope.py`) and the scaffold / shipped-plugin tests.

## Regression protection — a Claude-Code-specific suite

`tests/claude_code/` is an opt-in suite (`CAMAS_CC_E2E=1`, model from `CAMAS_CC_MODEL`) that drives a **real** headless `claude -p`, excluded from coverage:

- **`test_hook_contract`** pins the CC facts camas relies on (PostToolBatch fires and carries the path on stdin; `${file_path}` does not interpolate; FileChanged does not fire) — so a future Claude Code that changes any of them fails here.
- **`test_autofix_e2e`** proves the whole chain: a real edit → `PostToolBatch` → local `python -m camas mcp fix` reads stdin → runs the registered `Config.agent.fix` node → the fixable defect is gone.

`.github/workflows/claude-code-harness.yaml` runs it weekly + on push against the DeepSeek backend (`ANTHROPIC_BASE_URL` + `ANTHROPIC_AUTH_TOKEN=DEEPSEEK_API_KEY`, `deepseek-v4-flash`), behind a harden-runner egress lock — the same working config as the agentic review workflow.

## Verification

- `camas all`: lint, format, mypy, pyright, ty, zuban, pyrefly, **coverage 100%** — all green.
- The CC suite opted-in vs real `sonnet`: **2/2 pass in 15s**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
