### PR TITLE
fix(matrix): specialize_node preserves group env; verify nested env/matrix threading (#86)

### DIFF
--- a/src/camas/core/matrix.py
+++ b/src/camas/core/matrix.py
@@ -125,6 +125,7 @@ def specialize_node(task: TaskNode, binding: MatrixBinding, suffix: str) -> Task
 			return type(group)(
 				*(specialize_node(t, binding, suffix) for t in group.tasks),
 				name=f"{group.name} {suffix}" if group.name is not None else None,
+				env={k: substitute_in_str(v, binding) for k, v in group.env.items()},
 				cwd=substitute_cwd(group.cwd, binding),
 				help=substitute_help(group.help, binding),
 				paths=substitute_paths(group.paths, binding),

--- a/tests/core/test_matrix.py
+++ b/tests/core/test_matrix.py
@@ -7,6 +7,7 @@ import pytest
 
 from camas import Parallel, Sequential, Task
 from camas.core.matrix import expand_matrix
+from camas.core.traversal import flatten_leaves
 
 
 def test_no_matrix_passthrough() -> None:
@@ -124,6 +125,38 @@ def test_nested_group_children() -> None:
 						raise AssertionError(f"expected Parallel, got {child}")
 		case _:
 			raise AssertionError(f"unexpected: {result}")
+
+
+def test_nested_group_env_threads_and_survives_specialization() -> None:
+	"""https://github.com/JPHutchins/camas/issues/86 — nested-group env under an ancestor matrix.
+
+	The group's own env threads into its leaves (execution) and is preserved on the specialized
+	group node (specialize_node keeps env, substituted per binding — not just name/cwd/help/paths).
+	"""
+	task = Parallel(
+		Sequential(Task("run {PY}"), env={"NESTED": "v-{PY}"}, name="inner"),
+		matrix={"PY": ("3.12", "3.13")},
+	)
+	result = expand_matrix(task)
+	assert isinstance(result, Parallel)
+	assert [group.env for group in result.tasks] == [{"NESTED": "v-3.12"}, {"NESTED": "v-3.13"}]
+	assert [leaf.task.env for leaf in flatten_leaves(result)] == [
+		{"NESTED": "v-3.12", "PY": "3.12"},
+		{"NESTED": "v-3.13", "PY": "3.13"},
+	]
+
+
+def test_nested_group_matrix_expands_under_ancestor_matrix() -> None:
+	"""https://github.com/JPHutchins/camas/issues/86 — a nested group's own matrix is fully expanded
+	before specialize_node runs, so it never sees a group carrying a matrix; the axes compose into
+	the leaves."""
+	task = Parallel(
+		Sequential(Task("t {OS} {PY}"), matrix={"OS": ("lin", "mac")}, name="inner"),
+		matrix={"PY": ("3.12",)},
+	)
+	result = expand_matrix(task)
+	cmds = sorted(leaf.task.cmd for leaf in flatten_leaves(result))
+	assert cmds == ["t lin 3.12", "t mac 3.12"]
 
 
 def test_container_env_propagates_to_leaves() -> None:


### PR DESCRIPTION
> [!WARNING]
> **LLM Disclosure**
>
> This PR was authored by claude-opus-4-8[1m] on behalf of @JPHutchins, resolving the #86 investigation with context fresh from the #149 `expand_matrix`/`specialize_node` work.

Closes #86.

## Finding — not a correctness bug

Verified empirically: when an ancestor matrix expands a nested group, the group's own `env` **is** correctly threaded into its leaves (baked by `expand_matrix`, substituted per binding), and a nested group's own `matrix` **is** fully expanded — `specialize_node` never even sees a group carrying a matrix, because `expand_matrix` consumes nested matrices first. Execution has always been correct.

The only real observable was **cosmetic**: `specialize_node` reconstructed a matrix-specialized group with `name`/`cwd`/`help`/`paths` but dropped its `env` field, so a matrix-expanded group displayed `env={}` while a non-matrix one (via `expand_matrix`'s own reconstruction) kept it.

## Change

- `specialize_node` now preserves the group `env` field (substituted per binding), matching `expand_matrix`'s non-matrix reconstruction. This is display-only — execution reads **leaf** `env`, which was already correct, so there's no double-application.
- No change needed for `matrix`: it's already `None` on any group `specialize_node` receives.

## Tests

- `test_nested_group_env_threads_and_survives_specialization` — pins both the leaf `env` (execution) and the preserved group-`env` field (display) for a nested group under a matrix.
- `test_nested_group_matrix_expands_under_ancestor_matrix` — a nested group's own matrix composes with the ancestor's into the leaves.

## Verification

`camas all` — lint, format, mypy, pyright, ty, zuban, pyrefly, **coverage 100%** — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
