### PR TITLE
fix(scaffold): emit `uv run tasks.py mcp` for PEP 723 repos

### DIFF
--- a/src/camas/mcp/scaffold.py
+++ b/src/camas/mcp/scaffold.py
@@ -53,6 +53,20 @@ def tasks_py_path() -> Path | None:
 	return next((d / "tasks.py" for d in (cwd, *cwd.parents) if (d / "tasks.py").is_file()), None)
 
 
+def pep723_tasks_py_in_cwd() -> Path | None:
+	"""``Path.cwd() / "tasks.py"`` if it exists and has a PEP 723 header with a ``camas``
+	dependency, otherwise ``None``.
+	"""
+	tasks_py = Path.cwd() / "tasks.py"
+	if not tasks_py.is_file():
+		return None
+	from ..main.pep723 import camas_requirement_from
+
+	if camas_requirement_from(tasks_py) is not None:
+		return tasks_py
+	return None
+
+
 def resolve_pin() -> str | None:
 	"""The camas MCP requirement with extras for pinning, resolved from the project's ``tasks.py``."""
 	tasks_py = tasks_py_path()
@@ -112,8 +126,12 @@ def write_mcp_json(argv: list[str]) -> int:
 def launch_command(*, pin: str | None = None) -> tuple[str, list[str]] | None:
 	"""The most portable launch command for camas, or None if none is portable enough to commit."""
 	tail = ["mcp"]
-	if shutil.which("uv") is not None and uv_project_root() is not None:
-		return "uv", ["run", "camas", *tail]
+	if shutil.which("uv") is not None:
+		if uv_project_root() is not None:
+			return "uv", ["run", "camas", *tail]
+		tasks_py = pep723_tasks_py_in_cwd()
+		if tasks_py is not None:
+			return "uv", ["run", tasks_py.name, *tail]
 	if shutil.which("uvx") is not None:
 		spec = pin if pin is not None else "camas[mcp]"
 		return "uvx", [spec, *tail]
@@ -131,7 +149,7 @@ def uv_project_root() -> Path | None:
 def portability_note(command: str) -> str:
 	"""How portable the chosen launch command is, for the committed ``.mcp.json``."""
 	if command == "uv":
-		return "This entry is portable; uv resolves camas from the lockfile."
+		return "This entry is portable; uv resolves camas from the lockfile or the PEP 723 header in tasks.py."
 	if command == "uvx":
 		return "This entry is portable; uvx downloads and runs camas[mcp] from PyPI."
 	return "This entry is portable if your team installs camas on PATH; commit it to share."

--- a/tests/mcp/test_scaffold.py
+++ b/tests/mcp/test_scaffold.py
@@ -97,6 +97,78 @@ def test_launch_command_str_none(monkeypatch: pytest.MonkeyPatch) -> None:
 	assert launch_command_str() is None
 
 
+def test_launch_command_uv_with_pep723_tasks_py(
+	tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+	monkeypatch.chdir(tmp_path)
+	(tmp_path / "tasks.py").write_text(
+		'# /// script\n# dependencies = ["camas>=0.1.8"]\n# ///\nfrom camas import Task\n'
+	)
+	monkeypatch.setattr("shutil.which", _which("uv"))
+	assert launch_command() == ("uv", ["run", "tasks.py", "mcp"])
+	assert launch_command(pin="camas[mcp]>=0.1.8") == ("uv", ["run", "tasks.py", "mcp"])
+
+
+def test_launch_command_uv_lock_wins_over_pep723_tasks_py(
+	tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+	monkeypatch.chdir(tmp_path)
+	(tmp_path / "uv.lock").write_text("")
+	(tmp_path / "tasks.py").write_text(
+		'# /// script\n# dependencies = ["camas>=0.1.8"]\n# ///\nfrom camas import Task\n'
+	)
+	monkeypatch.setattr("shutil.which", _which("uv", "camas"))
+	assert launch_command() == ("uv", ["run", "camas", "mcp"])
+
+
+def test_launch_command_pep723_tasks_py_must_be_in_cwd(
+	tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+	sub = tmp_path / "sub"
+	sub.mkdir()
+	(sub / "tasks.py").write_text(
+		'# /// script\n# dependencies = ["camas>=0.1.8"]\n# ///\nfrom camas import Task\n'
+	)
+	monkeypatch.chdir(tmp_path)
+	monkeypatch.setattr("shutil.which", _which("uv"))
+	assert launch_command() is None
+
+
+def test_launch_command_tasks_py_without_pep723_header_falls_through(
+	tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+	monkeypatch.chdir(tmp_path)
+	(tmp_path / "tasks.py").write_text("from camas import Task\nlint = Task('echo')\n")
+	monkeypatch.setattr("shutil.which", _which("uv"))
+	assert launch_command() is None
+
+
+def test_write_mcp_json_uses_uv_run_tasks_py_when_pep723(
+	tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+	monkeypatch.chdir(tmp_path)
+	(tmp_path / "tasks.py").write_text(
+		'# /// script\n# dependencies = ["camas>=0.1.8"]\n# ///\nfrom camas import Task\n'
+	)
+	monkeypatch.setattr("shutil.which", _which("uv"))
+	assert write_mcp_json([]) == 0
+	entry = json.loads((tmp_path / ".mcp.json").read_text())["mcpServers"]["camas"]
+	assert (entry["command"], entry["args"]) == ("uv", ["run", "tasks.py", "mcp"])
+
+
+def test_write_hooks_uses_uv_run_tasks_py_when_pep723(
+	tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+	monkeypatch.chdir(tmp_path)
+	(tmp_path / "tasks.py").write_text(
+		'# /// script\n# dependencies = ["camas>=0.1.8"]\n# ///\nfrom camas import Task\n'
+	)
+	monkeypatch.setattr("shutil.which", _which("uv"))
+	assert write_hooks([]) == 0
+	out = capsys.readouterr().out
+	assert "uv run tasks.py mcp fix" in out
+
+
 def test_tasks_py_path_finds_tasks_py(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
 	(tmp_path / "tasks.py").write_text("")
 	monkeypatch.chdir(tmp_path)


### PR DESCRIPTION
## Summary

Closes #165.

`camas mcp init` checked for a `uv.lock` but not a PEP 723 `tasks.py`, so a non-Python repo with a PEP 723 header (no `uv.lock`) fell to the `uvx 'camas[mcp]==X' mcp` branch. `uvx` works (the pin matches) but is a **different resolution path** than the user's `uv run tasks.py …` — an ephemeral PyPI fetch, not the same pin source and env the header provides. When a PEP 723 `tasks.py` is the camas source, the launcher should mirror the user's invocation.

## The fix

New precedence slot in `launch_command` between `uv.lock` and `uvx`: if `uv` is on PATH and `tasks.py` in cwd has a PEP 723 `camas` header, emit `uv run tasks.py mcp` (uv reads the pin from the header — no lockfile or `[project]` needed, works on non-Python repos).

New precedence:
1. `uv` + `uv.lock` → `uv run camas mcp` (Python/uv project; lockfile is the pin — **unchanged**)
2. `uv` + PEP 723 `tasks.py` in cwd → `uv run tasks.py mcp` (**new** — standalone case, mirrors the user's invocation)
3. `uvx` available → `uvx 'camas[mcp]==X' mcp` (pinned fallback — no `tasks.py`, no `uv.lock`)
4. `camas` on PATH → `camas mcp` (last resort)

The new `pep723_tasks_py_in_cwd()` helper checks **cwd only** (not ancestors) — bare `tasks.py` — because `.mcp.json` is committed and the MCP client's cwd is the project root; a relative-ancestor path (`../tasks.py`) would be fragile. Lockfile precedence is unchanged; `uvx` remains the fallback for repos with no `tasks.py`.

## Verification

- `uv run camas fix` green (lint_fix, format).
- `uv run camas all` green locally: ty, pyrefly, zuban, mypy, pyright all pass; 100% coverage; 1090 tests pass.
- End-to-end against local camas in a PEP 723 non-Python repo: `camas mcp init` now writes `uv run tasks.py mcp` (was `uvx 'camas[mcp]==0.1.19' mcp`).
- New tests: `test_launch_command_uv_with_pep723_tasks_py` (pin ignored, header owns it), `test_launch_command_uv_lock_wins_over_pep723_tasks_py` (lockfile precedence), `test_launch_command_pep723_tasks_py_must_be_in_cwd` (no `../tasks.py`), `test_launch_command_tasks_py_without_pep723_header_falls_through`, `test_write_mcp_json_uses_uv_run_tasks_py_when_pep723` (E2E), `test_write_hooks_uses_uv_run_tasks_py_when_pep723` (E2E).
- Cross-platform (OS × Python) results via CI — monitoring to completion.

---

> [!WARNING]
> **LLM Disclosure**
>
> This PR was authored by z-ai/glm-5.2 on behalf of @JPHutchins. JP asked whether the `uvx` launcher in #165 was right or should change; assessment confirmed it should emit `uv run tasks.py mcp` to mirror the user's invocation. Implementation and tests were delegated to a sonnet subagent under the main agent's plan; the main agent reviewed the diff, verified the fix end-to-end, and drove `uv run camas all` to green before pushing.
