### PR TITLE
test(packaging): guard mypyc effect-exclusion drift; harden nix resolveExtra (#134) (#135)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -89,9 +89,60 @@
                 nativeBuildInputs = [ pkgs.nixfmt ];
               }
               ''
-                nixfmt --check ${./flake.nix} ${./nix/package.nix}
+                nixfmt --check ${./flake.nix} ${./nix/package.nix} ${./nix/resolve-extras.nix}
                 touch $out
               '';
+
+          extras-resolver =
+            let
+              resolver = import ./nix/resolve-extras.nix {
+                inherit lib;
+                pname = "camas";
+              };
+              realExtras = (lib.importTOML ./pyproject.toml).project.optional-dependencies;
+              resolveNames =
+                pyprojectExtras: python3Packages: extra:
+                map (drv: drv.name) (resolver.mkResolveExtra { inherit python3Packages pyprojectExtras; } extra);
+              forced = value: builtins.tryEval (builtins.deepSeq value value);
+              fakePackages = {
+                httpx = {
+                  name = "httpx";
+                };
+                msgspec = {
+                  name = "msgspec";
+                };
+              };
+              realResolved = builtins.mapAttrs (
+                extra: _: resolveNames realExtras pkgs.python3Packages extra
+              ) realExtras;
+              realResolves = (forced realResolved).success;
+              cyclicFails =
+                !(forced (
+                  resolveNames {
+                    a = [ "camas[b]" ];
+                    b = [ "camas[a]" ];
+                  } fakePackages "a"
+                )).success;
+              missingFails =
+                !(forced (
+                  resolveNames {
+                    x = [ "definitely-absent-pkg" ];
+                  } fakePackages "x"
+                )).success;
+              unparseableFails =
+                !(forced (
+                  resolveNames {
+                    y = [ "@vcs+https://example/x" ];
+                  } fakePackages "y"
+                )).success;
+            in
+            assert realResolves;
+            assert cyclicFails;
+            assert missingFails;
+            assert unparseableFails;
+            pkgs.runCommand "extras-resolver-check" { } ''
+              touch $out
+            '';
         }
         // lib.mapAttrs' (
           name: pkg: lib.nameValuePair ("package" + lib.optionalString (name != "default") "-${name}") pkg

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -23,28 +23,11 @@ let
 
   pyprojectExtras = (lib.importTOML (src + "/pyproject.toml")).project.optional-dependencies;
 
-  parseSpec =
-    spec:
-    if lib.hasPrefix "${pname}[" spec then
-      {
-        self = lib.splitString "," (lib.removeSuffix "]" (lib.removePrefix "${pname}[" spec));
-      }
-    else
-      { pkg = builtins.head (builtins.match "([A-Za-z0-9._-]+).*" spec); };
+  resolver = import ./resolve-extras.nix { inherit lib pname; };
 
-  resolveExtra =
-    extra:
-    lib.unique (
-      lib.concatMap (
-        spec:
-        let
-          parsed = parseSpec spec;
-        in
-        if parsed ? self then lib.concatMap resolveExtra parsed.self else [ python3Packages.${parsed.pkg} ]
-      ) pyprojectExtras.${extra}
-    );
-
-  optional-dependencies = lib.mapAttrs (extra: _: resolveExtra extra) pyprojectExtras;
+  optional-dependencies = lib.mapAttrs (
+    extra: _: resolver.mkResolveExtra { inherit python3Packages pyprojectExtras; } extra
+  ) pyprojectExtras;
 in
 python3Packages.buildPythonApplication {
   inherit pname version src;

--- a/nix/resolve-extras.nix
+++ b/nix/resolve-extras.nix
@@ -1,0 +1,71 @@
+# Pure extras resolver extracted from package.nix so its guards are exercisable
+# from the flake `extras-resolver` check. It maps each pyproject
+# [project.optional-dependencies] spec to a nixpkgs python3Packages derivation,
+# following `camas[...]` self-references, and throws a readable message on the
+# four edges that would otherwise fail with an opaque eval trace or loop forever:
+#   1. a PyPI name whose nixpkgs attr differs (map it in pypiToNixAttr),
+#   2. a package absent from python3Packages,
+#   3. a mutually self-referential extra pair (cycle), and
+#   4. a spec that is not a parseable PEP 508 name.
+{
+  lib,
+  pname,
+}:
+let
+  parseSpec =
+    spec:
+    if lib.hasPrefix "${pname}[" spec then
+      {
+        self = lib.splitString "," (lib.removeSuffix "]" (lib.removePrefix "${pname}[" spec));
+      }
+    else
+      let
+        matched = builtins.match "([A-Za-z0-9._-]+).*" spec;
+      in
+      if matched == null then
+        throw "camas resolve-extras: cannot parse requirement ${builtins.toJSON spec}; expected a spec beginning with a PEP 508 name ([A-Za-z0-9._-])"
+      else
+        { pkg = builtins.head matched; };
+
+  mkResolveExtra =
+    {
+      python3Packages,
+      pyprojectExtras,
+      pypiToNixAttr ? { },
+    }:
+    let
+      resolvePkg =
+        extra: name:
+        let
+          attr = pypiToNixAttr.${name} or name;
+        in
+        if python3Packages ? ${attr} then
+          python3Packages.${attr}
+        else
+          throw "camas resolve-extras: extra '${extra}' requires Python package '${name}' (nixpkgs attr '${attr}') which is absent from python3Packages; add it to nixpkgs or map it in pypiToNixAttr";
+
+      resolve =
+        seen: extra:
+        if builtins.elem extra seen then
+          throw "camas resolve-extras: cyclic self-reference in optional-dependencies: ${
+            lib.concatStringsSep " -> " (seen ++ [ extra ])
+          }"
+        else
+          lib.unique (
+            lib.concatMap (
+              spec:
+              let
+                parsed = parseSpec spec;
+              in
+              if parsed ? self then
+                lib.concatMap (resolve (seen ++ [ extra ])) parsed.self
+              else
+                [ (resolvePkg extra parsed.pkg) ]
+            ) pyprojectExtras.${extra}
+          );
+    in
+    resolve [ ];
+in
+{
+  inherit parseSpec mkResolveExtra;
+}

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -79,7 +79,7 @@ def module_siblings(tree: ast.AST) -> frozenset[str]:
 
 
 def parse_module(path: Path) -> ast.Module:
-	return ast.parse(path.read_text())
+	return ast.parse(path.read_text(encoding="utf-8"))
 
 
 def combined_roots(path: Path) -> frozenset[str]:
@@ -118,10 +118,10 @@ def literal_exclusion(source: str) -> frozenset[str]:
 
 
 def test_effect_exclusion_matches_derived_set() -> None:
-	pyproject = tomllib.loads((ROOT / "pyproject.toml").read_text())
+	pyproject = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
 	optional = optional_dist_names(pyproject)
 	derived = derived_exclusion(optional)
-	literal = literal_exclusion((ROOT / "setup.py").read_text())
+	literal = literal_exclusion((ROOT / "setup.py").read_text(encoding="utf-8"))
 	assert derived == literal, (
 		"setup.py _effect_excluded has drifted from the imports; "
 		f"symmetric difference = {sorted(derived ^ literal)} "

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -1,0 +1,129 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2026 JP Hutchins
+
+"""Guard: setup.py's mypyc effect-exclusion set stays derivable from the imports.
+
+The compiled (``CAMAS_USE_MYPYC=1``) build keeps every effect module with an
+optional dependency interpreted, because those deps are absent from the isolated
+build env. ``setup.py`` hardcodes that set; this test derives it from the actual
+effect-module imports and the pyproject extras and asserts they agree, so drift
+fails the fast ``check`` job instead of the slow wheels build.
+"""
+
+from __future__ import annotations
+
+import ast
+import itertools
+import string
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Final
+
+if sys.version_info >= (3, 11):
+	import tomllib
+else:  # pragma: no cover
+	import tomli as tomllib
+
+if TYPE_CHECKING:
+	from collections.abc import Mapping
+
+ROOT: Final = Path(__file__).resolve().parent.parent
+EFFECT_DIR: Final = ROOT / "src" / "camas" / "effect"
+NAME_CHARS: Final = frozenset(string.ascii_letters + string.digits + "._-")
+
+
+def dist_name(spec: str) -> str:
+	"""The leading PEP 508 distribution name of a requirement spec."""
+	return "".join(itertools.takewhile(lambda char: char in NAME_CHARS, spec.strip()))
+
+
+def optional_dist_names(pyproject: Mapping[str, Any]) -> frozenset[str]:
+	"""Distribution names reachable only through a ``[project.optional-dependencies]`` extra."""
+	project = pyproject["project"]
+	core = frozenset(dist_name(spec) for spec in project["dependencies"])
+	optional = frozenset(
+		dist_name(spec)
+		for specs in project["optional-dependencies"].values()
+		for spec in specs
+		if not spec.startswith("camas[")
+	)
+	return optional - core
+
+
+def import_roots(node: ast.AST) -> tuple[str, ...]:
+	"""Absolute (level-0) import roots contributed by a single AST node."""
+	match node:
+		case ast.Import(names=names):
+			return tuple(alias.name.split(".", 1)[0] for alias in names)
+		case ast.ImportFrom(module=str(module), level=0):
+			return (module.split(".", 1)[0],)
+		case _:
+			return ()
+
+
+def sibling_imports(node: ast.AST) -> tuple[str, ...]:
+	"""Sibling names a single AST node pulls in via ``from . import X``."""
+	match node:
+		case ast.ImportFrom(module=None, level=1, names=names):
+			return tuple(alias.name for alias in names)
+		case _:
+			return ()
+
+
+def module_roots(tree: ast.AST) -> frozenset[str]:
+	return frozenset(root for node in ast.walk(tree) for root in import_roots(node))
+
+
+def module_siblings(tree: ast.AST) -> frozenset[str]:
+	return frozenset(name for node in ast.walk(tree) for name in sibling_imports(node))
+
+
+def parse_module(path: Path) -> ast.Module:
+	return ast.parse(path.read_text())
+
+
+def combined_roots(path: Path) -> frozenset[str]:
+	"""Import roots of an effect module plus those of its ``from . import`` siblings."""
+	tree = parse_module(path)
+	return module_roots(tree) | frozenset(
+		root
+		for sibling in module_siblings(tree)
+		for root in module_roots(parse_module(EFFECT_DIR / f"{sibling}.py"))
+	)
+
+
+def public_effect_files() -> tuple[Path, ...]:
+	return tuple(path for path in sorted(EFFECT_DIR.glob("*.py")) if not path.name.startswith("_"))
+
+
+def derived_exclusion(optional: frozenset[str]) -> frozenset[str]:
+	"""Public effect modules whose own or sibling imports reach an optional dependency."""
+	return frozenset(path.name for path in public_effect_files() if combined_roots(path) & optional)
+
+
+def effect_excluded_members(node: ast.AST) -> tuple[str, ...]:
+	"""The members of the ``_effect_excluded`` set literal at a single AST node."""
+	match node:
+		case ast.Assign(targets=[ast.Name(id="_effect_excluded")], value=value):
+			return tuple(ast.literal_eval(value))
+		case _:
+			return ()
+
+
+def literal_exclusion(source: str) -> frozenset[str]:
+	"""The ``_effect_excluded`` set literal declared in setup.py source."""
+	return frozenset(
+		member for node in ast.walk(ast.parse(source)) for member in effect_excluded_members(node)
+	)
+
+
+def test_effect_exclusion_matches_derived_set() -> None:
+	pyproject = tomllib.loads((ROOT / "pyproject.toml").read_text())
+	optional = optional_dist_names(pyproject)
+	derived = derived_exclusion(optional)
+	literal = literal_exclusion((ROOT / "setup.py").read_text())
+	assert derived == literal, (
+		"setup.py _effect_excluded has drifted from the imports; "
+		f"symmetric difference = {sorted(derived ^ literal)} "
+		f"(derived = {sorted(derived)}, literal = {sorted(literal)})"
+	)


### PR DESCRIPTION
> [!WARNING]
> **LLM Disclosure**
>
> This PR was authored by claude-opus-4-8[1m] on behalf of @JPHutchins, bundling the packaging-SSOT items of the #128 cleanup epic. It was implemented and validated (`camas all`) in an isolated worktree.

Closes #134, closes #135. Two packaging-SSOT drift guards.

## #134 — mypyc effect-exclusion drift (guard test)

Per maintainer decision this is a **guard test**, not a derivation in `setup.py` (which is excluded from all five typecheckers and coverage — the derivation would ship untested). New `tests/test_packaging.py` derives the expected exclusion set from the **real effect-module imports** + pyproject extras and asserts it equals `setup.py`'s `_effect_excluded` literal, so drift fails the fast `check` job before the slow wheels build.

Detection scans actual imports rather than the brittle extra-name==basename coincidence: optional dist names = union of every `[project.optional-dependencies]` spec (minus `camas[...]` self-refs) minus the core deps → `{httpx, msgspec, ty, mcp}`; a public effect module is excluded iff its own or a `from . import _sibling` private sibling's import roots intersect that set — so `github_checks.py` matches via its own `httpx`, `ctrf.py` via `_ctrf_model`→`msgspec`. Helpers stay comprehension/`match`-based with the `tomllib`/`tomli` shim, holding 100% branch coverage. `setup.py` is unchanged. (Verified the guard fires by temporarily dropping `ctrf.py` from the literal.)

## #135 — Nix `resolveExtra` guards

Extracted `parseSpec` + `resolveExtra` from `nix/package.nix` into a pure `nix/resolve-extras.nix` (a `mkResolveExtra` factory) with four readable-throw guards: an explicit `pypiToNixAttr` override table + a has-attribute assertion (PyPI≠nixpkgs-attr / package absent), cycle detection via a threaded `seen` list, and a null-match guard in `parseSpec`. Behavior is identical for today's extras. A new flake `checks.extras-resolver` asserts the real extras resolve and that synthetic cyclic / missing-package / unparseable-spec inputs each fail eval (`builtins.tryEval`); `resolve-extras.nix` was added to the `nixfmt --check` command.

## Validation

`camas all` green (100% coverage, all typecheckers). The Nix `checks.extras-resolver` runs under the existing `nix flake check` CI job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
