### PR TITLE
fix(test): eliminate SIGINT race in test_ctrl_c_keeps_pre_interrupt_completion_finished (#156)

### DIFF
--- a/tests/core/test_execution.py
+++ b/tests/core/test_execution.py
@@ -26,11 +26,15 @@ from camas.core.execution import (
 from camas.core.leaf_state import KILL_PRESSES
 from camas.v0.completion import INTERRUPT_RC, Finished, Skipped, Stopped
 from camas.v0.leaf_state import Interrupting, LeafState, Running
+from camas.v0.task_event import CompletedEvent
 
 if TYPE_CHECKING:
+	from collections.abc import Sequence
 	from pathlib import Path
 
 	from camas.core.completion import RunResult, TaskResult
+	from camas.v0.task import TaskNode
+	from camas.v0.task_event import TaskEvent
 
 
 def test_force_color_injected_in_subprocess(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -399,13 +403,23 @@ def test_ctrl_c_resolves_jobs_queued_leaves_as_stopped() -> None:
 
 @pytest.mark.skipif(sys.platform == "win32", reason="POSIX signal handling only")
 def test_ctrl_c_keeps_pre_interrupt_completion_finished() -> None:
+	class _SignalAfterQuick:
+		async def setup(self, task: TaskNode) -> None:
+			return None
+
+		async def on_event(self, event: TaskEvent, states: Sequence[LeafState], ctx: None) -> None:
+			if isinstance(event, CompletedEvent) and event.task.name == "quick":
+				os.kill(os.getpid(), signal.SIGINT)
+
+		async def teardown(self, ctxs: tuple[None, ...]) -> None:
+			pass
+
 	async def scenario() -> RunResult:
-		asyncio.get_running_loop().call_later(0.4, _raise_sigint)
 		task = Parallel(
 			Task(("python", "-c", "pass"), name="quick"),
 			Task(("python", "-c", "import time; time.sleep(5)"), name="slow"),
 		)
-		return await run(task)
+		return await run(task, effects=(_SignalAfterQuick(),))
 
 	result = asyncio.run(scenario())
 	by_name = {r.name: r.completion for r in result.results}


### PR DESCRIPTION
Closes #156.

## Problem

`test_ctrl_c_keeps_pre_interrupt_completion_finished` used a fixed 0.4s wall-clock timer (`call_later`) to fire SIGINT, assuming the "quick" subprocess (`python -c pass`) would finish within that window. On CPU-starved runners — particularly the macOS `example` job which fans 6 Python matrix leaves across a single runner — subprocess startup latency could exceed 0.4s, making the "quick" task still running when SIGINT arrived. That caused it to be reported as `Stopped` instead of `Finished`, failing the assertion.

## Fix

Replace `call_later(0.4, _raise_sigint)` with a minimal `Effect` that fires SIGINT deterministically — only when it observes the `CompletedEvent` for the "quick" task. This removes the wall-clock assumption entirely; the test is now robust regardless of CPU load.

## Verification

- All 8 local checks pass (format, lint, mypy, pyright, ty, zuban, pyrefly, test)
- The fixed test passes reliably — it no longer depends on subprocess startup beating a deadline

🤖 Generated with [Claude Code](https://claude.com/claude-code)