### PR TITLE
feat(scope): paths on Group + correct {paths}-less run rule; #141 docs papercuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,15 +216,17 @@ Durations are `1s`, `500ms`, `2m`, `1h`, or a bare number of seconds. Only leave
 
 ## Path scoping (`--paths`)
 
-`camas <task> --paths <path>…` scopes a run to changed paths instead of the whole tree. A leaf opts in by writing the `{paths}` placeholder in its command and declaring its scope with `paths=` — a directory prefix, or a `(changed) -> paths` callable:
+`camas <task> --paths <path>…` scopes a run to changed paths instead of the whole tree. A command opts in by writing the `{paths}` placeholder and declaring its scope with `paths=` — a directory prefix, or a `(changed) -> paths` callable. A `Sequential`/`Parallel` may carry `paths=` too: it's the default scope for descendant `{paths}` commands that set none (the same way `env`/`cwd` propagate into a group's leaves):
 
 ```python
 py = Task("ruff format {paths}", mutates=True, paths="src")
 web = Task("prettier --write {paths}", mutates=True, paths="web")
-_ = Config(agent=Claude(fix=Sequential(py, web)))
+# the group's paths="." is the default for both children (neither sets its own):
+autofix = Parallel(Task("ruff format {paths}"), Task("ruff check --fix {paths}"), paths=".")
+_ = Config(agent=Claude(fix=Sequential(py, web, autofix)))
 ```
 
-`--paths` works on any task — `camas check --paths src/a.py`. Without it, every `{paths}` resolves to its full-run default (`ruff format src`); with it, each leaf runs only over the changed files it covers, and a leaf that covers none is dropped (`--paths` is repeatable, or comma-separated).
+`--paths` works on any task — `camas check --paths src/a.py`. Without it, every `{paths}` resolves to its full-run default (`ruff format src`); with it, each `{paths}` command runs only over the changed files it covers, and one covering none is dropped. A command **without** `{paths}` can't be narrowed, so its `paths=` is a no-op and it always runs — camas errs on correctness (a tool it can't narrow might be affected by the edit). `--paths` is repeatable, or comma-separated.
 
 For the Claude Code plugin, you **register** the auto-fix node — whatever you named it — to `Config.agent.fix`; the PostToolBatch hook runs *that* node over the just-changed files, zero model tokens. Install the plugin (`/plugin marketplace add JPHutchins/camas`), run `camas mcp init --hooks` (which writes the hook with the launcher it resolves for your project), or wire it by hand:
 

--- a/src/camas/__init__.py
+++ b/src/camas/__init__.py
@@ -64,7 +64,7 @@ README's Versioning section.
 ``Config(agent=Claude(fix=..., check=...))`` wires the Claude Code
 plugin's gate. ``fix`` is the deterministic, behavior-preserving autofix
 node the ``PostToolBatch`` hook runs over the changed files (scope it with
-``{paths}``; zero model tokens) — declared, not inferred from
+``{paths}``, on a leaf or a whole group; zero model tokens) — declared, not inferred from
 ``mutates=``, since a mutating leaf may be a compiler or codegen rather
 than a fixer. ``check`` is the node the gate validates (``None`` defers
 to ``default_task``/``github_task``), scoped by ``--paths`` and

--- a/src/camas/__init__.py
+++ b/src/camas/__init__.py
@@ -36,8 +36,9 @@ recorded timing fits the budget — the marked, mutating ones first in
 sequence, then the read-only rest in parallel — a fast, self-pruning
 inner-loop subset of a task. ``camas_run`` exposes the same budget as its
 ``under`` argument. That subset is what a pre-commit / git-hook wants;
-untimed leaves are excluded, so an empty cache (a fresh clone) runs
-nothing under a budget until the task has run once unbudgeted.
+untimed leaves run (and are thereby measured), only leaves measured over
+budget are excluded, so a cold cache (a fresh clone) runs the whole tree
+under a budget until the leaves have been measured once.
 
 Two authoring idioms the engine can't enforce: ``tasks.py`` is
 real Python, so source matrix axis values from the project's single

--- a/src/camas/core/gate.py
+++ b/src/camas/core/gate.py
@@ -13,7 +13,7 @@ import shlex
 import sys
 from typing import TYPE_CHECKING, Literal, NamedTuple, TypeAlias
 
-from ..v0.task import Parallel, Sequential, Task
+from ..v0.task import Group, Task
 from .budget import plan_under
 from .execution import run
 from .matrix import expand_matrix
@@ -86,23 +86,15 @@ def with_agent_format(node: TaskNode) -> TaskNode:
 				else (*node.cmd, *shlex.split(args))
 			)
 			return dataclasses.replace(node, cmd=cmd)
-		case Sequential(tasks=children, name=name, matrix=matrix, env=env, cwd=cwd, help=help):
-			return Sequential(
-				*(with_agent_format(c) for c in children),
-				name=name,
-				matrix=matrix,
-				env=env,
-				cwd=cwd,
-				help=help,
-			)
-		case Parallel(tasks=children, name=name, matrix=matrix, env=env, cwd=cwd, help=help):
-			return Parallel(
-				*(with_agent_format(c) for c in children),
-				name=name,
-				matrix=matrix,
-				env=env,
-				cwd=cwd,
-				help=help,
+		case Group() as group:
+			return type(group)(
+				*(with_agent_format(c) for c in group.tasks),
+				name=group.name,
+				matrix=group.matrix,
+				env=group.env,
+				cwd=group.cwd,
+				help=group.help,
+				paths=group.paths,
 			)
 		case _:
 			assert_never(node)

--- a/src/camas/core/matrix.py
+++ b/src/camas/core/matrix.py
@@ -17,7 +17,7 @@ if sys.version_info >= (3, 11):
 else:  # pragma: no cover
 	from typing_extensions import assert_never
 
-from ..v0.task import Parallel, Sequential, Task, TaskNode
+from ..v0.task import Group, Parallel, Sequential, Task, TaskNode
 from .task import MatrixBinding, VarBinding, task_label
 
 if TYPE_CHECKING:
@@ -121,19 +121,13 @@ def specialize_node(task: TaskNode, binding: MatrixBinding, suffix: str) -> Task
 	match task:
 		case Task():
 			return specialize_task(task, binding, suffix)
-		case Sequential(tasks=tasks, name=name, cwd=cwd, help=help):
-			return Sequential(
-				*(specialize_node(t, binding, suffix) for t in tasks),
-				name=f"{name} {suffix}" if name is not None else None,
-				cwd=substitute_cwd(cwd, binding),
-				help=substitute_help(help, binding),
-			)
-		case Parallel(tasks=tasks, name=name, cwd=cwd, help=help):
-			return Parallel(
-				*(specialize_node(t, binding, suffix) for t in tasks),
-				name=f"{name} {suffix}" if name is not None else None,
-				cwd=substitute_cwd(cwd, binding),
-				help=substitute_help(help, binding),
+		case Group() as group:
+			return type(group)(
+				*(specialize_node(t, binding, suffix) for t in group.tasks),
+				name=f"{group.name} {suffix}" if group.name is not None else None,
+				cwd=substitute_cwd(group.cwd, binding),
+				help=substitute_help(group.help, binding),
+				paths=substitute_paths(group.paths, binding),
 			)
 		case _:
 			assert_never(task)
@@ -198,23 +192,15 @@ def apply_overrides(task: TaskNode, overrides: Mapping[str, tuple[str, ...]]) ->
 	match task:
 		case Task():
 			return task
-		case Sequential(tasks=tasks, name=name, matrix=matrix, env=env, cwd=cwd, help=help):
-			return Sequential(
-				*(apply_overrides(t, overrides) for t in tasks),
-				name=name,
-				matrix=applied(matrix),
-				env=env,
-				cwd=cwd,
-				help=help,
-			)
-		case Parallel(tasks=tasks, name=name, matrix=matrix, env=env, cwd=cwd, help=help):
-			return Parallel(
-				*(apply_overrides(t, overrides) for t in tasks),
-				name=name,
-				matrix=applied(matrix),
-				env=env,
-				cwd=cwd,
-				help=help,
+		case Group() as group:
+			return type(group)(
+				*(apply_overrides(t, overrides) for t in group.tasks),
+				name=group.name,
+				matrix=applied(group.matrix),
+				env=group.env,
+				cwd=group.cwd,
+				help=group.help,
+				paths=group.paths,
 			)
 		case _:
 			assert_never(task)
@@ -312,12 +298,13 @@ def expand_matrix(
 	task: TaskNode,
 	ancestor_env: Mapping[str, str] | None = None,
 	ancestor_cwd: Path | None = None,
+	ancestor_paths: str | PathScope | None = None,
 ) -> TaskNode:
-	"""Recursively expand all matrix parameters and propagate container env/cwd into leaves.
+	"""Recursively expand all matrix parameters and propagate container env/cwd/paths into leaves.
 
-	Container env and cwd are also retained on the expanded group nodes (for display
-	purposes); execution still reads the accumulated values from leaves. A child's
-	``cwd`` takes precedence over an ancestor's.
+	Container env, cwd, and paths are also retained on the expanded group nodes (for display
+	purposes); execution and scoping read the accumulated values from leaves. A child's own
+	``cwd``/``paths`` takes precedence over an ancestor's.
 
 	>>> expand_matrix(Task("echo hi"))
 	Task(cmd='echo hi', name=None, env={}, cwd=None)
@@ -328,6 +315,8 @@ def expand_matrix(
 	{'K': 'v'}
 	>>> expand_matrix(Parallel(Task("hi"), cwd=Path("w"))).tasks[0].cwd == Path("w")  # type: ignore[union-attr]
 	True
+	>>> expand_matrix(Parallel(Task("ruff {paths}"), paths=".")).tasks[0].paths  # type: ignore[union-attr]
+	'.'
 	"""
 	parent_env: Final = dict(ancestor_env) if ancestor_env else {}
 	match task:
@@ -339,22 +328,32 @@ def expand_matrix(
 				cwd=task.cwd if task.cwd is not None else ancestor_cwd,
 				help=task.help,
 				mutates=task.mutates,
-				paths=task.paths,
+				paths=task.paths if task.paths is not None else ancestor_paths,
 				agent_format=task.agent_format,
 			)
-		case Sequential(tasks=tasks, matrix=matrix, env=env, cwd=cwd):
+		case Sequential(tasks=tasks, matrix=matrix, env=env, cwd=cwd, paths=paths):
 			seq_env: Final = parent_env | env
 			seq_cwd: Final = cwd if cwd is not None else ancestor_cwd
-			seq_expanded: Final = tuple(expand_matrix(t, seq_env, seq_cwd) for t in tasks)
+			seq_paths: Final = paths if paths is not None else ancestor_paths
+			seq_expanded: Final = tuple(
+				expand_matrix(t, seq_env, seq_cwd, seq_paths) for t in tasks
+			)
 			if matrix is None:
-				return Sequential(*seq_expanded, name=task.name, env=env, cwd=cwd, help=task.help)
+				return Sequential(
+					*seq_expanded, name=task.name, env=env, cwd=cwd, help=task.help, paths=paths
+				)
 			return expand_sequential_matrix(seq_expanded, matrix, task.name, env, cwd, task.help)
-		case Parallel(tasks=tasks, matrix=matrix, env=env, cwd=cwd):
+		case Parallel(tasks=tasks, matrix=matrix, env=env, cwd=cwd, paths=paths):
 			par_env: Final = parent_env | env
 			par_cwd: Final = cwd if cwd is not None else ancestor_cwd
-			par_expanded: Final = tuple(expand_matrix(t, par_env, par_cwd) for t in tasks)
+			par_paths: Final = paths if paths is not None else ancestor_paths
+			par_expanded: Final = tuple(
+				expand_matrix(t, par_env, par_cwd, par_paths) for t in tasks
+			)
 			if matrix is None:
-				return Parallel(*par_expanded, name=task.name, env=env, cwd=cwd, help=task.help)
+				return Parallel(
+					*par_expanded, name=task.name, env=env, cwd=cwd, help=task.help, paths=paths
+				)
 			return expand_parallel_matrix(par_expanded, matrix, task.name, env, cwd, task.help)
 		case _:
 			assert_never(task)

--- a/src/camas/core/scope.py
+++ b/src/camas/core/scope.py
@@ -28,7 +28,7 @@ if sys.version_info >= (3, 11):
 else:  # pragma: no cover
 	from typing_extensions import assert_never
 
-from ..v0.task import Parallel, Sequential, Task
+from ..v0.task import Group, Task
 
 if TYPE_CHECKING:
 	from collections.abc import Iterable
@@ -143,37 +143,40 @@ def _rebase_to_cwd(parts: tuple[str, ...], cwd: Path | None) -> tuple[str, ...]:
 
 
 def _resolve_leaf(task: Task, changed: tuple[str, ...]) -> Task | None:
-	match task.paths:
-		case None:
-			return task
-		case scope:
-			parts = _as_scope(scope)(tuple(c.replace("\\", "/") for c in changed))
-			if changed and not parts:
-				return None
-			return Task(
-				cmd=_inject(task.cmd, _rebase_to_cwd(parts, task.cwd)),
-				name=task.name,
-				env=task.env,
-				cwd=task.cwd,
-				help=task.help,
-				mutates=task.mutates,
-				paths=task.paths,
-				agent_format=task.agent_format,
-			)
+	if PATHS_TOKEN not in task.cmd:
+		return task
+	parts = _as_scope(task.paths if task.paths is not None else ".")(
+		tuple(c.replace("\\", "/") for c in changed)
+	)
+	if changed and not parts:
+		return None
+	return Task(
+		cmd=_inject(task.cmd, _rebase_to_cwd(parts, task.cwd)),
+		name=task.name,
+		env=task.env,
+		cwd=task.cwd,
+		help=task.help,
+		mutates=task.mutates,
+		paths=task.paths,
+		agent_format=task.agent_format,
+	)
 
 
 def scope_to_changed(node: TaskNode, changed: tuple[str, ...]) -> TaskNode | None:
-	"""``node`` with each leaf's ``{paths}`` resolved for ``changed``, leaves covering none
-	of it pruned, and emptied groups dropped (``None`` when nothing remains).
+	"""``node`` with each ``{paths}`` command narrowed to the changed files under its scope,
+	leaves whose scope intersects none of them pruned, and emptied groups dropped (``None``
+	when nothing remains).
 
-	A leaf whose command omits ``{paths}`` but sets ``paths`` runs whole when its prefix
-	changed and is skipped otherwise — the selection a file-list-averse tool (``mypy``,
-	``cargo``) needs; here the Rust check drops on a Python-only change.
+	A command with no ``{paths}`` can't be narrowed, so it always runs — its ``paths`` (own or
+	inherited from a group) is a no-op there. Only a ``{paths}`` command is pruned, and only
+	when its scope covers none of the changed files.
 
+	>>> from camas.v0.task import Parallel
 	>>> py = Task("ruff check {paths}", name="lint", paths=".")
-	>>> rs = Task("cargo check", name="cargo", paths="rust")
-	>>> scope_to_changed(Parallel(py, rs), ("src/app.py",))
-	Parallel(tasks=(Task(cmd='ruff check src/app.py', name='lint', env={}, cwd=None, paths='.'),), name=None, matrix=None, env={}, cwd=None)
+	>>> scope_to_changed(py, ("src/app.py",)).cmd
+	'ruff check src/app.py'
+	>>> scope_to_changed(Task("cargo check", name="cargo"), ("src/app.py",)).cmd
+	'cargo check'
 	>>> scope_to_changed(Parallel(py), ("README.md",)) == Parallel(Task("ruff check README.md", name="lint", paths="."))
 	True
 	>>> scope_to_changed(Parallel(Task("ruff {paths}", paths="src")), ("docs/x.md",)) is None
@@ -182,21 +185,20 @@ def scope_to_changed(node: TaskNode, changed: tuple[str, ...]) -> TaskNode | Non
 	match node:
 		case Task():
 			return _resolve_leaf(node, changed)
-		case Sequential(tasks=children, name=name, matrix=matrix, env=env, cwd=cwd, help=help):
+		case Group() as group:
 			kept = tuple(
-				s for s in (scope_to_changed(c, changed) for c in children) if s is not None
+				s for s in (scope_to_changed(c, changed) for c in group.tasks) if s is not None
 			)
 			return (
-				Sequential(*kept, name=name, matrix=matrix, env=env, cwd=cwd, help=help)
-				if kept
-				else None
-			)
-		case Parallel(tasks=children, name=name, matrix=matrix, env=env, cwd=cwd, help=help):
-			kept = tuple(
-				s for s in (scope_to_changed(c, changed) for c in children) if s is not None
-			)
-			return (
-				Parallel(*kept, name=name, matrix=matrix, env=env, cwd=cwd, help=help)
+				type(group)(
+					*kept,
+					name=group.name,
+					matrix=group.matrix,
+					env=group.env,
+					cwd=group.cwd,
+					help=group.help,
+					paths=group.paths,
+				)
 				if kept
 				else None
 			)

--- a/src/camas/core/scope.py
+++ b/src/camas/core/scope.py
@@ -1,13 +1,20 @@
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: 2026 JP Hutchins
 
-"""Path-scoping: resolve a leaf's ``{paths}`` placeholder against the changed files.
+"""Path-scoping: narrow a leaf's ``{paths}`` command to the changed files under its scope.
 
-A leaf opts into scoping by putting ``{paths}`` in its command and setting ``Task.paths``
-to either a directory-prefix string (``"."``, ``"frontend"``) or a ``(changed) -> args``
-callable. On a full run (no changed set) ``{paths}`` becomes the prefix — or the callable's
-default — so the task still runs over everything; on a scoped run it becomes the changed
-files the leaf covers, and a leaf that covers none of them is dropped.
+``{paths}`` in a command marks it narrowable; the changed files replace the placeholder. The
+scope is ``Task.paths`` — a directory-prefix string (``"."``, ``"frontend"``) or a
+``(changed) -> args`` callable — or, when a leaf sets none, the ``paths`` inherited from its
+enclosing ``Sequential``/``Parallel``: a group's ``paths`` is the default target for its
+descendants, baked into leaves by :func:`camas.core.matrix.expand_matrix` (own wins, else
+inherit) the same way ``env``/``cwd`` propagate. On a full run ``{paths}`` becomes the scope's
+prefix (or the callable's default); on a scoped run it becomes the changed files the scope
+covers, and a ``{paths}`` leaf covering none of them is dropped.
+
+A command with **no** ``{paths}`` can't be narrowed, so it always runs and its ``paths`` (own or
+inherited) is a no-op — camas errs on correctness: a tool that can't narrow might be affected by
+the edit. Only a ``{paths}`` command is ever pruned.
 
 :func:`with_default_paths` resolves the full-run default and is applied before every run.
 :func:`scope_to_changed` resolves and prunes against a changed set — the entry point for

--- a/src/camas/main/expression.py
+++ b/src/camas/main/expression.py
@@ -16,7 +16,7 @@ if sys.version_info >= (3, 11):
 else:  # pragma: no cover
 	from typing_extensions import assert_never
 
-from ..v0.task import AgentFormat, OutputKind, Parallel, Sequential, Task, TaskNode
+from ..v0.task import AgentFormat, Group, OutputKind, Parallel, Sequential, Task, TaskNode
 
 if TYPE_CHECKING:
 	from collections.abc import Mapping
@@ -258,6 +258,7 @@ def eval_node(
 						env=eval_env(kw.get("env")),
 						cwd=eval_opt_str(kw.get("cwd")),
 						help=eval_opt_str(kw.get("help")),
+						paths=eval_opt_str(kw.get("paths")),
 					)
 				case "Ref":
 					ref_name_node = args[0] if args else kw.get("name")
@@ -368,15 +369,11 @@ def to_expression(node: TaskNode) -> str:
 				f"{cwd_kwarg(cwd)}{help_kwarg(help)}{mutates_kwarg(mutates)}"
 				f"{paths_kwarg(paths)}{agent_format_kwarg(agent_format)})"
 			)
-		case Sequential(tasks=tasks, name=name, matrix=matrix, env=env, cwd=cwd, help=help):
+		case Group() as group:
 			return (
-				f"Sequential({render_members(tasks)}{name_kwarg(name)}{matrix_kwarg(matrix)}"
-				f"{env_kwarg(env)}{cwd_kwarg(cwd)}{help_kwarg(help)})"
-			)
-		case Parallel(tasks=tasks, name=name, matrix=matrix, env=env, cwd=cwd, help=help):
-			return (
-				f"Parallel({render_members(tasks)}{name_kwarg(name)}{matrix_kwarg(matrix)}"
-				f"{env_kwarg(env)}{cwd_kwarg(cwd)}{help_kwarg(help)})"
+				f"{type(group).__name__}({render_members(group.tasks)}{name_kwarg(group.name)}"
+				f"{matrix_kwarg(group.matrix)}{env_kwarg(group.env)}{cwd_kwarg(group.cwd)}"
+				f"{help_kwarg(group.help)}{paths_kwarg(group.paths)})"
 			)
 		case _:
 			assert_never(node)
@@ -488,23 +485,15 @@ def resolve_refs(
 			return resolve_refs(defs[name], defs, visiting | {name})
 		case Task():
 			return node
-		case Sequential(tasks=tasks, name=n, matrix=m, env=e, cwd=c, help=h):
-			return Sequential(
-				*(resolve_refs(t, defs, visiting) for t in tasks),
-				name=n,
-				matrix=m,
-				env=e,
-				cwd=c,
-				help=h,
-			)
-		case Parallel(tasks=tasks, name=n, matrix=m, env=e, cwd=c, help=h):
-			return Parallel(
-				*(resolve_refs(t, defs, visiting) for t in tasks),
-				name=n,
-				matrix=m,
-				env=e,
-				cwd=c,
-				help=h,
+		case Group() as group:
+			return type(group)(
+				*(resolve_refs(t, defs, visiting) for t in group.tasks),
+				name=group.name,
+				matrix=group.matrix,
+				env=group.env,
+				cwd=group.cwd,
+				help=group.help,
+				paths=group.paths,
 			)
 		case _:
 			assert_never(node)

--- a/src/camas/main/parser.py
+++ b/src/camas/main/parser.py
@@ -312,8 +312,9 @@ def build_parser(state: TasksState = EMPTY_STATE) -> argparse.ArgumentParser:
 		metavar="DURATION",
 		help="run only the task's leaves whose timed estimate fits DURATION (e.g. 1s, "
 		"500ms, 2m), mutating leaves (formatters) first then the read-only rest in "
-		"parallel; untimed leaves are skipped. Operates on the named task, or the "
-		"Config default when none is given",
+		"parallel; untimed leaves run (and are thereby measured), only leaves measured "
+		"over budget are skipped, so a cold cache runs the whole tree. Operates on the "
+		"named task, or the Config default when none is given",
 	)
 	parser.add_argument(
 		"--paths",

--- a/src/camas/main/starter.py
+++ b/src/camas/main/starter.py
@@ -51,7 +51,7 @@ ci = Sequential(
 # Code plugin's PostToolBatch hook runs it after each edit batch via `camas mcp fix` (the changed
 # files arrive on stdin), for free. Replace the placeholder with your real fixers, e.g.:
 #   autofix = Task("ruff check --fix {paths}", mutates=True, paths=".")
-#   autofix = Parallel(Task("ruff format {paths}", mutates=True, paths="."), Task("ruff check --fix {paths}", mutates=True, paths="."))
+#   autofix = Parallel(Task("ruff format {paths}", mutates=True), Task("ruff check --fix {paths}", mutates=True), paths=".")
 autofix = Task('python -c "" {paths}', name="autofix", mutates=True, paths=".")
 
 # Config is discovered by type, under any binding name (here `_`): bare `camas` runs

--- a/src/camas/main/starter.py
+++ b/src/camas/main/starter.py
@@ -51,7 +51,7 @@ ci = Sequential(
 # Code plugin's PostToolBatch hook runs it after each edit batch via `camas mcp fix` (the changed
 # files arrive on stdin), for free. Replace the placeholder with your real fixers, e.g.:
 #   autofix = Task("ruff check --fix {paths}", mutates=True, paths=".")
-#   autofix = Parallel(Task("ruff format {paths}", mutates=True), Task("ruff check --fix {paths}", mutates=True), paths=".")
+#   autofix = Parallel(Task("ruff format {paths}", mutates=True, paths="."), Task("ruff check --fix {paths}", mutates=True, paths="."))
 autofix = Task('python -c "" {paths}', name="autofix", mutates=True, paths=".")
 
 # Config is discovered by type, under any binding name (here `_`): bare `camas` runs

--- a/src/camas/main/tasks.py
+++ b/src/camas/main/tasks.py
@@ -19,7 +19,7 @@ else:  # pragma: no cover
 
 from ..v0.config import Agent, Claude, Config
 from ..v0.effect import Effect
-from ..v0.task import Parallel, Sequential, Task, TaskNode
+from ..v0.task import Group, Parallel, Sequential, Task, TaskNode
 from .expression import Ref, parse_task_value, resolve_refs
 from .state import LoadOk
 
@@ -67,10 +67,16 @@ def assign_key_name(node: TaskNode | Ref, key: str) -> TaskNode | Ref:
 				paths=paths,
 				agent_format=agent_format,
 			)
-		case Sequential(tasks=tasks, name=None, matrix=matrix, env=env, cwd=cwd, help=help):
-			return Sequential(*tasks, name=key, matrix=matrix, env=env, cwd=cwd, help=help)
-		case Parallel(tasks=tasks, name=None, matrix=matrix, env=env, cwd=cwd, help=help):
-			return Parallel(*tasks, name=key, matrix=matrix, env=env, cwd=cwd, help=help)
+		case Group(name=None) as group:
+			return type(group)(
+				*group.tasks,
+				name=key,
+				matrix=group.matrix,
+				env=group.env,
+				cwd=group.cwd,
+				help=group.help,
+				paths=group.paths,
+			)
 		case _:
 			return node
 
@@ -139,13 +145,15 @@ def name_scope_bindings(scope: Mapping[str, object]) -> dict[str, TaskNode]:
 		match source:
 			case Task():
 				return source
-			case Sequential(tasks=children, name=n, matrix=m, env=e, cwd=c, help=h):
-				return Sequential(
-					*(promote(ch) for ch in children), name=n, matrix=m, env=e, cwd=c, help=h
-				)
-			case Parallel(tasks=children, name=n, matrix=m, env=e, cwd=c, help=h):
-				return Parallel(
-					*(promote(ch) for ch in children), name=n, matrix=m, env=e, cwd=c, help=h
+			case Group() as group:
+				return type(group)(
+					*(promote(ch) for ch in group.tasks),
+					name=group.name,
+					matrix=group.matrix,
+					env=group.env,
+					cwd=group.cwd,
+					help=group.help,
+					paths=group.paths,
 				)
 			case _:
 				assert_never(source)

--- a/src/camas/mcp/serve.py
+++ b/src/camas/mcp/serve.py
@@ -31,7 +31,7 @@ from ..core.gate import run_gate
 from ..core.hook_event import changed_from_stdin
 from ..core.matrix import expand_matrix, override_matrix
 from ..core.render import render_tree_lines, strip_ansi
-from ..core.scope import scope_to_changed, to_changed, with_default_paths
+from ..core.scope import scope_to_changed, to_changed
 from ..core.task import task_label
 from ..main.argv import apply_passthrough
 from ..main.format import format_load_error_hint
@@ -1074,16 +1074,24 @@ def run_gate_cli(
 		print(f"camas mcp gate: {e}", file=sys.stderr)
 		return 2
 	changed = to_changed(args.paths or changed_from_stdin(), base)
+	camas_dir = (config if config is not None else Config()).camas_path(base)
 	if args.dry_run:
 		expanded = expand_matrix(node)
-		scoped = scope_to_changed(expanded, changed) if changed else with_default_paths(expanded)
+		plan = (
+			plan_under(expanded, args.under, timings.load(camas_dir))
+			if args.under is not None
+			else None
+		)
+		budgeted = plan.node if plan is not None else expanded
+		scoped = scope_to_changed(budgeted, changed) if budgeted is not None else None
 		if scoped is None:
 			print("No leaves cover the changed paths — nothing would run.")
 		else:
-			plan = "\n".join(render_tree_lines(scoped, show_cmd=True, color=False))
-			print(f"Dry run — resolved path-scoped plan, nothing executed:\n{plan}")
+			tree = "\n".join(render_tree_lines(scoped, show_cmd=True, color=False))
+			print(f"Dry run — resolved path-scoped plan, nothing executed:\n{tree}")
+		if plan is not None:
+			print(budget_headline(to_budget_report(plan)))
 		return 0
-	camas_dir = (config if config is not None else Config()).camas_path(base)
 	outcome = asyncio.run(
 		run_gate(node, changed, under=args.under, jobs=args.jobs, timings=timings.load(camas_dir))
 	)

--- a/src/camas/mcp/wire.py
+++ b/src/camas/mcp/wire.py
@@ -186,8 +186,10 @@ class RunRequest(BaseModel):
 		gt=0,
 		description="Wall-clock budget in seconds: run only the leaves whose recorded "
 		"estimate fits, mutating leaves (formatters) first then the read-only rest in "
-		"parallel. Untimed leaves are skipped. Omit 'task' to budget the default task; "
-		"the 'budget' field of the response reports what was selected and excluded.",
+		"parallel. Untimed leaves run (and are thereby measured); only leaves measured "
+		"over budget are skipped, so a cold cache runs the whole tree. Omit 'task' to "
+		"budget the default task; the 'budget' field of the response reports what was "
+		"selected and excluded.",
 	)
 	dry_run: bool = Field(
 		default=False,

--- a/src/camas/mcp/wire.py
+++ b/src/camas/mcp/wire.py
@@ -242,8 +242,9 @@ class GateRequest(BaseModel):
 	paths: list[str] = Field(
 		default_factory=list,
 		description="Changed paths to scope the gate to — the camas-fixer subagent passes the "
-		"edited files. Empty gates the whole task; each leaf's {paths} is injected with the "
-		"files it covers and leaves covering nothing are dropped.",
+		"edited files. Empty gates the whole task; each {paths} command is injected with the "
+		"files it covers (one covering none is dropped), while a command without {paths} can't "
+		"be narrowed and always runs.",
 	)
 	task: str | None = Field(
 		default=None,

--- a/src/camas/v0/task.py
+++ b/src/camas/v0/task.py
@@ -60,9 +60,11 @@ class Task:
 	The ``--under`` budget scheduler runs such leaves sequentially, before the
 	read-only group, so they never race a checker over the same files.
 
-	``paths`` opts a leaf into ``{paths}`` substitution (:mod:`camas.core.scope`): a
-	directory-prefix string (``"."``) or a ``(changed) -> tuple[str, ...]`` callable that
-	maps the changed files into the command; ``None`` leaves the command untouched.
+	``paths`` is the scope for a ``{paths}`` command (:mod:`camas.core.scope`): a
+	directory-prefix string (``"."``) or a ``(changed) -> tuple[str, ...]`` callable that maps the
+	changed files into the command. A ``Sequential``/``Parallel`` may set ``paths`` to supply the
+	default to descendants that set none. A command without ``{paths}`` can't be narrowed, so its
+	``paths`` is a no-op and the command always runs.
 
 	``agent_format`` is the agent-only structured-output variant (:class:`AgentFormat`): the gate
 	appends its ``args`` and tags the diagnostics ``kind``; a human run leaves the command as-is.
@@ -162,6 +164,9 @@ class Group:
 	``str`` → ``Task`` coercion), identical kwargs, hashable. Use
 	``isinstance(x, Group)`` to test for "either kind of grouping node";
 	pattern-match on the concrete subclass to discriminate.
+
+	``paths`` is the default path-scope for descendant ``{paths}`` leaves that set none
+	(see :mod:`camas.core.scope`); ``env``/``cwd`` likewise propagate into leaves.
 
 	>>> isinstance(Sequential("a"), Group) and isinstance(Parallel("a"), Group)
 	True

--- a/src/camas/v0/task.py
+++ b/src/camas/v0/task.py
@@ -167,6 +167,8 @@ class Group:
 	True
 	>>> hash(Sequential("a")) == hash(Sequential("a"))
 	True
+	>>> Parallel(Task("ruff {paths}"), paths=".").paths
+	'.'
 	"""
 
 	tasks: tuple[TaskNode, ...]
@@ -175,6 +177,7 @@ class Group:
 	env: dict[str, str]
 	cwd: Path | None
 	help: str | None
+	paths: str | PathScope | None
 
 	def __init__(
 		self,
@@ -184,6 +187,7 @@ class Group:
 		env: dict[str, str] | None = None,
 		cwd: str | Path | None = None,
 		help: str | None = None,
+		paths: str | PathScope | None = None,
 	) -> None:
 		put = object.__setattr__
 		put(self, "tasks", tuple(Task(cmd=t) if isinstance(t, str) else t for t in tasks))
@@ -192,6 +196,7 @@ class Group:
 		put(self, "env", env if env is not None else {})
 		put(self, "cwd", Path(cwd) if isinstance(cwd, str) else cwd)
 		put(self, "help", help)
+		put(self, "paths", paths)
 
 	def __hash__(self) -> int:
 		matrix_key = None if self.matrix is None else tuple(sorted(self.matrix.items()))
@@ -203,15 +208,21 @@ class Group:
 				tuple(sorted(self.env.items())),
 				self.cwd,
 				self.help,
+				self.paths,
 			)
 		)
 
 	def __repr__(self) -> str:
-		base = (
-			f"{type(self).__name__}(tasks={self.tasks!r}, name={self.name!r}, "
-			f"matrix={self.matrix!r}, env={self.env!r}, cwd={self.cwd!r}"
+		parts = (
+			f"tasks={self.tasks!r}",
+			f"name={self.name!r}",
+			f"matrix={self.matrix!r}",
+			f"env={self.env!r}",
+			f"cwd={self.cwd!r}",
+			*([f"help={self.help!r}"] if self.help is not None else []),
+			*([f"paths={self.paths!r}"] if self.paths is not None else []),
 		)
-		return f"{base}, help={self.help!r})" if self.help is not None else f"{base})"
+		return f"{type(self).__name__}({', '.join(parts)})"
 
 
 class Sequential(Group):  # pyrefly: ignore[bad-class-definition]

--- a/tests/core/test_gate.py
+++ b/tests/core/test_gate.py
@@ -40,7 +40,6 @@ async def test_gate_scoped_to_nothing_is_green_noop() -> None:
 
 
 async def test_gate_runs_untimed_check_under_budget() -> None:
-	# untimed leaves RUN (and get measured), never skipped — the check executes and passes
 	out = await run_gate(Parallel(CHECK_PASS), (), under=1.0, timings={})
 	assert out.residual_class == "green"
 	assert out.result is not None
@@ -56,7 +55,6 @@ async def test_gate_budget_runs_fitting_check() -> None:
 
 
 async def test_gate_budget_skips_over_budget_check() -> None:
-	# a leaf measured to exceed the budget is skipped; nothing runs → green (deliberate time-box)
 	out = await run_gate(
 		Parallel(CHECK_PASS), (), under=0.001, timings={task_label(CHECK_PASS): TaskTiming(99.0, 1)}
 	)

--- a/tests/core/test_scope.py
+++ b/tests/core/test_scope.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from camas import Parallel, Sequential, Task
+from camas.core.matrix import expand_matrix
 from camas.core.scope import scope_to_changed, to_changed, with_default_paths
 
 if TYPE_CHECKING:
@@ -47,12 +48,40 @@ def test_none_paths_leaf_is_untouched_and_always_runs() -> None:
 	assert with_default_paths(mypy) == mypy
 
 
-def test_prefix_without_placeholder_is_run_whole_or_skip() -> None:
-	"""A leaf with ``paths`` but no ``{paths}`` runs its command unchanged when its prefix
-	changed (the selection a file-list-averse tool needs), and is skipped otherwise."""
+def test_placeholderless_command_always_runs_paths_is_noop() -> None:
+	"""A command with no ``{paths}`` can't narrow, so it always runs and its ``paths`` is a
+	no-op — camas errs on correctness: the tool might touch the edited files."""
 	mypy = Task("mypy .", name="mypy", paths="src")
 	assert scope_to_changed(mypy, ("src/app.py",)) == mypy
-	assert scope_to_changed(mypy, ("docs/readme.md",)) is None
+	assert scope_to_changed(mypy, ("docs/readme.md",)) == mypy
+
+
+def test_placeholder_without_paths_defaults_to_whole_project() -> None:
+	"""A ``{paths}`` leaf with no scope (own or inherited) defaults to the whole project, so it
+	narrows to the changed files on a scoped run and to ``.`` on a full run."""
+	assert _cmd(scope_to_changed(Task("ruff {paths}"), ("a.py",))) == "ruff a.py"
+	assert _cmd(with_default_paths(Task("ruff {paths}"))) == "ruff ."
+
+
+def test_group_paths_inherited_by_placeholder_child() -> None:
+	"""A group's ``paths`` is the default scope of a ``{paths}`` child lacking its own — baked into
+	leaves by ``expand_matrix`` like ``cwd`` — so the child scopes to the changed files and runs."""
+	tree = expand_matrix(Parallel(Task("ruff format {paths}", name="fmt"), paths="."))
+	scoped = scope_to_changed(tree, ("src/a.py", "src/b.py"))
+	assert isinstance(scoped, Parallel)
+	assert _cmd(scoped.tasks[0]) == "ruff format src/a.py src/b.py"
+	full = with_default_paths(tree)
+	assert isinstance(full, Parallel)
+	assert _cmd(full.tasks[0]) == "ruff format ."
+
+
+def test_group_paths_do_not_prune_placeholderless_child() -> None:
+	"""A ``{paths}``-less child under a group ``paths`` still runs — inherited ``paths`` only fills
+	a ``{paths}`` placeholder, it never prunes a command that can't narrow."""
+	tree = expand_matrix(Parallel(Task("mypy .", name="mypy"), paths="src"))
+	scoped = scope_to_changed(tree, ("docs/x.md",))
+	assert isinstance(scoped, Parallel)
+	assert _cmd(scoped.tasks[0]) == "mypy ."
 
 
 def test_callable_paths_full_control() -> None:

--- a/tests/main/test_dispatch.py
+++ b/tests/main/test_dispatch.py
@@ -291,7 +291,7 @@ def test_run_under_all_over_budget_runs_nothing(
 
 _TIDY = (
 	"from camas import Claude, Config, Task\n"
-	'tidy = Task(("python", "-c", "import pathlib; pathlib.Path(\'fixed.txt\').write_text(\'done\')"),'
+	'tidy = Task(("python", "-c", "import pathlib; pathlib.Path(\'fixed.txt\').write_text(\'done\')", "{{paths}}"),'
 	' name="tidy", mutates=True, paths={scope!r})\n'
 	"_ = Config(agent=Claude(fix=tidy))\n"
 )

--- a/tests/main/test_dispatch.py
+++ b/tests/main/test_dispatch.py
@@ -297,8 +297,9 @@ _TIDY = (
 )
 
 
-def test_fix_cli_runs_registered_agent_fix(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-	# the registered node is named "tidy", not "fix" — fix_cli resolves Config.agent.fix by reference
+def test_fix_cli_resolves_registered_fix_by_reference(
+	tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
 	(tmp_path / "tasks.py").write_text(_TIDY.format(scope="."))
 	monkeypatch.chdir(tmp_path)
 	assert fix_cli(["--paths", "x.py"]) == 0

--- a/tests/mcp/test_gate_cli.py
+++ b/tests/mcp/test_gate_cli.py
@@ -191,7 +191,7 @@ def test_gate_cli_dry_run_no_match(
 	monkeypatch.chdir(tmp_path)
 	(tmp_path / "tasks.py").write_text(
 		"from camas import Config, Task\n"
-		'check = Task("echo scope-miss", name="check", paths="src")\n'
+		'check = Task("echo scope-miss {paths}", name="check", paths="src")\n'
 		"_ = Config(default_task=check)\n"
 	)
 	assert serve.gate_cli(["--paths", "unrelated.txt", "--dry-run"]) == 0

--- a/tests/mcp/test_gate_cli.py
+++ b/tests/mcp/test_gate_cli.py
@@ -10,6 +10,7 @@ import io
 import json
 from typing import TYPE_CHECKING
 
+from camas.core import timings
 from camas.core.hook_event import changed_from_stdin
 from camas.mcp import serve, wire
 
@@ -197,3 +198,50 @@ def test_gate_cli_dry_run_no_match(
 	out = capsys.readouterr().out
 	assert "No leaves cover" in out
 	assert "nothing would run" in out
+
+
+_BUDGET_TASKS = (
+	"from camas import Config, Parallel, Task\n"
+	'fast = Task("python --version", name="fast")\n'
+	'slow = Task("python --version", name="slow")\n'
+	'check = Parallel(fast, slow, name="check")\n'
+	"_ = Config(default_task=check)\n"
+)
+
+
+def test_gate_cli_dry_run_under_excludes_over_budget_leaf(
+	tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+	monkeypatch.delenv("CLAUDE_PROJECT_DIR", raising=False)
+	monkeypatch.chdir(tmp_path)
+	(tmp_path / "tasks.py").write_text(_BUDGET_TASKS)
+	camas_dir = tmp_path / ".camas"
+	camas_dir.mkdir()
+	timings.record(camas_dir, [("fast", 0.5), ("slow", 99.0)])
+	assert serve.gate_cli(["--paths", "sample.py", "--under", "5", "--dry-run"]) == 0
+	preview, _, headline = capsys.readouterr().out.partition("Time budget")
+	assert "Dry run" in preview
+	assert "fast" in preview
+	assert "slow" not in preview
+	assert "excluded 1 over budget" in headline
+	assert "slow" in headline
+
+
+def test_gate_cli_dry_run_under_all_over_budget(
+	tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+	monkeypatch.delenv("CLAUDE_PROJECT_DIR", raising=False)
+	monkeypatch.chdir(tmp_path)
+	(tmp_path / "tasks.py").write_text(
+		"from camas import Config, Task\n"
+		'check = Task("python --version", name="only")\n'
+		"_ = Config(default_task=check)\n"
+	)
+	camas_dir = tmp_path / ".camas"
+	camas_dir.mkdir()
+	timings.record(camas_dir, [("only", 99.0)])
+	assert serve.gate_cli(["--paths", "sample.py", "--under", "5", "--dry-run"]) == 0
+	out = capsys.readouterr().out
+	assert "nothing would run" in out
+	assert "excluded 1 over budget" in out
+	assert "only" in out


### PR DESCRIPTION
> [!WARNING]
> **LLM Disclosure**
>
> This PR was authored by claude-opus-4-8[1m] on behalf of @JPHutchins. It began as the #141 documentation papercuts; on her feedback the E2 item turned out to be a missing feature (`paths` on `Group`), which is implemented here, along with a `Group` pattern-matching cleanup she asked for.

Closes #141.

## `paths` on `Group` (was E2)

E2 was filed as "the starter's commented example uses a non-existent API" (`Parallel(…, paths=".")`). It's not non-existent — `paths=` was always meant to be valid on `Sequential`/`Parallel`, scoping the whole node. So this **implements** it rather than editing the comment:

- `Group` gains a `paths` field. A group's `paths` is **baked into descendant leaves by `expand_matrix`** (own wins, else inherit) — exactly how `env`/`cwd` already propagate — so a `{paths}` child without its own `paths` inherits the group's default target. This survives `--under` budget regrouping (which flattens the tree) because it's resolved during expansion, before scoping.
- The run/skip rule is corrected to match the design: **a command with no `{paths}` can't be narrowed, so it always runs** (its `paths`, own or inherited, is a no-op); only a `{paths}` command is pruned, and only when its scope covers none of the changed files. This overturns the old `mypy`/`cargo` "run-whole-or-skip" selector — those must run (err on correctness: the tool might touch the edited files). The `test_prefix_without_placeholder` test and the `cargo` doctest that pinned the old behavior are rewritten.
- The starter's `Parallel(Task("ruff format {paths}", …), Task("ruff check --fix {paths}", …), paths=".")` example is restored (now valid, and a showcase of the feature).
- `paths` carries through every group reconstruction site (matrix expand/specialize/override, scope, gate, tasks naming/promote, expression eval/serialize) so it round-trips.

## `Group` pattern-matching cleanup

The duplicated `case Sequential(...)` / `case Parallel(...)` reconstruction cases collapse to a single `case Group() as g: type(g)(...)` — cast-free, because matching `Group()` against a `TaskNode` subject narrows `g` to `Sequential | Parallel`, so `type(g)(…)` is a valid `TaskNode`. Applied in `scope`, `gate`, `override`, `promote`, `resolve_refs`, and `to_expression` (via `type(g).__name__`). The cases that behave differently per subclass (`execution`, `expand_matrix`'s helper dispatch) stay split.

## Retained papercuts

- **E1** — corrected the stale "`--under` skips untimed leaves" claim in `parser.py`, `wire.py`, and the `camas_docs`-served module docstring.
- **E3** — `camas mcp gate --dry-run` now applies `--under` (mirrors `run_gate`), previewing exactly what the real gate would run.
- **E4** — removed inline why-comments in the touched tests.

## Verification

`camas all` — lint, format, mypy, pyright, ty, zuban, pyrefly, **coverage 100%** — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
