### PR TITLE
fix(mcp): allow extra fields on HookCommand so init --hooks tolerates real settings.json (#130)

### DIFF
--- a/src/camas/mcp/scaffold.py
+++ b/src/camas/mcp/scaffold.py
@@ -12,7 +12,7 @@ import sys
 from pathlib import Path
 from typing import Any, Final, Literal, cast
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
 from ..core.timings import ensure_camas_dir
 from ..v0.config import DEFAULT_CAMAS_DIR
@@ -22,9 +22,9 @@ SETTINGS_PATH: Final = Path(".claude/settings.json")
 
 
 class HookCommand(BaseModel):
-	"""A single hook command entry in ``.claude/settings.json``."""
+	"""A single hook command entry in ``.claude/settings.json``, with extra fields preserved."""
 
-	model_config = ConfigDict(extra="forbid")
+	model_config = ConfigDict(extra="allow")
 
 	type: Literal["command"]
 	command: str
@@ -151,7 +151,7 @@ def write_hooks(argv: list[str]) -> int:
 		return 2
 	try:
 		settings = SettingsFile.model_validate(raw)
-	except Exception as e:
+	except ValidationError as e:
 		print(f"error: {settings_path}: {e}", file=sys.stderr)
 		return 2
 	launcher = launch_command_str(rich=False)

--- a/tests/mcp/test_scaffold.py
+++ b/tests/mcp/test_scaffold.py
@@ -316,6 +316,51 @@ def test_write_hooks_preserves_matcher_empty_string(
 	assert any(h["command"] == "camas mcp fix" for g in ptb for h in g["hooks"])
 
 
+def test_write_hooks_preserves_extra_hook_command_fields(
+	tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+	monkeypatch.chdir(tmp_path)
+	monkeypatch.setattr("shutil.which", _which("camas"))
+	(tmp_path / ".claude").mkdir(parents=True)
+	(tmp_path / ".claude" / "settings.json").write_text(
+		json.dumps(
+			{
+				"hooks": {
+					"PreToolUse": [
+						{"hooks": [{"type": "command", "command": "guard", "timeout": 30}]}
+					],
+					"PostToolBatch": [
+						{
+							"hooks": [
+								{
+									"type": "command",
+									"command": "echo hi",
+									"statusMessage": "linting",
+								}
+							]
+						}
+					],
+				}
+			}
+		)
+	)
+	assert write_hooks([]) == 0
+	settings = json.loads((tmp_path / ".claude" / "settings.json").read_text())
+	assert settings["hooks"]["PreToolUse"][0]["hooks"][0]["timeout"] == 30
+	echo = next(
+		h
+		for g in settings["hooks"]["PostToolBatch"]
+		for h in g["hooks"]
+		if h["command"] == "echo hi"
+	)
+	assert echo["statusMessage"] == "linting"
+	assert any(
+		h["command"] == "camas mcp fix"
+		for g in settings["hooks"]["PostToolBatch"]
+		for h in g["hooks"]
+	)
+
+
 def test_mcp_cli_init_hooks_routes_to_write_hooks(
 	tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
> [!WARNING]
> **LLM Disclosure**
>
> This PR was authored by claude-opus-4-8[1m] on behalf of @JPHutchins, who asked me to continue the #128 cleanup epic with its next child, #130.

Closes #130.

> **Stacked on #142** (`fix/129-autofix-posttoolbatch`). The code fix is independent of #129, but the regression test exercises the post-#129 hook shape (`PostToolBatch` + `camas mcp fix`), so this branches off #142 to avoid a guaranteed conflict. GitHub retargets the base to `main` when #142 merges.

## The bug

Claude Code documents optional hook-command fields — `timeout`, `if`, `once`, `statusMessage`, `async`, `asyncRewake`, `shell`, `args`. But `HookCommand` in `src/camas/mcp/scaffold.py` was left on `extra="forbid"`:

```python
class HookCommand(BaseModel):
    model_config = ConfigDict(extra="forbid")
    type: Literal["command"]
    command: str
```

while its siblings `HookGroup` and `SettingsFile` were set to `extra="allow"` in #126 ("to tolerate unknown fields from future CC versions or plugins"). `HookCommand` was left behind.

So a user's `.claude/settings.json` carrying **any** hook command with e.g. `timeout` — on **any** event — makes `SettingsFile.model_validate(raw)` raise; the broad `except Exception` swallows it and `write_hooks` returns `2`, refusing to install the camas autofix hook.

## The fix

- `HookCommand.model_config = ConfigDict(extra="allow")` — matching its siblings, so unknown CC fields round-trip through the model instead of aborting the write.
- Narrow `except Exception` → `except ValidationError` (the only thing `model_validate` should raise here; per repo convention, don't swallow the unexpected).

## Regression test

`test_write_hooks_preserves_extra_hook_command_fields` seeds a settings.json with a `PreToolUse` hook carrying `timeout` (untouched event) and a `PostToolBatch` hook carrying `statusMessage` (the write-path event), then asserts `write_hooks` returns `0` and **both extra fields survive** the write, alongside the appended `camas mcp fix` hook.

## Verification

- `camas all`: lint, format, mypy, pyright, ty, zuban, pyrefly, **coverage 100%** — 8/8 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
