### PR TITLE
fix(mcp): re-resolve the task graph on every tool call (#178)

### DIFF
--- a/src/camas/__init__.py
+++ b/src/camas/__init__.py
@@ -82,6 +82,12 @@ may add ``agent_format=("--output-format sarif", "sarif")`` (kinds:
 collects machine-readable diagnostics — appended only on gate runs, not
 human runs.
 
+The MCP server re-executes ``tasks.py`` on every tool call, so a command
+computed from the filesystem at the top level of ``tasks.py`` (a glob, a
+file list) stays fresh — but values computed in a separately imported
+module are import-cached and can go stale; prefer ``{paths}``/``when=``
+over snapshotting file lists where freshness matters.
+
 **LLM agents:** prefer the MCP::
 
     $ camas mcp [--help | --plain]

--- a/src/camas/mcp/serve.py
+++ b/src/camas/mcp/serve.py
@@ -112,8 +112,8 @@ class Compat(NamedTuple):
 
 @dataclass(slots=True)
 class Session:
-	"""Server state: the resolved project, its root, the compat switches, a per-run counter
-	naming each run's log directory, and the source mtime that gates lazy re-resolution.
+	"""Server state: the resolved project, its root, the compat switches, and a per-run
+	counter naming each run's log directory.
 	"""
 
 	project: TasksState
@@ -121,10 +121,8 @@ class Session:
 	compat: Compat
 	runs: int = 0
 	version_warning: str | None = field(default=None, init=False)
-	source_mtime_ns: int | None = field(default=None, init=False)
 
 	def __post_init__(self) -> None:
-		self.source_mtime_ns = source_mtime_ns(self.project)
 		self.version_warning = check_version_pin(self.project)
 
 	@property
@@ -134,11 +132,9 @@ class Session:
 		return (config if config is not None else Config()).camas_path(self.base)
 
 	def refresh(self) -> None:
-		"""Re-resolve the project if its source file changed on disk since it was pinned."""
-		if source_mtime_ns(self.project) != self.source_mtime_ns:
-			self.project = resolve_project_quiet(self.base)
-			self.source_mtime_ns = source_mtime_ns(self.project)
-			self.version_warning = check_version_pin(self.project)
+		"""Re-resolve the project from disk, matching the CLI's per-invocation re-execution."""
+		self.project = resolve_project_quiet(self.base)
+		self.version_warning = check_version_pin(self.project)
 
 	def reserve_run(self) -> int:
 		"""Claim the next run's sequence number (atomic between ``await`` points)."""
@@ -153,17 +149,6 @@ def project_source(state: TasksState) -> Path | None:
 			return source
 		case _:
 			assert_never(state)
-
-
-def source_mtime_ns(state: TasksState) -> int | None:
-	"""The mtime of a state's source file, or ``None`` if it has none or is gone."""
-	source = project_source(state)
-	if source is None:
-		return None
-	try:
-		return source.stat().st_mtime_ns
-	except OSError:
-		return None
 
 
 def check_version_pin(state: TasksState) -> str | None:

--- a/tests/mcp/test_serve.py
+++ b/tests/mcp/test_serve.py
@@ -995,7 +995,12 @@ def test_error_result_is_tool_error() -> None:
 
 
 async def test_in_memory_round_trip(tmp_path: Path) -> None:
-	session = _session({"lint": PASS}, Config(default_task=PASS), tmp_path)
+	(tmp_path / "tasks.py").write_text(
+		"from camas import Config, Task\n"
+		"lint = Task(('python', '-c', 'pass'))\n"
+		"_ = Config(default_task=lint)\n"
+	)
+	session = Session(serve.resolve_project(tmp_path), tmp_path, Compat())
 	async with create_connected_server_and_client_session(serve.build_server(session)) as client:
 		listed = await client.list_tools()
 		assert {t.name for t in listed.tools} == {
@@ -1017,7 +1022,10 @@ async def test_in_memory_round_trip(tmp_path: Path) -> None:
 
 
 async def test_list_via_client_expands_matrix_on_request(tmp_path: Path) -> None:
-	session = _session({"m": _MATRIX}, None, tmp_path)
+	(tmp_path / "tasks.py").write_text(
+		"from camas import Parallel, Task\nm = Parallel(Task('test {PY}'), matrix={'PY': ('3.13', '3.14')})\n"
+	)
+	session = Session(serve.resolve_project(tmp_path), tmp_path, Compat())
 	async with create_connected_server_and_client_session(serve.build_server(session)) as client:
 		collapsed = _text(await client.call_tool("camas_list", {}))
 		assert "[PY=3.13]" not in collapsed
@@ -1033,27 +1041,23 @@ async def test_call_unknown_tool_is_error(tmp_path: Path) -> None:
 	assert "unknown tool 'camas_nope'" in _text(result)
 
 
-def _bump_mtime(path: Path, session: Session) -> None:
-	os.utime(path, ns=(0, (session.source_mtime_ns or 0) + 1_000_000_000))
-
-
 def test_session_refresh_picks_up_edits(tmp_path: Path) -> None:
 	tasks_py = tmp_path / "tasks.py"
 	tasks_py.write_text("from camas import Task\na = Task('x')\n")
 	session = Session(serve.resolve_project(tmp_path), tmp_path, Compat())
 	assert serve.task_names(session.project) == ("a",)
 	tasks_py.write_text("from camas import Task\na = Task('x')\nb = Task('y')\n")
-	_bump_mtime(tasks_py, session)
 	session.refresh()
 	assert set(serve.task_names(session.project)) == {"a", "b"}
 
 
-def test_session_refresh_noop_when_unchanged(tmp_path: Path) -> None:
+def test_session_refresh_reresolves_when_file_unchanged(tmp_path: Path) -> None:
 	(tmp_path / "tasks.py").write_text("from camas import Task\na = Task('x')\n")
 	session = Session(serve.resolve_project(tmp_path), tmp_path, Compat())
 	pinned = session.project
 	session.refresh()
-	assert session.project is pinned
+	assert session.project is not pinned
+	assert serve.task_names(session.project) == ("a",)
 
 
 def test_session_refresh_noop_without_source(tmp_path: Path) -> None:
@@ -1089,10 +1093,70 @@ async def test_run_via_client_picks_up_new_task_without_check(tmp_path: Path) ->
 			"a = Task(('python', '-c', 'pass'))\n"
 			"b = Task(('python', '-c', 'pass'))\n"
 		)
-		_bump_mtime(tasks_py, session)
 		ran = await client.call_tool("camas_run", {"task": "b"})
 		assert ran.isError is False
 		assert "PASSED" in _text(ran)
+
+
+def _glob_check_tasks_py() -> str:
+	return (
+		"from pathlib import Path\n"
+		"from camas import Task\n"
+		"_t = [str(p) for p in sorted((Path(__file__).parent / 'targets').glob('*.txt'))]\n"
+		"check = Task(('python', '-c', "
+		"'import os,sys; sys.exit(0 if all(map(os.path.exists, sys.argv[1:])) else 1)', "
+		"*_t), name='check')\n"
+	)
+
+
+def test_session_refresh_reflects_filesystem_derived_command(tmp_path: Path) -> None:
+	targets = tmp_path / "targets"
+	targets.mkdir()
+	(targets / "a.txt").write_text("")
+	(tmp_path / "tasks.py").write_text(_glob_check_tasks_py())
+	session = Session(serve.resolve_project(tmp_path), tmp_path, Compat())
+	assert isinstance(session.project, LoadOk)
+	before_task = session.project.tasks["check"]
+	assert isinstance(before_task, Task)
+	assert isinstance(before_task.cmd, tuple)
+	assert before_task.cmd[-1].endswith("a.txt")
+	(targets / "a.txt").rename(targets / "b.txt")
+	session.refresh()
+	assert isinstance(session.project, LoadOk)
+	after_task = session.project.tasks["check"]
+	assert isinstance(after_task, Task)
+	assert isinstance(after_task.cmd, tuple)
+	assert after_task.cmd[-1].endswith("b.txt")
+
+
+async def test_run_via_client_reflects_filesystem_change_between_calls(tmp_path: Path) -> None:
+	targets = tmp_path / "targets"
+	targets.mkdir()
+	(targets / "a.txt").write_text("")
+	(tmp_path / "tasks.py").write_text(_glob_check_tasks_py())
+	session = Session(serve.resolve_project(tmp_path), tmp_path, Compat())
+	async with create_connected_server_and_client_session(serve.build_server(session)) as client:
+		first = await client.call_tool("camas_run", {"task": "check"})
+		assert first.isError is False
+		assert "PASSED" in _text(first)
+		(targets / "a.txt").rename(targets / "b.txt")
+		second = await client.call_tool("camas_run", {"task": "check"})
+		assert second.isError is False
+		assert "PASSED" in _text(second)
+
+
+async def test_run_via_client_surfaces_broken_edit_between_calls(tmp_path: Path) -> None:
+	tasks_py = tmp_path / "tasks.py"
+	tasks_py.write_text("from camas import Task\ncheck = Task(('python', '-c', 'pass'))\n")
+	session = Session(serve.resolve_project(tmp_path), tmp_path, Compat())
+	async with create_connected_server_and_client_session(serve.build_server(session)) as client:
+		first = await client.call_tool("camas_run", {"task": "check"})
+		assert first.isError is False
+		assert "PASSED" in _text(first)
+		tasks_py.write_text("raise RuntimeError('boom')\n")
+		second = await client.call_tool("camas_run", {"task": "check"})
+		assert second.isError is True
+		assert "Tasks unavailable" in _text(second)
 
 
 def _text(result: types.CallToolResult) -> str:


### PR DESCRIPTION
> [!WARNING]
> **LLM Disclosure**
>
> This post was authored by claude-fable-5 on behalf of @JPHutchins, who asked me to resolve #178 with a branch, PR, and integration-test coverage, using an Opus planning pass and a Sonnet implementation pass.

Closes #178

## Root cause

`Session.refresh()` already ran before every MCP tool call, but it was gated on the **tasks-file mtime** — the wrong signal for #178's failure: a task command computed from the filesystem at import time (a glob, a file list) goes stale while `tasks.py` itself is untouched, so the mtime gate no-ops and the server keeps serving the import-time snapshot. The CLI never has this problem because `load_tasks_from_py` re-executes the tasks module (`runpy.run_path`) on every invocation.

## Fix

Drop the gate: `refresh()` now unconditionally re-resolves the project from disk on every tool call, re-executing `tasks.py` exactly like the CLI does. The now-dead `source_mtime_ns` field and helper are removed. Cost is one `runpy` re-exec per call — the same work `camas_check` already does unconditionally, and trivial next to any real task.

Nothing else changes:
- Tool descriptions/schemas need no new mechanism — a command change doesn't alter task names, and `call_handler` already sends `tool_list_changed` when names do change. `camas_list`'s `command_preview` was already recomputed per call, so it now reflects fresh commands too.
- A broken edit between calls degrades exactly like the CLI: `resolve_project` catches the import error into `LoadErr` and the tool returns the load-error hint.

## Known limitation (documented, not fixed)

`runpy` re-executes `tasks.py`'s top level, but modules `tasks.py` *imports* stay cached in `sys.modules` — a file list computed inside an imported helper module can still go stale. Clearing `sys.modules` would be fragile, so instead the authoring guide (`camas_docs` tutorial in the `camas.__init__` docstring) now notes the re-execution semantics and steers toward `{paths}`/`when=` over snapshotted file lists.

## Tests (`tests/mcp/test_serve.py`)

- `test_run_via_client_reflects_filesystem_change_between_calls` — end-to-end reproduction of the issue over an in-memory MCP client: `camas_run` a task whose command globs a `targets/` dir, rename the target file **without touching `tasks.py`**, run again. Fails pre-fix (stale command references the renamed file), passes post-fix.
- `test_session_refresh_reflects_filesystem_derived_command` — same discriminator at the `Session.refresh()` unit level.
- `test_run_via_client_surfaces_broken_edit_between_calls` — a `raise` inserted into `tasks.py` between calls yields a tool error with the load-error hint, not a crash.
- Existing mtime-gate tests updated: `_bump_mtime` helper deleted, `test_session_refresh_noop_when_unchanged` replaced by `test_session_refresh_reresolves_when_file_unchanged` (fresh object, same content). Two older tests that fabricated an in-memory project with no real `tasks.py` on disk now write one, since per-call refresh genuinely re-resolves from disk.

## Verification

- Pre-fix: the two new discriminator tests fail with the exact stale-command behavior from the issue (`FAILED (returncode=1)` on the second call).
- Post-fix: `camas check` (ruff format/lint, mypy, pyright, ty, zuban, pyrefly, pytest — 1291 passed, 10 skipped) and `camas coverage` (100.00%, gate met) both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VWrNfVfpzbASFaTLEy7oKF