### PR TITLE
ci(harness): fix egress-lock race — uv from PyPI, system Python, minimal allowlist

### DIFF
--- a/.github/workflows/claude-code-harness.yaml
+++ b/.github/workflows/claude-code-harness.yaml
@@ -33,12 +33,20 @@ jobs:
         with:
           node-version: "22"
 
-      - uses: astral-sh/setup-uv@v8.2.0
+      # uv comes from PyPI (already allowlisted) rather than astral-sh/setup-uv, which resolves
+      # versions via raw.githubusercontent.com and pulls the binary from releases.astral.sh — both
+      # would need allowlisting. harden-runner enforces from its pre-step, so the lock covers setup
+      # too regardless of step order; every host setup touches must be on the allowlist below.
+      - name: Install uv (pinned)
+        run: |
+          pipx install --force uv==0.9.15
+          echo "$(pipx environment --value PIPX_BIN_DIR)" >> "$GITHUB_PATH"
+      - run: uv --version
 
       - run: npm install -g @anthropic-ai/claude-code@2.1.197
 
-      # Lock egress AFTER trusted setup (whose downloads we don't want to fight) and BEFORE the
-      # headless run. Only the hosts the suite needs; a blocked host shows in this step's summary.
+      # Allowlist = the hosts setup (uv wheels from PyPI, claude-code from npm) and the headless
+      # suite (DeepSeek) reach; a blocked host shows in this step's summary.
       - name: Lock network egress
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
@@ -47,6 +55,7 @@ jobs:
             api.deepseek.com:443
             pypi.org:443
             files.pythonhosted.org:443
+            registry.npmjs.org:443
             github.com:443
             objects.githubusercontent.com:443
 

--- a/.github/workflows/claude-code-harness.yaml
+++ b/.github/workflows/claude-code-harness.yaml
@@ -59,12 +59,17 @@ jobs:
             github.com:443
             objects.githubusercontent.com:443
 
+      # The contract suite needs any interpreter >=3.10; --python 3.12 pins the runner's system
+      # Python so uv does not download the .python-version default (3.14) from a GitHub release
+      # asset host that is not on the allowlist. UV_PYTHON_DOWNLOADS=never makes a missing one fail
+      # fast, before the DeepSeek-billed run.
       - name: Run the Claude Code integration suite
         env:
           CAMAS_CC_E2E: "1"
           CAMAS_CC_MODEL: deepseek-v4-flash
           ANTHROPIC_BASE_URL: https://api.deepseek.com/anthropic
           ANTHROPIC_AUTH_TOKEN: ${{ secrets.DEEPSEEK_API_KEY }}
+          UV_PYTHON_DOWNLOADS: never
         run: |
           [ -n "$ANTHROPIC_AUTH_TOKEN" ] || { echo "::error::DEEPSEEK_API_KEY secret is not set"; exit 1; }
-          uv run pytest tests/claude_code/ -v --no-cov -p no:cacheprovider
+          uv run --python 3.12 pytest tests/claude_code/ -v --no-cov -p no:cacheprovider


### PR DESCRIPTION
> [!WARNING]
> **LLM Disclosure**
>
> This PR was authored by claude-opus-4-8[1m] on behalf of @JPHutchins. While monitoring CI for #143 and #145 she asked me to fix the failing `harness` job so those PRs could merge green; this fixes its root cause.

## The bug

`harness` was failing intermittently at `astral-sh/setup-uv` (`fetch failed` on `raw.githubusercontent.com`). Root cause: **harden-runner enforces its egress `block` from the pre-step**, so the workflow's "lock egress *after* trusted setup" step ordering never actually shielded the setup downloads. The job only ever passed when harden-runner **silently fell back to audit mode** (i.e. no egress protection at all); when it genuinely enforced `block`, `setup-uv` died fetching the astral version manifest from `raw.githubusercontent.com` — a host not on the allowlist.

So the "minimal allowlist" was never real: setup routinely reached `raw.githubusercontent.com`, `releases.astral.sh`, `registry.npmjs.org`, and a GitHub release-asset CDN, all only because the block wasn't in force.

## The fix

Make the job pass **with the block genuinely enforced**, while keeping the allowlist minimal:

1. **uv from PyPI, pinned** (`pipx install uv==0.9.15`) instead of `astral-sh/setup-uv`. PyPI (`pypi.org` / `files.pythonhosted.org`) is already allowlisted, so this drops the dependency on `raw.githubusercontent.com` **and** `releases.astral.sh`. A `uv --version` gate fails fast on a PATH error, before the DeepSeek-billed run.
2. **`registry.npmjs.org`** added to the allowlist — unavoidable, since `claude-code` ships only via npm.
3. **Pin the suite to the runner's system Python** (`uv run --python 3.12` + `UV_PYTHON_DOWNLOADS=never`). Otherwise `uv run` downloads the `.python-version` default (3.14) as a managed CPython from `release-assets.githubusercontent.com` (GitHub's newer asset CDN, not the allowlisted `objects.githubusercontent.com`). The hook-contract suite needs only an interpreter ≥3.10.

Net allowlist growth: **exactly one host** (`registry.npmjs.org`); the workflow no longer touches `raw.githubusercontent.com`, `releases.astral.sh`, or `release-assets.githubusercontent.com`.

## Validation

Pushed to this branch (which triggers `harness` on the workflow-path filter). The run is **green end-to-end with `egress-policy: block` genuinely enforced** — setup, the egress lock, and the DeepSeek-backed integration suite all pass. The two earlier red runs died before any `claude -p` call, so they cost $0 of the burner key.

Unblocks the green merge of #143 and #145; relates to the harness-hardening work under the #128 epic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
