### PR TITLE
fix(mcp): write_hooks sweeps camas's stale autofix hook from every event (#157)

### DIFF
--- a/src/camas/mcp/scaffold.py
+++ b/src/camas/mcp/scaffold.py
@@ -146,18 +146,32 @@ def _kept_hooks(group: dict[str, Any]) -> list[dict[str, Any]]:
 	]
 
 
+def _swept_event(groups: object) -> list[dict[str, Any]]:
+	"""One event's hook groups with camas's autofix hooks removed and any group they emptied
+	dropped.
+	"""
+	return [
+		{**g, "hooks": remaining} for g in _object_list(groups) if (remaining := _kept_hooks(g))
+	]
+
+
 def _with_camas_hook(raw: dict[str, Any], camas_group: dict[str, Any]) -> dict[str, Any]:
-	"""``raw`` with its ``PostToolBatch`` rebuilt: non-camas groups kept in place, ``camas_group``
-	appended — every other key and its order left untouched, no defaults injected.
+	"""``raw`` with camas's own autofix hook removed from every event — dropping any group or event
+	it empties, so a stale hook from an older camas (e.g. under ``FileChanged``) is swept out — and
+	the current hook appended under ``PostToolBatch``. Every other key keeps its position, no
+	defaults injected.
 	"""
 	hooks = raw.get("hooks")
 	hooks_dict: dict[str, Any] = cast("dict[str, Any]", hooks) if isinstance(hooks, dict) else {}
-	kept = [
-		{**g, "hooks": remaining}
-		for g in _object_list(hooks_dict.get("PostToolBatch"))
-		if (remaining := _kept_hooks(g))
-	]
-	return {**raw, "hooks": {**hooks_dict, "PostToolBatch": [*kept, camas_group]}}
+	swept: dict[str, Any] = {
+		event: groups
+		for event in hooks_dict
+		if (groups := _swept_event(hooks_dict[event])) or event == "PostToolBatch"
+	}
+	return {
+		**raw,
+		"hooks": {**swept, "PostToolBatch": [*swept.get("PostToolBatch", []), camas_group]},
+	}
 
 
 def write_hooks(argv: list[str]) -> int:

--- a/tests/mcp/test_scaffold.py
+++ b/tests/mcp/test_scaffold.py
@@ -266,6 +266,49 @@ def test_write_hooks_merges_existing_settings(
 	assert "PostToolBatch" in settings["hooks"]
 
 
+def test_write_hooks_sweeps_stale_hooks_from_all_events(
+	tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+	"""https://github.com/JPHutchins/camas/issues/157 — a camas autofix hook left under a non-current
+	event by an older camas (the pre-PostToolBatch ``FileChanged`` hook) is swept out on the next
+	init --hooks: an event holding only the stale camas hook is dropped, a non-camas hook in another
+	event is preserved, and the current hook lands under PostToolBatch."""
+	monkeypatch.chdir(tmp_path)
+	monkeypatch.setattr("shutil.which", _which("camas"))
+	(tmp_path / ".claude").mkdir(parents=True)
+	(tmp_path / ".claude" / "settings.json").write_text(
+		json.dumps(
+			{
+				"hooks": {
+					"FileChanged": [
+						{
+							"hooks": [
+								{"type": "command", "command": "camas mcp fix --paths ${file_path}"}
+							]
+						}
+					],
+					"PreToolUse": [
+						{
+							"hooks": [
+								{
+									"type": "command",
+									"command": "camas mcp fix --paths ${file_path}",
+								},
+								{"type": "command", "command": "echo keep-me"},
+							]
+						}
+					],
+				}
+			}
+		)
+	)
+	assert write_hooks([]) == 0
+	hooks = json.loads((tmp_path / ".claude" / "settings.json").read_text())["hooks"]
+	assert "FileChanged" not in hooks
+	assert [h["command"] for g in hooks["PreToolUse"] for h in g["hooks"]] == ["echo keep-me"]
+	assert "mcp fix" in hooks["PostToolBatch"][-1]["hooks"][0]["command"]
+
+
 def test_write_hooks_rejects_matcher_null(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
 	monkeypatch.chdir(tmp_path)
 	monkeypatch.setattr("shutil.which", _which("camas"))


### PR DESCRIPTION
> [!WARNING]
> **LLM Disclosure**
>
> This PR was authored by claude-opus-4-8[1m] on behalf of @JPHutchins, who — running 0.1.18 — had an agent surface a stale `FileChanged` hook; I traced it and fixed the upgrade-cleanup gap.

Closes #157.

## The bug

Pre-#129 camas (≤ 0.1.17) wrote the autofix hook under the **`FileChanged`** event (`… mcp fix --paths ${file_path}`). #129 / 0.1.18 switched to **`PostToolBatch`**, but `write_hooks` (`camas mcp init --hooks`) only ever swept camas's own `mcp fix` hooks out of the **`PostToolBatch` event**. So a user who ran `init --hooks` on an older camas and then upgraded and re-ran it was left with the dead `FileChanged` hook alongside the new one — `FileChanged` doesn't fire on Claude's edits and `${file_path}` doesn't interpolate, so it's a no-op, but it's a confusing leftover in the committed `settings.json`. (The shipped 0.1.18 tree itself is clean; the plugin-install path self-heals — only the `init --hooks` path didn't.)

## The fix

`_with_camas_hook` now sweeps camas's `mcp fix` hooks from **every** event, dropping any group or event it empties, then appends the current hook under `PostToolBatch`:

- A camas-only event (the stale `FileChanged`) is dropped entirely.
- A non-camas hook in any event is preserved (its group kept, the camas hook removed).
- Order preservation and no-default-injection (from #144) are unchanged; the only new drop is the dead camas hook.

This makes `init --hooks` idempotent across the event rename and cleans up any pre-0.1.18 install on the next run.

## Test

`test_write_hooks_sweeps_stale_hooks_from_all_events` — a `settings.json` with a camas-only `FileChanged` group **and** a `PreToolUse` group holding a camas hook + a user hook; after `write_hooks`, `FileChanged` is gone, the `PreToolUse` user hook survives (camas hook removed), and the current hook is under `PostToolBatch`.

## Workaround (for anyone already affected on 0.1.18)

Delete the `FileChanged` block from `.claude/settings.json`, or just re-run `camas mcp init --hooks` once this ships.

## Verification

`camas all` — lint, format, mypy, pyright, ty, zuban, pyrefly, **coverage 100%** — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
