### PR TITLE
fix(main): to_expression renders group fields and tuple commands (#131)

### DIFF
--- a/src/camas/main/expression.py
+++ b/src/camas/main/expression.py
@@ -329,7 +329,9 @@ def to_expression(node: TaskNode) -> str:
 	>>> to_expression(Task("echo hi"))
 	'Task("echo hi")'
 	>>> to_expression(Task(("ruff", "check", ".")))
-	'Task("ruff check .")'
+	'Task(("ruff", "check", "."))'
+	>>> to_expression(Task(("solo",)))
+	'Task(("solo",))'
 	>>> to_expression(Task("ruff", name="lint"))
 	'Task("ruff", name="lint")'
 	>>> to_expression(Task("ruff format .", mutates=True))
@@ -340,6 +342,8 @@ def to_expression(node: TaskNode) -> str:
 	'Parallel(Task("a"), Task("b"), name="checks")'
 	>>> to_expression(Sequential(Parallel(Task("a"), name="p"), Task("b"), name="s"))
 	'Sequential(Parallel(Task("a"), name="p"), Task("b"), name="s")'
+	>>> to_expression(Parallel(Task("a"), name="checks", cwd="rust", help="all checks"))
+	'Parallel(Task("a"), name="checks", cwd="rust", help="all checks")'
 	>>> to_expression(Task("ruff check {paths}", name="lint", paths="src"))
 	'Task("ruff check {paths}", name="lint", paths="src")'
 	>>> to_expression(Task("test", cwd="rust", help="run tests"))
@@ -360,14 +364,20 @@ def to_expression(node: TaskNode) -> str:
 			agent_format=agent_format,
 		):
 			return (
-				f"Task({quote(join_command(cmd))}{name_kwarg(name)}{env_kwarg(env)}"
+				f"Task({render_command(cmd)}{name_kwarg(name)}{env_kwarg(env)}"
 				f"{cwd_kwarg(cwd)}{help_kwarg(help)}{mutates_kwarg(mutates)}"
 				f"{paths_kwarg(paths)}{agent_format_kwarg(agent_format)})"
 			)
-		case Sequential(tasks=tasks, name=name):
-			return f"Sequential({render_members(tasks)}{name_kwarg(name)})"
-		case Parallel(tasks=tasks, name=name):
-			return f"Parallel({render_members(tasks)}{name_kwarg(name)})"
+		case Sequential(tasks=tasks, name=name, matrix=matrix, env=env, cwd=cwd, help=help):
+			return (
+				f"Sequential({render_members(tasks)}{name_kwarg(name)}{matrix_kwarg(matrix)}"
+				f"{env_kwarg(env)}{cwd_kwarg(cwd)}{help_kwarg(help)})"
+			)
+		case Parallel(tasks=tasks, name=name, matrix=matrix, env=env, cwd=cwd, help=help):
+			return (
+				f"Parallel({render_members(tasks)}{name_kwarg(name)}{matrix_kwarg(matrix)}"
+				f"{env_kwarg(env)}{cwd_kwarg(cwd)}{help_kwarg(help)})"
+			)
 		case _:
 			assert_never(node)
 
@@ -378,6 +388,10 @@ def render_members(tasks: tuple[TaskNode, ...]) -> str:
 
 def name_kwarg(name: str | None) -> str:
 	return f", name={quote(name)}" if name is not None else ""
+
+
+def matrix_kwarg(matrix: dict[str, tuple[str, ...]] | None) -> str:
+	return f", matrix={matrix!r}" if matrix is not None else ""
 
 
 def env_kwarg(env: Mapping[str, str]) -> str:
@@ -417,8 +431,11 @@ def quote(value: str) -> str:
 	return json.dumps(value, ensure_ascii=False)
 
 
-def join_command(cmd: str | tuple[str, ...]) -> str:
-	return cmd if isinstance(cmd, str) else " ".join(cmd)
+def render_command(cmd: str | tuple[str, ...]) -> str:
+	if isinstance(cmd, str):
+		return quote(cmd)
+	inner = ", ".join(quote(part) for part in cmd)
+	return f"({inner},)" if len(cmd) == 1 else f"({inner})"
 
 
 def parse_task_value(raw: str) -> TaskNode | Ref:

--- a/tests/main/test_expression.py
+++ b/tests/main/test_expression.py
@@ -35,6 +35,21 @@ def test_to_expression_round_trips_every_field() -> None:
 	assert parse_expression(to_expression(task)) == task
 
 
+def test_to_expression_round_trips_group_fields_and_tuple_commands() -> None:
+	"""#131: the group fields (matrix/env/cwd/help) and tuple/exec commands survive the
+	round-trip too — #85 fixed only the Task arm, leaving groups and tuples lossy."""
+	group = Parallel(
+		Task(("uv", "run", "pytest")),
+		Task(("solo",)),
+		name="checks",
+		matrix={"PY": ("3.13", "3.14"), "OS": ("linux",)},
+		env={"CI": "1"},
+		cwd="rust",
+		help="all checks",
+	)
+	assert parse_expression(to_expression(group)) == group
+
+
 @pytest.mark.parametrize(
 	("expr", "expected"),
 	[

--- a/tests/mcp/test_catalog.py
+++ b/tests/mcp/test_catalog.py
@@ -51,7 +51,9 @@ def test_matrix_axes_reported_with_unexpanded_preview_by_default() -> None:
 	node = Parallel(Task("test {PY}"), matrix={"PY": ("3.13", "3.14")}, name="m")
 	resp = to_list_response({"m": node}, None)
 	assert resp.tasks[0].matrix_axes == {"PY": ["3.13", "3.14"]}
-	assert resp.tasks[0].command_preview == 'Parallel(Task("test {PY}"), name="m")'
+	assert resp.tasks[0].command_preview == (
+		"Parallel(Task(\"test {PY}\"), name=\"m\", matrix={'PY': ('3.13', '3.14')})"
+	)
 
 
 def test_expand_inlines_every_matrix_leaf() -> None:


### PR DESCRIPTION
> [!WARNING]
> **LLM Disclosure**
>
> This PR was authored by claude-opus-4-8[1m] on behalf of @JPHutchins, continuing the #128 cleanup epic — she asked me to move on to the next child (#131) after landing #129/#130.

Closes #131. Completes the round-trip fix #85 started (which covered only the `Task` arm).

## The loss

`to_expression` promised an agent could paste its output back into `tasks.py` or a `camas` expression unchanged, and `camas_list`'s `command_preview` is built on it. But it was lossy two ways:

1. **Group fields dropped.** The `Sequential`/`Parallel` arms rendered only `name`, silently discarding `matrix` / `env` / `cwd` / `help`. `to_expression(Parallel(Task("a"), matrix={"PY": ("3.13", "3.14")}, help="…"))` came back as `Parallel(Task("a"))`.
2. **Tuple/exec commands flattened.** `Task(("sh", "-c", "echo a; echo b"))` rendered as `Task("sh -c echo a; echo b")` — parse that back and `;` now separates shell commands, a *different program*.

## The fix

- The group arms now render `matrix`/`env`/`cwd`/`help` through the existing `*_kwarg` helpers (new `matrix_kwarg`).
- `render_command` (replacing `join_command`) emits a tuple command as a **tuple literal** — `Task(("sh", "-c", …))` — with the single-element trailing comma handled, so it round-trips as an exec-form command rather than a shell string.

## Tests

- New `test_to_expression_round_trips_group_fields_and_tuple_commands`: a `Parallel` with `matrix` (multi-axis), `env`, `cwd`, `help`, `name`, and both multi- and single-element tuple commands round-trips unchanged. (The old `test_to_expression_round_trips_every_field` only exercised a `Task`, which masked this.)
- New docstring doctests for the tuple-literal and group-field forms.
- Updated `test_matrix_axes_reported_with_unexpanded_preview_by_default`, which had pinned the lossy behavior — the unexpanded `command_preview` now surfaces the `matrix` instead of dropping it. The expanded-preview path is unchanged (`expand_matrix` consumes the matrix into leaves, leaving `matrix=None`).

## Verification

- `camas all`: lint, format, mypy, pyright, ty, zuban, pyrefly, **coverage 100%** — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
