### PR TITLE
fix(core): to_changed splits comma entries and drops blanks (#132)

### DIFF
--- a/src/camas/core/scope.py
+++ b/src/camas/core/scope.py
@@ -41,21 +41,28 @@ PATHS_TOKEN: Final = "{paths}"
 
 def to_changed(raw: Iterable[str], base: Path) -> tuple[str, ...]:
 	"""Normalize externally-supplied changed paths to the repo-relative POSIX form
-	:func:`scope_to_changed` matches: resolve each against ``base`` (a hook's stdin paths are
-	absolute), drop any that fall outside it. The boundary every changed set passes through —
-	the CLI ``--paths``, the ``camas_gate`` request, and a hook's files all carry raw paths.
+	:func:`scope_to_changed` matches: split comma-separated entries, drop blanks, resolve each
+	against ``base`` (a hook's stdin paths are absolute), and drop any that fall outside it. The
+	single boundary every changed set passes through — the CLI ``--paths``, the ``camas_gate``
+	request, and a hook's files all normalize here, so identical input scopes identically.
 
 	>>> import tempfile, os
 	>>> d = Path(tempfile.mkdtemp()); _ = (d / "src").mkdir()
 	>>> _ = (d / "src" / "a.py").write_text(""); _ = (d / "b.py").write_text("")
 	>>> to_changed([str(d / "src" / "a.py"), "b.py", "/elsewhere/x.py"], d)
 	('src/a.py', 'b.py')
+	>>> to_changed(["src/a.py,b.py"], d)
+	('src/a.py', 'b.py')
+	>>> to_changed(["", "  ", "b.py"], d)
+	('b.py',)
 	"""
 	root = base.resolve()
 	return tuple(
 		rp.relative_to(root).as_posix()
 		for r in raw
-		if (rp := (root / r).resolve()).is_relative_to(root)
+		for e in r.split(",")
+		if (entry := e.strip())
+		if (rp := (root / entry).resolve()).is_relative_to(root)
 	)
 
 

--- a/src/camas/main/dispatch.py
+++ b/src/camas/main/dispatch.py
@@ -152,8 +152,8 @@ def fix_cli(argv: list[str]) -> int:
 		"--paths",
 		action="append",
 		default=[],
-		metavar="PATH",
-		help="changed path to scope to (repeatable)",
+		metavar="PATH[,PATH...]",
+		help="changed paths to scope to (repeatable, comma-separated)",
 	)
 	parser.add_argument(
 		"--dry-run",
@@ -395,12 +395,11 @@ def dispatch(state: TasksState, argv: list[str] | None = None) -> None:
 
 			if args.paths is not None:
 				base = source.parent if source is not None else Path.cwd()
-				raw_changed = tuple(p for raw in args.paths for p in parse_axis_values(raw))
-				changed = to_changed(raw_changed, base)
+				changed = to_changed(args.paths, base)
 				scoped = scope_to_changed(expand_matrix(resolved), changed) if changed else None
 				if scoped is None:
 					print(
-						f"No task leaf covers {', '.join(raw_changed) or '(no paths given)'}"
+						f"No task leaf covers {', '.join(changed) or '(no paths given)'}"
 						" — nothing to run."
 					)
 					sys.exit(0)

--- a/src/camas/mcp/serve.py
+++ b/src/camas/mcp/serve.py
@@ -1025,8 +1025,8 @@ def parse_gate_args(argv: list[str]) -> GateArgs:
 		"--paths",
 		action="append",
 		default=[],
-		metavar="PATH",
-		help="changed path to scope to (repeatable)",
+		metavar="PATH[,PATH...]",
+		help="changed paths to scope to (repeatable, comma-separated)",
 	)
 	parser.add_argument(
 		"--under", type=float, default=None, metavar="SECONDS", help="wall-clock budget"

--- a/tests/core/test_scope.py
+++ b/tests/core/test_scope.py
@@ -3,8 +3,13 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from camas import Parallel, Sequential, Task
-from camas.core.scope import scope_to_changed, with_default_paths
+from camas.core.scope import scope_to_changed, to_changed, with_default_paths
+
+if TYPE_CHECKING:
+	from pathlib import Path
 
 
 def _cmd(node: object) -> str | tuple[str, ...]:
@@ -95,3 +100,17 @@ def test_backslash_changed_paths_are_normalized() -> None:
 def test_paths_with_spaces_are_shell_quoted_in_string_command() -> None:
 	fmt = Task("ruff format {paths}", name="fmt", paths=".")
 	assert _cmd(scope_to_changed(fmt, ("a b.py",))) == "ruff format 'a b.py'"
+
+
+def test_to_changed_drops_blank_entries(tmp_path: Path) -> None:
+	"""#132: a blank ``--paths`` entry (or a hook delivering an empty path) contributes nothing,
+	rather than resolving to ``.`` and widening a scoped run to the whole tree."""
+	assert to_changed(["", "  "], tmp_path) == ()
+	assert to_changed(["", "a.py"], tmp_path) == ("a.py",)
+
+
+def test_to_changed_splits_comma_separated_entries(tmp_path: Path) -> None:
+	"""#132: one comma-joined entry scopes identically to the same paths passed separately, so
+	``--paths a,b`` matches across every entrypoint that routes through ``to_changed``."""
+	assert to_changed(["a.py,b.py"], tmp_path) == ("a.py", "b.py")
+	assert to_changed(["a.py,b.py"], tmp_path) == to_changed(["a.py", "b.py"], tmp_path)


### PR DESCRIPTION
> [!WARNING]
> **LLM Disclosure**
>
> This PR was authored by claude-opus-4-8[1m] on behalf of @JPHutchins, continuing the #128 cleanup epic — she asked me to move on to #132 after landing #129/#130/#131.

Closes #132.

## The bugs

The three `--paths` entrypoints normalized changed paths inconsistently, and one input silently widened a scoped run to the whole tree:

1. **Empty entry → whole tree.** `(root / "").resolve()` is `root`, so a blank `--paths` entry (or a hook delivering an empty `file_path`) resolved to `.` — and `.` covers everything. `camas mcp fix --paths ""`, or one blank path in a `PostToolBatch` batch, therefore scoped the whole tree, blowing the `--under` budget and the fast-scope promise. The worst case: a batch with one blank path *plus* real edits widened the entire batch to the whole tree.
2. **Comma-split divergence.** `camas <task> --paths a,b` split into two paths (via `parse_axis_values`), but `camas mcp fix --paths a,b` and `camas mcp gate --paths a,b` treated `a,b` as one literal path (which then resolved to a nonexistent file and got dropped). The metavars codified it: `PATH[,PATH...]` on the main parser vs `PATH` on fix/gate.

## The fix

Fold split-and-drop-blanks into `to_changed` — the single boundary every changed set passes through (CLI `--paths`, the `camas_gate` request, and a hook's stdin), as its own docstring already claimed. Now identical input scopes identically everywhere:

- Each raw entry is split on `,`, stripped, and dropped if blank, before the existing resolve-and-drop-outside-root step.
- `dispatch`'s inline `parse_axis_values` path-split is now redundant and removed (it still splits matrix axis values).
- The `camas mcp fix` / `camas mcp gate` `--paths` metavars now advertise `PATH[,PATH...]`, matching the main parser.

## Tests

- Two `to_changed` doctests: a comma-joined entry splits into two paths; blank/whitespace entries contribute nothing (the whole-tree regression).
- `test_to_changed_drops_blank_entries` + `test_to_changed_splits_comma_separated_entries`, the latter asserting `["a,b"]` scopes identically to `["a", "b"]`.
- The existing `test_dispatch_paths_empty_skips` now exercises the normalized path.

## Verification

- `camas all`: lint, format, mypy, pyright, ty, zuban, pyrefly, **coverage 100%** — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
