### PR TITLE
fix(plugin): camas-fixer gates via MCP tool; write_hooks rebuilds settings.json faithfully (#133) (#144)

### DIFF
--- a/agent/claude/plugin/agents/camas-fixer.md
+++ b/agent/claude/plugin/agents/camas-fixer.md
@@ -3,16 +3,17 @@ name: camas-fixer
 description: Drives a scope of changed files to a green camas gate on a cheap model, off the main agent's context — gates the scope, fixes what fails, and re-gates in a bounded loop, then hands back any residual it cannot settle. Delegate to it after a batch of edits with the changed paths as its scope; spawn one per independent scope to run them in parallel, and run it in the background so it never blocks your reasoning.
 model: haiku
 maxTurns: 5
-tools: Read, Edit, Bash, mcp__camas__camas_gate
+tools: Read, Edit, mcp__camas__camas_gate
 ---
 
 You drive a scope of changed files to a green camas gate cheaply, so the main agent spends no
 reasoning on what a fix-and-recheck loop can settle. You are given the changed paths to work
 over (and, when the main agent already ran the gate, its failing diagnostics). Loop:
 
-1. Gate the scope: run `camas mcp gate --paths <the changed paths you were given>` to see what
-   fails — do not widen the scope, gate exactly what was handed to you.
-2. If it comes back green (exit 0), you are done — say so.
+1. Gate the scope: call the `camas_gate` MCP tool with its `paths` argument set to the changed
+   paths you were given to see what fails — do not widen the scope, gate exactly what was handed
+   to you.
+2. If it reports the checks are green (a CONTINUE verdict), you are done — say so.
 3. If it still fails, read the diagnostics, edit the code to fix the underlying cause, and
    re-gate the same scope. Repeat until green or you run out of turns.
 

--- a/src/camas/mcp/scaffold.py
+++ b/src/camas/mcp/scaffold.py
@@ -134,6 +134,32 @@ def launch_command_str(*, rich: bool) -> str | None:
 	return shlex.join((cmd, *args))
 
 
+def _object_list(value: object) -> list[dict[str, Any]]:
+	"""The value as a list of JSON objects, or ``[]`` if it is not a list."""
+	return cast("list[dict[str, Any]]", value) if isinstance(value, list) else []
+
+
+def _kept_hooks(group: dict[str, Any]) -> list[dict[str, Any]]:
+	"""The group's hooks minus any camas autofix hook."""
+	return [
+		h for h in _object_list(group.get("hooks")) if "mcp fix" not in cast("str", h["command"])
+	]
+
+
+def _with_camas_hook(raw: dict[str, Any], camas_group: dict[str, Any]) -> dict[str, Any]:
+	"""``raw`` with its ``PostToolBatch`` rebuilt: non-camas groups kept in place, ``camas_group``
+	appended — every other key and its order left untouched, no defaults injected.
+	"""
+	hooks = raw.get("hooks")
+	hooks_dict: dict[str, Any] = cast("dict[str, Any]", hooks) if isinstance(hooks, dict) else {}
+	kept = [
+		{**g, "hooks": remaining}
+		for g in _object_list(hooks_dict.get("PostToolBatch"))
+		if (remaining := _kept_hooks(g))
+	]
+	return {**raw, "hooks": {**hooks_dict, "PostToolBatch": [*kept, camas_group]}}
+
+
 def write_hooks(argv: list[str]) -> int:
 	"""Write the ``PostToolBatch`` autofix hook into ``.claude/settings.json`` using
 	``launch_command()`` resolution (without ``--rich``, which the hook does not need).
@@ -150,7 +176,7 @@ def write_hooks(argv: list[str]) -> int:
 		print(f"error: {settings_path} is not a JSON object", file=sys.stderr)
 		return 2
 	try:
-		settings = SettingsFile.model_validate(raw)
+		SettingsFile.model_validate(raw)
 	except ValidationError as e:
 		print(f"error: {settings_path}: {e}", file=sys.stderr)
 		return 2
@@ -163,23 +189,12 @@ def write_hooks(argv: list[str]) -> int:
 			file=sys.stderr,
 		)
 		return 2
-	camas_hook = HookGroup(
-		hooks=[
-			HookCommand(
-				type="command",
-				command=f"{launcher} fix",
-			)
-		]
-	)
-	existing = settings.hooks.get("PostToolBatch", [])
-	kept: list[HookGroup] = []
-	for g in existing:
-		remaining = [h for h in g.hooks if "mcp fix" not in h.command]
-		if remaining:
-			kept.append(g.model_copy(update={"hooks": remaining}))
-	settings.hooks["PostToolBatch"] = [*kept, camas_hook]
+	camas_group: dict[str, Any] = {"hooks": [{"type": "command", "command": f"{launcher} fix"}]}
 	settings_path.parent.mkdir(parents=True, exist_ok=True)
-	settings_path.write_text(settings.model_dump_json(indent=2) + "\n", encoding="utf-8")
+	settings_path.write_text(
+		json.dumps(_with_camas_hook(cast("dict[str, Any]", raw), camas_group), indent=2) + "\n",
+		encoding="utf-8",
+	)
 	print(
 		f"Wrote the camas PostToolBatch autofix hook to {settings_path}\n"
 		f"  PostToolBatch:  {launcher} fix\n"

--- a/tests/mcp/test_scaffold.py
+++ b/tests/mcp/test_scaffold.py
@@ -361,6 +361,32 @@ def test_write_hooks_preserves_extra_hook_command_fields(
 	)
 
 
+def test_write_hooks_preserves_key_order_and_omits_matcher(
+	tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+	monkeypatch.chdir(tmp_path)
+	monkeypatch.setattr("shutil.which", _which("camas"))
+	(tmp_path / ".claude").mkdir(parents=True)
+	(tmp_path / ".claude" / "settings.json").write_text(
+		json.dumps(
+			{
+				"$schema": "https://example.com/schema.json",
+				"permissions": {"allow": ["Read"]},
+				"hooks": {
+					"PreToolUse": [{"hooks": [{"type": "command", "command": "guard"}]}],
+				},
+			}
+		)
+	)
+	assert write_hooks([]) == 0
+	settings = json.loads((tmp_path / ".claude" / "settings.json").read_text())
+	assert list(settings.keys()) == ["$schema", "permissions", "hooks"]
+	assert list(settings["hooks"].keys()) == ["PreToolUse", "PostToolBatch"]
+	assert "matcher" not in settings["hooks"]["PreToolUse"][0]
+	assert "matcher" not in settings["hooks"]["PostToolBatch"][0]
+	assert settings["hooks"]["PostToolBatch"][0]["hooks"][0]["command"] == "camas mcp fix"
+
+
 def test_mcp_cli_init_hooks_routes_to_write_hooks(
 	tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/plugin/test_shipped_plugin.py
+++ b/tests/plugin/test_shipped_plugin.py
@@ -45,3 +45,9 @@ def test_marketplace_points_at_the_shipped_plugin() -> None:
 def test_plugin_ships_the_fixer_and_skill() -> None:
 	assert "name: camas-fixer" in (_PLUGIN / "agents" / "camas-fixer.md").read_text()
 	assert "name: gate" in (_PLUGIN / "skills" / "gate" / "SKILL.md").read_text()
+
+
+def test_fixer_gates_via_mcp_tool_not_bare_cli() -> None:
+	fixer = (_PLUGIN / "agents" / "camas-fixer.md").read_text()
+	assert "camas_gate" in fixer
+	assert "camas mcp gate" not in fixer


### PR DESCRIPTION
> [!WARNING]
> **LLM Disclosure**
>
> This PR was authored by claude-opus-4-8[1m] on behalf of @JPHutchins, who asked me to bundle the remaining #128 cleanup-epic children into single PRs using worktrees and workflows. This one collects two disjoint-file plugin/install-surface fixes; it was implemented and validated (`camas all`) in an isolated worktree.

Closes #133, closes #144.

Two independent fixes to the shipped plugin / hook-install surface.

## #133 — `camas-fixer` drives its granted MCP tool, not a bare CLI

`agent/claude/plugin/agents/camas-fixer.md` granted `mcp__camas__camas_gate` in frontmatter but its step-1 body told the agent to `Bash` a bare `camas mcp gate` — which breaks in a uvx-only install (the #96/#116 PATH regression, on the one surface #116 didn't sweep) and is exactly the MCP-vs-CLI confusion #127 tracks.

- Step 1 now instructs calling the `camas_gate` MCP tool with its `paths` argument.
- Step 2's verdict wording now matches the MCP tool's `CONTINUE` verdict rather than a shell exit code.
- The now-unused `Bash` grant is dropped (`tools: Read, Edit, mcp__camas__camas_gate`), so granted tools match instructions.
- `skills/gate/SKILL.md` is untouched: its only bare-`camas` line documents what the hook runs (`camas mcp fix`), which the issue explicitly exempts.
- A guard test in `tests/plugin/test_shipped_plugin.py` asserts `camas_gate` is present and the bare `camas mcp gate` string is absent.

## #144 — `write_hooks` edits `settings.json` faithfully

`write_hooks()` validated with `SettingsFile.model_validate(raw)` and then **re-serialized the model** (`model_dump_json`), which reordered top-level/group keys (hoisting `hooks`) and injected `matcher: ""` onto groups that omitted it — a spurious diff in a user's committed config on first `camas mcp init --hooks`.

Now the model is validated for its side effect only, and a byte-faithful rebuild of the parsed `raw` dict is `json.dumps`-ed:

- Three small **typed** module-level helpers (`_object_list`, `_kept_hooks`, `_with_camas_hook`) contain the raw-dict casts against the 5-typechecker gauntlet, mirroring the existing `parse_json_object` cast pattern (no scattered casts).
- Dict-spread rebuild preserves every untouched key's position and injects no defaults.
- The camas `PostToolBatch` group is built as a matcher-less plain dict, matching the shipped `hooks.json` canonical shape.
- New test `test_write_hooks_preserves_key_order_and_omits_matcher` asserts top-level order is preserved (`hooks` not hoisted), `PostToolBatch` is appended after an existing event, and no `matcher` is injected on the untouched group or the camas group. All existing `write_hooks` tests still pass.

## Verification

`camas all` — lint, format, mypy, pyright, ty, zuban, coverage **100%** (branch). The `#133` change is markdown-only; `#144` exercises the raw-dict typing under all five checkers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
