### PR TITLE
feat: dogfood-friction batch — run default, version-skew hints, github_default docs (#177)

### DIFF
--- a/.github/workflows/claude-code-harness.yaml
+++ b/.github/workflows/claude-code-harness.yaml
@@ -9,7 +9,7 @@ name: Claude Code hook harness
 # PostToolBatch hook fires, and the fixer reaches green via the MCP camas_gate tool.
 #
 # It uses the same DeepSeek backend the agentic review workflow does (ANTHROPIC_BASE_URL +
-# ANTHROPIC_AUTH_TOKEN=DEEPSEEK_API_KEY, a burner key with a hard spend cap), on the cheap
+# ANTHROPIC_AUTH_TOKEN=MODEL_API_KEY, a burner key with a hard spend cap), on the cheap
 # deepseek-v4-flash tier. The schedule catches a Claude Code release changing the contract even
 # when camas itself has not changed.
 on:
@@ -74,12 +74,12 @@ jobs:
           CAMAS_CC_E2E: "1"
           CAMAS_CC_MODEL: deepseek-v4-flash
           ANTHROPIC_BASE_URL: https://api.deepseek.com/anthropic
-          ANTHROPIC_AUTH_TOKEN: ${{ secrets.DEEPSEEK_API_KEY }}
+          ANTHROPIC_AUTH_TOKEN: ${{ secrets.MODEL_API_KEY }}
           # The camas-fixer subagent is model: haiku; point the haiku tier at DeepSeek so the
           # fixer-loop test (criterion #3) drives a real subagent round-trip, as claude-code-review does.
           ANTHROPIC_DEFAULT_HAIKU_MODEL: deepseek-v4-flash
           CLAUDE_CODE_SUBAGENT_MODEL: deepseek-v4-flash
           UV_PYTHON_DOWNLOADS: never
         run: |
-          [ -n "$ANTHROPIC_AUTH_TOKEN" ] || { echo "::error::DEEPSEEK_API_KEY secret is not set"; exit 1; }
+          [ -n "$ANTHROPIC_AUTH_TOKEN" ] || { echo "::error::MODEL_API_KEY secret is not set"; exit 1; }
           uv run --python 3.12 pytest tests/claude_code/ -v --no-cov -p no:cacheprovider

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ Because `github_task` reproduces CI, running it before a push catches a CI failu
 echo 'exec camas check' > .git/hooks/pre-push && chmod +x .git/hooks/pre-push
 ```
 
-`git push --no-verify` still bypasses it deliberately. An LLM agent needs no hook — `camas_list` reports the CI task as `github_default`, so it runs `camas_run` with that name before pushing.
+`git push --no-verify` still bypasses it deliberately. An LLM agent needs no hook — when a `github_task` is declared, `camas_list` reports it as `github_default`, so the agent runs `camas_run` with that name before pushing. The field is `null` when no `github_task` is set; camas never infers it from your CI workflow files.
 
 ## Time budget (`--under`)
 

--- a/src/camas/__init__.py
+++ b/src/camas/__init__.py
@@ -53,34 +53,37 @@ real ordering (a mutating step, or one that consumes a prior's output).
 (``github_task`` takes over under GitHub Actions) — so a CI step is just
 ``camas`` (or ``uv run camas``), which won't go stale if you change
 ``github_task``. That same ``github_task`` reproduces CI locally — run it
-before you push to catch a CI failure first: ``camas_list`` surfaces it as
-``github_default`` for an agent to ``camas_run``, and a named CI task
-doubles as a one-line git ``pre-push`` hook.
+before you push to catch a CI failure first: ``camas_list`` surfaces the
+declared ``github_task`` as ``github_default`` for an agent to ``camas_run``
+(``null`` when no ``github_task`` is set — camas never infers it from CI
+workflow files), and a named CI task doubles as a one-line git ``pre-push``
+hook.
 
 These five are the unversioned alias for the latest API generation; to
 pin a generation, import from its namespace (``camas.v0``). See the
 README's Versioning section.
 
-``Config(agent=Claude(fix=..., check=...))`` wires the Claude Code
-plugin's gate. ``fix`` is the deterministic, behavior-preserving autofix
-node the ``PostToolBatch`` hook runs over the changed files (scope it with
-``{paths}``, on a leaf or a whole group; zero model tokens) — declared, not inferred from
-``mutates=``, since a mutating leaf may be a compiler or codegen rather
-than a fixer. A leaf whose command can't take ``{paths}`` (``cargo build``,
-``nix flake check``) instead sets ``when=`` — a directory-prefix string, a
-tuple of prefixes, or a ``(changed) -> bool`` callable — so the gate skips
-it on a scoped run the change doesn't touch, and never consults it on a
-full run; ``by_suffix`` builds a suffix-filtering ``paths`` scope for a
-``{paths}`` leaf that should still run against the whole project on a
-full run. ``check`` is the node the gate validates (``None`` defers
-to ``default_task``/``github_task``), scoped by ``--paths`` and
-time-boxed by ``--under``; the plugin delegates it to a background
-``camas-fixer`` subagent that drives the changed scope to green off the
-main agent's context, rather than blocking on a hook. A checking leaf
-may add ``agent_format=("--output-format sarif", "sarif")`` (kinds:
-``sarif``, ``rdjson``, ``lsp``, ``junit``, ``tap``, ``raw``) so the gate
-collects machine-readable diagnostics — appended only on gate runs, not
-human runs.
+``Config(agent=Claude(fix=..., check=..., default=...))`` wires the Claude
+Code plugin's gate. ``fix`` is the deterministic, behavior-preserving
+autofix node the ``PostToolBatch`` hook runs over the changed files (scope
+it with ``{paths}``, on a leaf or a whole group; zero model tokens) —
+declared, not inferred from ``mutates=``, since a mutating leaf may be a
+compiler or codegen rather than a fixer. A leaf whose command can't take
+``{paths}`` (``cargo build``, ``nix flake check``) instead sets ``when=`` —
+a directory-prefix string, a tuple of prefixes, or a ``(changed) -> bool``
+callable — so the gate skips it on a scoped run the change doesn't touch,
+and never consults it on a full run; ``by_suffix`` builds a suffix-filtering
+``paths`` scope for a ``{paths}`` leaf that should still run against the
+whole project on a full run. ``check`` is the node the gate validates
+(``None`` defers to ``default_task``/``github_task``), scoped by ``--paths``
+and time-boxed by ``--under``; the plugin delegates it to a background
+``camas-fixer`` subagent that drives the changed scope to green off the main
+agent's context, rather than blocking on a hook. A checking leaf may add
+``agent_format=("--output-format sarif", "sarif")`` (kinds: ``sarif``,
+``rdjson``, ``lsp``, ``junit``, ``tap``, ``raw``) so the gate collects
+machine-readable diagnostics — appended only on gate runs, not human runs.
+``default`` is the task a no-task ``camas_run`` runs — ``None`` defers to
+``check``, then ``github_task``/``default_task``.
 
 The MCP server re-executes ``tasks.py`` on every tool call, so a command
 computed from the filesystem at the top level of ``tasks.py`` (a glob, a

--- a/src/camas/main/format.py
+++ b/src/camas/main/format.py
@@ -110,6 +110,24 @@ def format_load_error_hint(source: Path, exception: Exception) -> str:
 	)
 
 
+def format_version_skew_hint(running: str, spec: str) -> str:
+	"""Hint shown when the running MCP server's camas version does not satisfy
+	``tasks.py``'s pin — points the caller at reconnecting, and at the
+	``uv run tasks.py`` fallback that resolves the pin fresh per invocation.
+
+	>>> "reconnect the MCP server" in format_version_skew_hint("0.1.21", "==0.1.22")
+	True
+	>>> "uv run tasks.py" in format_version_skew_hint("0.1.21", "==0.1.22")
+	True
+	"""
+	return (
+		f"MCP server is running camas {running} but tasks.py pins camas{spec} — "
+		"reconnect the MCP server to pick up the new version.\n\n"
+		"Run the task directly with `uv run tasks.py <task>` in the meantime: it resolves the "
+		"pinned camas version fresh per invocation, so it works while the server is stale."
+	)
+
+
 def format_scope_warnings(tasks: Mapping[str, TaskNode]) -> str:
 	"""Render every :func:`camas.core.scope.scope_warnings` message across the raw trees in
 	``tasks``, deduplicated (a node shared by two names warns once) and one per line —

--- a/src/camas/main/tasks.py
+++ b/src/camas/main/tasks.py
@@ -214,7 +214,11 @@ def name_scope_config(scope: Mapping[str, object]) -> Config | None:
 	def promote_agent(agent: Agent | None) -> Agent | None:
 		if agent is None:
 			return None
-		return Claude(fix=promote_required(agent.fix), check=promote_field(agent.check))
+		return Claude(
+			fix=promote_required(agent.fix),
+			check=promote_field(agent.check),
+			default=promote_field(agent.default),
+		)
 
 	return Config(
 		default_task=promote_field(config.default_task),

--- a/src/camas/mcp/catalog.py
+++ b/src/camas/mcp/catalog.py
@@ -34,6 +34,7 @@ def to_list_response(
 	"""
 	default = task_name(config.default_task) if config is not None else None
 	github_default = task_name(config.github_task) if config is not None else None
+	run_default = task_name(config.run_default()) if config is not None else None
 	return wire.ListResponse(
 		tasks=tuple(
 			task_info(
@@ -48,6 +49,7 @@ def to_list_response(
 		),
 		default=default,
 		github_default=github_default,
+		run_default=run_default,
 	)
 
 

--- a/src/camas/mcp/serve.py
+++ b/src/camas/mcp/serve.py
@@ -399,7 +399,9 @@ def tools(task_names: tuple[str, ...], compat: Compat) -> Tools:
 				declared via Config(github_task=...) (camas is the single definition shared by
 				local and CI), so running it locally before you commit or push reproduces CI
 				exactly; github_default is null when the project declares no github_task (camas
-				never infers it from CI workflow files). Tasks whose leaves have been timed also
+				never infers it from CI workflow files). run_default names the task a no-task
+				camas_run resolves (agent default, else check, else the github or default
+				task). Tasks whose leaves have been timed also
 				carry an estimated duration and their slowest leaf, so you can pick a quick task
 				for the inner loop and the thorough one before committing. Use this first to
 				discover valid task names for camas_run; it is the source of truth. Read-only;
@@ -553,7 +555,7 @@ def list_call(session: Session, arguments: dict[str, Any]) -> types.CallToolResu
 
 def check_call(session: Session) -> types.CallToolResult:
 	"""Handle ``camas_check``: re-resolve and re-pin the project from disk, then validate it."""
-	session.project = resolve_project_quiet(session.base)
+	session.refresh()
 	resp = to_check_response(session.project).model_copy(
 		update={"server_version": running_version()}
 	)
@@ -577,7 +579,7 @@ def init_call(session: Session) -> types.CallToolResult:
 		return success(init_text(resp), resp, session.compat)
 	except OSError as e:
 		return error_result(f"camas_init: could not scaffold tasks.py: {e}")
-	session.project = resolve_project_quiet(session.base)
+	session.refresh()
 	resp = wire.InitResponse(status="created", path=str(created), content=starter_text())
 	return success(init_text(resp), resp, session.compat)
 
@@ -879,6 +881,8 @@ def list_text(resp: wire.ListResponse, *, expand_matrix: bool) -> str:
 			f"{resp.github_default}. A bare `camas` runs it under GitHub Actions, so a CI "
 			f"step is just `camas` — naming the task there is redundant."
 		)
+	if resp.run_default is not None and resp.run_default != resp.default:
+		lines.append(f"no-task camas_run runs: {resp.run_default}")
 	lines.append("")
 	width = max((len(t.name) for t in resp.tasks), default=0)
 	for t in resp.tasks:

--- a/src/camas/mcp/serve.py
+++ b/src/camas/mcp/serve.py
@@ -35,7 +35,7 @@ from ..core.render import render_tree_lines, strip_ansi
 from ..core.scope import scope_to_changed, to_changed, with_default_paths
 from ..core.task import task_label
 from ..main.argv import apply_passthrough
-from ..main.format import format_load_error_hint
+from ..main.format import format_load_error_hint, format_version_skew_hint
 from ..main.init import create_starter_tasks_py, starter_text
 from ..main.pep723 import camas_requirement_from, version_specifier
 from ..main.state import EMPTY_STATE, LoadErr, LoadOk, TasksState
@@ -96,6 +96,11 @@ INIT_ANNOTATIONS: Final = types.ToolAnnotations(
 	readOnlyHint=False, destructiveHint=False, idempotentHint=True, openWorldHint=False
 )
 RUN_LOG_KEEP: Final = 10
+NO_RUN_DEFAULT_MSG: Final = (
+	"camas_run has no task to run: name a task, or set a project default in tasks.py — "
+	"Config(default_task=…), Config(github_task=…), or "
+	"Config(agent=Claude(fix=…, default=…))."
+)
 
 
 class Compat(NamedTuple):
@@ -151,12 +156,32 @@ def project_source(state: TasksState) -> Path | None:
 			assert_never(state)
 
 
+class VersionSkew(NamedTuple):
+	"""The running camas version and the PEP 723 pin it fails to satisfy."""
+
+	running: str
+	spec: str
+
+
 def check_version_pin(state: TasksState) -> str | None:
 	"""Compare the running camas version against the PEP 723 pin in the project's ``tasks.py``.
 
 	Uses a lightweight parse (``==``, ``>=``, ``>``, ``<=``, ``<``) that avoids a ``packaging``
 	dependency. ``!=``, ``~=``, and comma-separated compound specifiers are skipped rather than
 	risking a false positive — we err toward silence. Only a single specifier is checked.
+	"""
+	skew = version_skew(state)
+	if skew is None:
+		return None
+	return (
+		f"camas {skew.running} does not satisfy tasks.py pin {skew.spec}; "
+		f"re-run `camas mcp init --claude` after bumping"
+	)
+
+
+def version_skew(state: TasksState) -> VersionSkew | None:
+	"""The (running, pin) pieces when the running camas version does not satisfy the project's
+	PEP 723 pin, else ``None`` — the structural form of :func:`check_version_pin`.
 	"""
 	source = project_source(state)
 	if source is None:
@@ -167,16 +192,20 @@ def check_version_pin(state: TasksState) -> str | None:
 	spec = version_specifier(req)
 	if spec is None:
 		return None
-	try:
-		running = version("camas")
-	except PackageNotFoundError:
+	running = running_version()
+	if running is None:
 		return None
 	if version_satisfies(running, spec):
 		return None
-	return (
-		f"camas {running} does not satisfy tasks.py pin {spec}; "
-		f"re-run `camas mcp init --claude` after bumping"
-	)
+	return VersionSkew(running=running, spec=spec)
+
+
+def running_version() -> str | None:
+	"""The installed camas distribution version, or ``None`` when metadata is unavailable."""
+	try:
+		return version("camas")
+	except PackageNotFoundError:
+		return None
 
 
 def version_satisfies(running: str, specifier: str) -> bool:
@@ -366,9 +395,11 @@ def tools(task_names: tuple[str, ...], compat: Compat) -> Tools:
 				unexpanded template by default (their axis values are listed separately, which
 				keeps discovery compact); pass expand_matrix=true to inline every resolved leaf
 				recursively. Two tasks are flagged: the default (what the developer runs while
-				working) and the github default — the exact task this project's CI runs (camas
-				is the single definition shared by local and CI), so running it locally before
-				you commit or push reproduces CI exactly. Tasks whose leaves have been timed also
+				working) and the github default — the exact task this project's CI runs,
+				declared via Config(github_task=...) (camas is the single definition shared by
+				local and CI), so running it locally before you commit or push reproduces CI
+				exactly; github_default is null when the project declares no github_task (camas
+				never infers it from CI workflow files). Tasks whose leaves have been timed also
 				carry an estimated duration and their slowest leaf, so you can pick a quick task
 				for the inner loop and the thorough one before committing. Use this first to
 				discover valid task names for camas_run; it is the source of truth. Read-only;
@@ -397,8 +428,8 @@ def tools(task_names: tuple[str, ...], compat: Compat) -> Tools:
 				whose recorded estimate fits — mutating leaves (formatters) first, then the
 				read-only rest in parallel; omit task to budget the project default. Compact
 				failures-first summary by default; dry_run=true previews the fully-resolved plan
-				without executing. A non-zero result means a task failed — a normal result, not a
-				tool error.
+				without executing. Omit task entirely to run the project's configured default. A
+				non-zero result means a task failed — a normal result, not a tool error.
 			""").strip(),
 			input_schema=wire.run_input_schema(task_names),
 			output_model=wire.RunResponse,
@@ -506,7 +537,7 @@ def list_call(session: Session, arguments: dict[str, Any]) -> types.CallToolResu
 		return error_result(f"invalid camas_list arguments:\n{e}")
 	match session.project:
 		case LoadErr(source=source, exception=exception):
-			return error_result(format_load_error_hint(source, exception))
+			return error_result(load_error_hint(session, source, exception))
 		case LoadOk(tasks=tasks, config=config):
 			resp = to_list_response(
 				tasks, config, timings.load(session.camas_dir), expand=req.expand_matrix
@@ -523,7 +554,9 @@ def list_call(session: Session, arguments: dict[str, Any]) -> types.CallToolResu
 def check_call(session: Session) -> types.CallToolResult:
 	"""Handle ``camas_check``: re-resolve and re-pin the project from disk, then validate it."""
 	session.project = resolve_project_quiet(session.base)
-	resp = to_check_response(session.project)
+	resp = to_check_response(session.project).model_copy(
+		update={"server_version": running_version()}
+	)
 	return success(with_warning(session, check_text(resp)), resp, session.compat)
 
 
@@ -553,7 +586,7 @@ async def run_call(session: Session, arguments: dict[str, Any]) -> types.CallToo
 	"""Handle ``camas_run``: validate, resolve the node, then dry-run or execute in-process."""
 	match session.project:
 		case LoadErr(source=source, exception=exception):
-			return error_result(format_load_error_hint(source, exception))
+			return error_result(load_error_hint(session, source, exception))
 		case LoadOk(tasks=tasks, config=config):
 			return await run_for(session, tasks, config, arguments)
 		case _:
@@ -599,29 +632,29 @@ def resolve_run_node(
 	"""The ``(name, node)`` to run: looked up by name, then matrix-overridden and
 	passthrough-appended.
 
-	When ``dry_run=true`` and ``task`` is omitted, resolves the project's default task
-	so a bare dry-run previews it without erroring.
+	When ``task`` is omitted, resolves the project's configured default task —
+	honored identically for a normal run and a ``dry_run`` preview.
 
 	Raises:
-		ValueError: when ``req.task`` is omitted outside a dry-run, names no task, an
-			override targets an unknown matrix axis, or passthrough args are applied to
-			a non-leaf task.
+		ValueError: when ``req.task`` is omitted and no default is configured, names
+			no task, an override targets an unknown matrix axis, or passthrough args
+			are applied to a non-leaf task.
 	"""
 	if req.task is None:
-		if req.dry_run and config is not None:
-			default = config.gate_check(github=False)
-			if default is not None:
-				return "default task", default
-		raise ValueError("camas_run requires 'task' (or pass 'under' to budget the default task)")
-	if req.task not in tasks:
+		default = config.run_default() if config is not None else None
+		if default is None:
+			raise ValueError(NO_RUN_DEFAULT_MSG)
+		name, node = default.name or "default task", default
+	elif req.task not in tasks:
 		known = ", ".join(sorted(tasks)) or "none"
 		raise ValueError(f"no task named {req.task!r} (known: {known})")
-	node = tasks[req.task]
+	else:
+		name, node = req.task, tasks[req.task]
 	if req.matrix_overrides:
 		node = override_matrix(node, {k: tuple(v) for k, v in req.matrix_overrides.items()})
 	if req.args:
 		node = apply_passthrough(node, tuple(req.args))
-	return req.task, node
+	return name, node
 
 
 async def run_budget(
@@ -636,13 +669,13 @@ async def run_budget(
 		return error_result("camas_run: 'args' (passthrough) cannot be combined with 'under'")
 	try:
 		source = budget_source(tasks, config, req.task)
+		label = req.task or source.name or "default task"
 		if req.matrix_overrides:
 			source = override_matrix(source, {k: tuple(v) for k, v in req.matrix_overrides.items()})
 	except ValueError as e:
 		return error_result(str(e))
 	plan = plan_under(source, budget_s, timings.load(session.camas_dir))
 	report = to_budget_report(plan)
-	label = req.task or "default task"
 	if plan.node is None:
 		empty = wire.RunResponse(
 			returncode=0, elapsed=0.0, passed=0, failed=0, skipped=0, interrupt_count=0, leaves=()
@@ -673,20 +706,20 @@ async def run_budget(
 def budget_source(
 	tasks: Mapping[str, TaskNode], config: Config | None, task: str | None
 ) -> TaskNode:
-	"""The task a budget run filters: the named task, else the project's default task.
+	"""The task a budget run filters: the named task, else the project's configured default.
 
 	Raises:
 		ValueError: when ``task`` names no task, or no task is named and no
-			:class:`Config` default exists to budget.
+			default is configured to budget.
 	"""
 	if task is not None:
 		if task not in tasks:
 			known = ", ".join(sorted(tasks)) or "none"
 			raise ValueError(f"no task named {task!r} (known: {known})")
 		return tasks[task]
-	default = config.default_task if config is not None else None
+	default = config.run_default() if config is not None else None
 	if default is None:
-		raise ValueError("no task given and no Config default_task to budget; name a task to run")
+		raise ValueError(NO_RUN_DEFAULT_MSG)
 	return default
 
 
@@ -935,10 +968,15 @@ def check_text(resp: wire.CheckResponse) -> str:
 			)
 		case _:
 			assert_never(resp.status)
+	version_note = (
+		f"\n\ncamas server version: {resp.server_version}"
+		if resp.server_version is not None
+		else ""
+	)
 	if not resp.warnings:
-		return verdict
+		return verdict + version_note
 	warnings = "\n".join(f"  - {w}" for w in resp.warnings)
-	return f"{verdict}\n\nWarnings (advisory — not failures):\n{warnings}"
+	return f"{verdict}{version_note}\n\nWarnings (advisory — not failures):\n{warnings}"
 
 
 def docs_text(resp: wire.DocsResponse) -> str:
@@ -1018,6 +1056,17 @@ def attach_logs(resp: wire.RunResponse, logs: tuple[Path | None, ...]) -> wire.R
 def error_result(text: str) -> types.CallToolResult:
 	"""A tool-execution error (``isError=true``) with self-correcting text for the agent."""
 	return types.CallToolResult(content=[types.TextContent(type="text", text=text)], isError=True)
+
+
+def load_error_hint(session: Session, source: Path, exception: Exception) -> str:
+	"""The load-error tool text, prefixed with the version-skew + CLI-fallback hint when the
+	running server does not satisfy the pin (a stale server, not a broken file).
+	"""
+	base = format_load_error_hint(source, exception)
+	skew = version_skew(session.project)
+	if skew is None:
+		return base
+	return f"{format_version_skew_hint(skew.running, skew.spec)}\n\n{base}"
 
 
 def resolve_project(base: Path) -> TasksState:
@@ -1101,7 +1150,7 @@ async def gate_call(session: Session, arguments: dict[str, Any]) -> types.CallTo
 	"""Handle ``camas_gate``: scope to the changed paths, autofix, run the checks, classify."""
 	match session.project:
 		case LoadErr(source=source, exception=exception):
-			return error_result(format_load_error_hint(source, exception))
+			return error_result(load_error_hint(session, source, exception))
 		case LoadOk(tasks=tasks, config=config):
 			return await gate_for(session, tasks, config, arguments)
 		case _:
@@ -1141,7 +1190,7 @@ async def fix_call(session: Session, arguments: dict[str, Any]) -> types.CallToo
 	"""Handle ``camas_fix``: scope to the changed paths, run the registered fix node."""
 	match session.project:
 		case LoadErr(source=source, exception=exception):
-			return error_result(format_load_error_hint(source, exception))
+			return error_result(load_error_hint(session, source, exception))
 		case LoadOk(tasks=tasks, config=config):
 			return await fix_for(session, tasks, config, arguments)
 		case _:
@@ -1278,6 +1327,21 @@ def parse_gate_args(argv: list[str]) -> GateArgs:
 	)
 
 
+def gate_cli_load_error(state: TasksState, source: Path, exception: Exception) -> str:
+	"""The headless-gate load-error message, extended with a version-mismatch + CLI-fallback note
+	when the installed camas does not satisfy the pin.
+	"""
+	base = f"camas mcp gate: cannot load {source}: {exception}"
+	skew = version_skew(state)
+	if skew is None:
+		return base
+	return (
+		f"{base}\n"
+		f"camas {skew.running} does not satisfy tasks.py pin camas{skew.spec}; run "
+		"`uv run tasks.py <task>` to load the pinned version."
+	)
+
+
 def gate_cli(argv: list[str]) -> int:
 	"""Run the gate once, headless: scope this project's checks to the changed paths (``--paths``,
 	else the files in a ``PostToolBatch`` event on stdin), print the ``GateResponse`` as JSON to
@@ -1290,7 +1354,7 @@ def gate_cli(argv: list[str]) -> int:
 	state = resolve_project_quiet(base)
 	match state:
 		case LoadErr(source=source, exception=exception):
-			print(f"camas mcp gate: cannot load {source}: {exception}", file=sys.stderr)
+			print(gate_cli_load_error(state, source, exception), file=sys.stderr)
 			return 2
 		case LoadOk(tasks=tasks, config=config):
 			return run_gate_cli(args, base, tasks, config)

--- a/src/camas/mcp/wire.py
+++ b/src/camas/mcp/wire.py
@@ -114,7 +114,13 @@ class ListResponse(BaseModel):
 
 	tasks: tuple[TaskInfo, ...]
 	default: str | None = None
-	github_default: str | None = None
+	github_default: str | None = Field(
+		default=None,
+		description=(
+			"The task declared as Config(github_task=...) — what this project's CI runs; null "
+			"when no github_task is set. Declarative: camas never infers it from CI workflow files."
+		),
+	)
 
 
 class CheckResponse(BaseModel):
@@ -132,6 +138,10 @@ class CheckResponse(BaseModel):
 	checker: Literal["ty", "mypy"] | None = None
 	diagnostics: str | None = None
 	warnings: tuple[str, ...] = ()
+	server_version: str | None = None
+	"""The camas version the MCP server is running; ``null`` when distribution metadata is
+	unavailable.
+	"""
 
 
 class DocsResponse(BaseModel):
@@ -179,9 +189,8 @@ class RunRequest(BaseModel):
 
 	task: str | None = Field(
 		default=None,
-		description="Task name to run — one of the names returned by camas_list. May be "
-		"omitted with 'under' (budgets the default task) or with 'dry_run' (previews "
-		"the default task).",
+		description="Task name to run — one of the names returned by camas_list. Omit to "
+		"run the project's configured default task (also honored by 'under' and 'dry_run').",
 	)
 	under: float | None = Field(
 		default=None,

--- a/src/camas/mcp/wire.py
+++ b/src/camas/mcp/wire.py
@@ -110,15 +110,31 @@ class TaskInfo(BaseModel):
 
 
 class ListResponse(BaseModel):
-	"""The project's task catalog: every task plus the default and CI-default names."""
+	"""The project's task catalog: every task plus the default, CI-default, and no-task-run
+	names.
+	"""
 
 	tasks: tuple[TaskInfo, ...]
-	default: str | None = None
+	default: str | None = Field(
+		default=None,
+		description=(
+			"The task declared as Config(default_task=...) — what the bare CLI runs while the "
+			"developer works; null when no default_task is set."
+		),
+	)
 	github_default: str | None = Field(
 		default=None,
 		description=(
 			"The task declared as Config(github_task=...) — what this project's CI runs; null "
 			"when no github_task is set. Declarative: camas never infers it from CI workflow files."
+		),
+	)
+	run_default: str | None = Field(
+		default=None,
+		description=(
+			"The task a no-task camas_run runs — resolved as Claude default, else Claude check, "
+			"else github_task, else default_task; null when nothing in the chain is configured "
+			"or the resolved task is unnamed."
 		),
 	)
 

--- a/src/camas/v0/config.py
+++ b/src/camas/v0/config.py
@@ -20,7 +20,7 @@ DEFAULT_CAMAS_DIR: Final = ".camas"
 
 
 class Claude(NamedTuple):
-	"""The Claude Code agent integration: the explicitly declared fix and check nodes."""
+	"""The Claude Code agent integration: the explicitly declared fix, check, and default nodes."""
 
 	fix: TaskNode
 	"""The deterministic, behavior-preserving autofix node the PostToolBatch hook runs (scoped,
@@ -30,6 +30,10 @@ class Claude(NamedTuple):
 	check: TaskNode | None = None
 	"""The node the gate checks; ``None`` defers to the default (or github) task, scoped by
 	``--paths`` and time-boxed by ``--under``.
+	"""
+	default: TaskNode | None = None
+	"""The task a no-task ``camas_run`` runs; ``None`` defers to the check node, then the
+	github or default task.
 	"""
 
 
@@ -80,3 +84,11 @@ class Config(NamedTuple):
 	def gate_fix(self) -> TaskNode | None:
 		"""The declared deterministic autofix node, or ``None`` when no agent is configured."""
 		return self.agent.fix if self.agent is not None else None
+
+	def run_default(self) -> TaskNode | None:
+		"""The task a no-task ``camas_run`` runs: the agent's ``default``, else the check node,
+		then the github or default task.
+		"""
+		if self.agent is not None and self.agent.default is not None:
+			return self.agent.default
+		return self.gate_check(github=True)

--- a/tests/main/test_format.py
+++ b/tests/main/test_format.py
@@ -15,6 +15,7 @@ from camas.main.format import (
 	format_signature,
 	format_task_summary_listing,
 	format_try_hint,
+	format_version_skew_hint,
 	print_available_effects,
 	print_task_summary_listing,
 	print_task_trees,
@@ -269,6 +270,14 @@ def test_format_try_hint_plain() -> None:
 
 def test_format_try_hint_colored() -> None:
 	assert "\033[" in format_try_hint(color=True)
+
+
+def test_format_version_skew_hint() -> None:
+	out = format_version_skew_hint("0.1.21", "==0.1.22")
+	assert "MCP server is running camas 0.1.21" in out
+	assert "pins camas==0.1.22" in out
+	assert "reconnect the MCP server" in out
+	assert "`uv run tasks.py <task>`" in out
 
 
 def test_format_available_effects_default_color() -> None:

--- a/tests/main/test_tasks.py
+++ b/tests/main/test_tasks.py
@@ -11,7 +11,7 @@ from unittest.mock import patch
 
 import pytest
 
-from camas import Config, Parallel, Sequential, Task
+from camas import Claude, Config, Parallel, Sequential, Task
 from camas.main import main
 from camas.main.dispatch import dispatch_arg, run_cli
 from camas.main.expression import (
@@ -786,6 +786,20 @@ def test_name_scope_config_promotes_aliased_task_fields() -> None:
 	assert resolved.default_task == Parallel(
 		Task("mypy .", name="mypy"), Task("pyright .", name="pyright"), name="ci"
 	)
+
+
+def test_name_scope_config_promotes_agent_default() -> None:
+	"""A ``Claude.default`` field aliasing a top-level binding runs with that binding's
+	propagated name, matching :func:`name_scope_bindings`."""
+	rundef = Task("pytest")
+	scope: dict[str, object] = {
+		"rundef": rundef,
+		"_": Config(agent=Claude(fix=Task("ruff --fix"), default=rundef)),
+	}
+	resolved = name_scope_config(scope)
+	assert resolved is not None
+	assert resolved.agent is not None
+	assert resolved.agent.default == Task("pytest", name="rundef")
 
 
 def test_name_scope_config_keeps_inline_task_field() -> None:

--- a/tests/mcp/test_catalog.py
+++ b/tests/mcp/test_catalog.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from camas import Config, Parallel, Sequential, Task
+from camas import Claude, Config, Parallel, Sequential, Task
 from camas.core.timings import TaskTiming
 from camas.mcp.catalog import to_list_response
 
@@ -44,7 +44,22 @@ def test_no_config_marks_nothing() -> None:
 
 def test_config_without_defaults_yields_no_markers() -> None:
 	resp = to_list_response({"t": Task("echo hi", name="t")}, Config())
-	assert (resp.default, resp.github_default) == (None, None)
+	assert (resp.default, resp.github_default, resp.run_default) == (None, None, None)
+
+
+def test_run_default_reported_for_agent_only_config() -> None:
+	rundef = Task("pytest", name="rundef")
+	resp = to_list_response(
+		{"rundef": rundef}, Config(agent=Claude(fix=Task("ruff --fix"), default=rundef))
+	)
+	assert (resp.default, resp.run_default) == (None, "rundef")
+
+
+def test_run_default_prefers_github_task_over_default_task() -> None:
+	ci = Task("pytest", name="ci")
+	lint = Task("ruff check .", name="lint")
+	resp = to_list_response({"ci": ci, "lint": lint}, Config(default_task=ci, github_task=lint))
+	assert (resp.default, resp.run_default) == ("ci", "lint")
 
 
 def test_matrix_axes_reported_with_unexpanded_preview_by_default() -> None:

--- a/tests/mcp/test_docs.py
+++ b/tests/mcp/test_docs.py
@@ -22,3 +22,9 @@ def test_to_docs_response_serves_init_docstring() -> None:
 		assert token in resp.tutorial
 	init = (Path(resp.source) / "__init__.py").read_text(encoding="utf-8")
 	assert resp.tutorial == ast.get_docstring(ast.parse(init))
+
+
+def test_docs_states_github_default_is_declared() -> None:
+	resp = to_docs_response()
+	assert "github_task" in resp.tutorial
+	assert "never infers" in resp.tutorial

--- a/tests/mcp/test_gate_cli.py
+++ b/tests/mcp/test_gate_cli.py
@@ -104,6 +104,21 @@ def test_gate_cli_load_error(
 	assert "cannot load" in capsys.readouterr().err
 
 
+def test_gate_cli_load_error_skew_hints_cli_fallback(
+	tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+	monkeypatch.delenv("CLAUDE_PROJECT_DIR", raising=False)
+	monkeypatch.chdir(tmp_path)
+	(tmp_path / "tasks.py").write_text(
+		"# /// script\n# dependencies = [\"camas==999.0.0\"]\n# ///\nraise ValueError('boom')\n"
+	)
+	assert serve.gate_cli([]) == 2
+	err = capsys.readouterr().err
+	assert "cannot load" in err
+	assert "does not satisfy tasks.py pin camas==999.0.0" in err
+	assert "uv run tasks.py" in err
+
+
 def test_gate_cli_unknown_task_errors(
 	tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:

--- a/tests/mcp/test_init_tool.py
+++ b/tests/mcp/test_init_tool.py
@@ -75,3 +75,11 @@ async def test_call_routes_init(tmp_path: Path) -> None:
 	result = await serve.call(_session(tmp_path), "camas_init", {})
 	assert result.isError is False
 	assert (tmp_path / "tasks.py").exists()
+
+
+def test_init_call_repins_version_warning(tmp_path: Path) -> None:
+	session = _session(tmp_path)
+	session.version_warning = "WARNING: stale"
+	result = serve.init_call(session)
+	assert result.isError is False
+	assert session.version_warning is None

--- a/tests/mcp/test_serve.py
+++ b/tests/mcp/test_serve.py
@@ -180,6 +180,13 @@ def test_tools_rich_includes_title_annotations_and_schema() -> None:
 	assert tool_init.annotations.readOnlyHint is False
 
 
+def test_list_tool_description_declares_github_default() -> None:
+	(tool_list, *_rest) = serve.tools((), Compat(emit_structured=False))
+	assert tool_list.description is not None
+	assert "Config(github_task" in tool_list.description
+	assert "null" in tool_list.description
+
+
 def test_list_call_text_lists_tasks_and_markers(tmp_path: Path) -> None:
 	ci = Sequential(PASS, name="ci")
 	session = _session(
@@ -200,6 +207,20 @@ def test_list_call_load_error(tmp_path: Path) -> None:
 	result = serve.list_call(session, {})
 	assert result.isError is True
 	assert "camas --check" in _text(result)
+
+
+def test_list_call_load_error_skew_prepends_reconnect_and_cli_hint(tmp_path: Path) -> None:
+	(tmp_path / "tasks.py").write_text(
+		"# /// script\n# dependencies = [\"camas==999.0.0\"]\n# ///\nraise RuntimeError('boom')\n"
+	)
+	session = Session(serve.resolve_project(tmp_path), tmp_path, Compat())
+	result = serve.list_call(session, {})
+	assert result.isError is True
+	text = _text(result)
+	assert "MCP server is running camas" in text
+	assert "reconnect the MCP server" in text
+	assert "uv run tasks.py" in text
+	assert "Tasks unavailable" in text
 
 
 def test_list_call_structured_when_rich(tmp_path: Path) -> None:
@@ -307,7 +328,7 @@ async def test_run_call_dry_run_no_task_no_default_errors(tmp_path: Path) -> Non
 	session = _session({"ci": PASS}, config, tmp_path)
 	result = await serve.run_call(session, {"dry_run": True})
 	assert result.isError is True
-	assert "requires 'task'" in _text(result)
+	assert "has no task to run" in _text(result)
 
 
 async def test_run_call_log_path_in_structured_content_when_rich(tmp_path: Path) -> None:
@@ -355,6 +376,16 @@ async def test_run_call_load_error(tmp_path: Path) -> None:
 	session = Session(LoadErr(tmp_path / "tasks.py", RuntimeError("boom")), tmp_path, Compat())
 	result = await serve.run_call(session, {"task": "lint"})
 	assert result.isError is True
+
+
+async def test_run_call_load_error_no_pin_omits_reconnect_hint(tmp_path: Path) -> None:
+	(tmp_path / "tasks.py").write_text("raise RuntimeError('boom')\n")
+	session = Session(serve.resolve_project(tmp_path), tmp_path, Compat())
+	result = await serve.run_call(session, {"task": "lint"})
+	assert result.isError is True
+	text = _text(result)
+	assert "reconnect the MCP server" not in text
+	assert "Tasks unavailable" in text
 
 
 async def test_run_call_structured_when_rich(tmp_path: Path) -> None:
@@ -489,6 +520,34 @@ def test_check_call_structured_when_rich(tmp_path: Path, monkeypatch: pytest.Mon
 	assert result.structuredContent["checker"] == "ty"
 
 
+def test_check_call_reports_server_version(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+	from importlib.metadata import version
+
+	(tmp_path / "tasks.py").write_text(_VALID_TASKS)
+	monkeypatch.setattr("camas.mcp.result.run_typecheck", _fixed_checker(CheckerOk("ty")))
+	result = serve.check_call(_session({}, None, tmp_path, rich=True))
+	assert result.structuredContent is not None
+	assert result.structuredContent["server_version"] == version("camas")
+	assert f"camas server version: {version('camas')}" in _text(result)
+
+
+def test_check_call_server_version_degrades_when_missing(
+	tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+	from importlib.metadata import PackageNotFoundError
+
+	def _raise(name: str) -> str:
+		raise PackageNotFoundError(name)
+
+	(tmp_path / "tasks.py").write_text(_VALID_TASKS)
+	monkeypatch.setattr("camas.mcp.result.run_typecheck", _fixed_checker(CheckerOk("ty")))
+	monkeypatch.setattr("camas.mcp.serve.version", _raise)
+	result = serve.check_call(_session({}, None, tmp_path, rich=True))
+	assert result.structuredContent is not None
+	assert result.structuredContent["server_version"] is None
+	assert "camas server version" not in _text(result)
+
+
 def test_check_call_reports_scope_warnings(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
 	(tmp_path / "tasks.py").write_text(
 		"from camas import Task\ncargo = Task('cargo build', name='cargo', paths='.')\n"
@@ -523,6 +582,13 @@ def test_check_text_renders_warnings_block_and_keeps_ok_status() -> None:
 def test_check_text_omits_warnings_block_when_clean() -> None:
 	resp = wire.CheckResponse(status="ok", source="/x/tasks.py", task_count=1, checker="ty")
 	assert "Warnings" not in serve.check_text(resp)
+
+
+def test_check_text_omits_server_version_when_none() -> None:
+	resp = wire.CheckResponse(
+		status="ok", source="/x/tasks.py", task_count=1, checker="ty", server_version=None
+	)
+	assert "camas server version" not in serve.check_text(resp)
 
 
 def test_docs_call_serves_tutorial_and_source(tmp_path: Path) -> None:
@@ -604,8 +670,17 @@ def test_resolve_run_node_applies_overrides_and_args() -> None:
 
 
 def test_resolve_run_node_requires_task() -> None:
-	with pytest.raises(ValueError, match="requires 'task'"):
+	with pytest.raises(ValueError, match="has no task to run"):
 		serve.resolve_run_node({"lint": PASS}, wire.RunRequest())
+
+
+def test_resolve_run_node_no_task_applies_args() -> None:
+	name, leaf = serve.resolve_run_node(
+		{}, wire.RunRequest(args=["-v"]), Config(default_task=Task("pytest", name="t"))
+	)
+	assert name == "t"
+	assert isinstance(leaf, Task)
+	assert leaf.cmd == "pytest -v"
 
 
 def _record(base: Path, leaves: list[tuple[str, float]]) -> None:
@@ -670,7 +745,23 @@ async def test_run_call_under_no_task_no_default_errors(tmp_path: Path) -> None:
 	session = _session({"lint": PASS}, None, tmp_path)
 	result = await serve.run_call(session, {"under": 1.0})
 	assert result.isError is True
-	assert "no task given and no Config default_task" in _text(result)
+	assert "has no task to run" in _text(result)
+
+
+async def test_run_call_under_no_task_config_present_no_default_errors(tmp_path: Path) -> None:
+	session = _session({"lint": PASS}, Config(), tmp_path)
+	result = await serve.run_call(session, {"under": 1.0})
+	assert result.isError is True
+	assert "has no task to run" in _text(result)
+
+
+async def test_run_call_under_no_task_labels_by_default_name(tmp_path: Path) -> None:
+	default = Sequential(_FMT, Parallel(_LINT, _SLOW), name="ci")
+	_record(tmp_path, [("fmt", 0.1), ("lint", 0.2), ("slow", 9.0)])
+	session = _session({"ci": default}, Config(default_task=default), tmp_path)
+	result = await serve.run_call(session, {"under": 5.0})
+	assert result.isError is False
+	assert "camas_run 'ci'" in _text(result)
 
 
 async def test_run_call_under_rejects_args(tmp_path: Path) -> None:
@@ -684,7 +775,49 @@ async def test_run_call_missing_task_errors(tmp_path: Path) -> None:
 	session = _session({"lint": PASS}, None, tmp_path)
 	result = await serve.run_call(session, {})
 	assert result.isError is True
-	assert "requires 'task'" in _text(result)
+	assert "has no task to run" in _text(result)
+
+
+async def test_run_call_no_task_runs_default(tmp_path: Path) -> None:
+	default = Sequential(PASS, name="ci")
+	session = _session({"ci": default}, Config(default_task=default), tmp_path)
+	result = await serve.run_call(session, {})
+	assert result.isError is False
+	assert "camas_run 'ci'" in _text(result)
+	assert (tmp_path / ".camas" / "runs" / "ci").is_dir()
+
+
+async def test_run_call_no_task_anonymous_default_labels_default_task(tmp_path: Path) -> None:
+	anon = Task(("python", "-c", "print('ok')"))
+	session = _session({}, Config(default_task=anon), tmp_path)
+	result = await serve.run_call(session, {})
+	assert result.isError is False
+	assert "camas_run 'default task'" in _text(result)
+
+
+async def test_run_call_no_task_config_present_no_default_errors(tmp_path: Path) -> None:
+	session = _session({"lint": PASS}, Config(), tmp_path)
+	result = await serve.run_call(session, {})
+	assert result.isError is True
+	assert "has no task to run" in _text(result)
+
+
+async def test_run_call_no_task_applies_matrix_overrides(tmp_path: Path) -> None:
+	default = Parallel(Task("echo {PY}", name="t"), matrix={"PY": ("3.12", "3.13")}, name="m")
+	session = _session({"m": default}, Config(default_task=default), tmp_path, rich=True)
+	result = await serve.run_call(session, {"dry_run": True, "matrix_overrides": {"PY": ["3.13"]}})
+	assert result.isError is False
+	assert result.structuredContent is not None
+	assert len(result.structuredContent["leaves"]) == 1
+	assert "echo 3.13" in _text(result)
+
+
+async def test_run_call_no_task_unknown_axis_errors(tmp_path: Path) -> None:
+	default = Parallel(Task("echo {PY}", name="t"), matrix={"PY": ("3.13",)}, name="m")
+	session = _session({"m": default}, Config(default_task=default), tmp_path)
+	result = await serve.run_call(session, {"matrix_overrides": {"NOPE": ["x"]}})
+	assert result.isError is True
+	assert "unknown matrix axis" in _text(result)
 
 
 async def test_run_call_under_unknown_task_errors(tmp_path: Path) -> None:

--- a/tests/mcp/test_serve.py
+++ b/tests/mcp/test_serve.py
@@ -197,9 +197,20 @@ def test_list_call_text_lists_tasks_and_markers(tmp_path: Path) -> None:
 	text = _text(result)
 	assert "default (developer's task): ci" in text
 	assert "github default" in text
+	assert "no-task camas_run runs: lint" in text
 	assert "lint" in text
 	assert "expand_matrix=true" not in text
 	assert result.structuredContent is None
+
+
+def test_list_call_text_omits_run_default_when_it_matches_default(tmp_path: Path) -> None:
+	ci = Sequential(PASS, name="ci")
+	session = _session({"ci": ci}, Config(default_task=ci), tmp_path)
+	result = serve.list_call(session, {})
+	assert result.isError is False
+	text = _text(result)
+	assert "default (developer's task): ci" in text
+	assert "no-task camas_run runs" not in text
 
 
 def test_list_call_load_error(tmp_path: Path) -> None:
@@ -1472,12 +1483,31 @@ def test_docs_call_prepends_version_warning(tmp_path: Path) -> None:
 	assert text.startswith("WARNING: version mismatch")
 
 
-def test_check_call_prepends_version_warning(tmp_path: Path) -> None:
-	session = _session({"lint": PASS}, None, tmp_path)
-	session.version_warning = "WARNING: version mismatch"
+def test_check_call_prepends_version_warning(
+	tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+	(tmp_path / "tasks.py").write_text(
+		'# /// script\n# dependencies = ["camas==999.0.0"]\n# ///\n' + _VALID_TASKS
+	)
+	monkeypatch.setattr("camas.mcp.result.run_typecheck", _fixed_checker(CheckerOk("ty")))
+	session = Session(serve.resolve_project(tmp_path), tmp_path, Compat())
 	result = serve.check_call(session)
 	assert result.isError is False
-	assert _text(result).startswith("WARNING: version mismatch")
+	assert _text(result).startswith("camas ")
+	assert "does not satisfy tasks.py pin ==999.0.0" in _text(result)
+
+
+def test_check_call_clears_stale_version_warning(
+	tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+	(tmp_path / "tasks.py").write_text(_VALID_TASKS)
+	monkeypatch.setattr("camas.mcp.result.run_typecheck", _fixed_checker(CheckerOk("ty")))
+	session = Session(serve.resolve_project(tmp_path), tmp_path, Compat())
+	session.version_warning = "WARNING: stale"
+	result = serve.check_call(session)
+	assert result.isError is False
+	assert "WARNING: stale" not in _text(result)
+	assert session.version_warning is None
 
 
 async def test_run_call_prepends_version_warning(tmp_path: Path) -> None:

--- a/tests/mcp/test_version_check.py
+++ b/tests/mcp/test_version_check.py
@@ -166,3 +166,30 @@ def test_check_version_pin_missing_distribution_returns_none(
 
 	monkeypatch.setattr(serve_mod, "version", _raise)
 	assert check_version_pin(state) is None
+
+
+def test_version_skew_returns_running_and_spec(tmp_path: Path) -> None:
+	"""``version_skew`` exposes the structured (running, pin) pair ``check_version_pin`` renders."""
+	from importlib.metadata import version as _camas_version
+
+	from camas.mcp import serve
+
+	(tmp_path / "tasks.py").write_text(
+		'# /// script\n# dependencies = ["camas==999.0.0"]\n# ///\n'
+		"from camas import Task\nlint = Task('echo hi')\n"
+	)
+	state = serve.resolve_project(tmp_path)
+	assert isinstance(state, LoadOk)
+	assert serve.version_skew(state) == serve.VersionSkew(
+		running=_camas_version("camas"), spec="==999.0.0"
+	)
+
+
+def test_version_skew_none_without_pin(tmp_path: Path) -> None:
+	"""No PEP 723 ``camas`` block means no skew."""
+	from camas.mcp import serve
+
+	(tmp_path / "tasks.py").write_text("from camas import Task\nlint = Task('echo hi')\n")
+	state = serve.resolve_project(tmp_path)
+	assert isinstance(state, LoadOk)
+	assert serve.version_skew(state) is None

--- a/tests/mcp/test_wire.py
+++ b/tests/mcp/test_wire.py
@@ -103,6 +103,11 @@ def test_list_response_github_default_schema_description() -> None:
 	assert "Config(github_task" in description
 
 
+def test_list_response_run_default_schema_description() -> None:
+	description = ListResponse.model_json_schema()["properties"]["run_default"]["description"]
+	assert "no-task camas_run" in description
+
+
 def test_check_response_defaults_and_rejects_bad_status() -> None:
 	resp = CheckResponse(status="ok", source="/x/tasks.py", task_count=3, checker="ty")
 	assert (resp.diagnostics, resp.task_count, resp.warnings) == (None, 3, ())

--- a/tests/mcp/test_wire.py
+++ b/tests/mcp/test_wire.py
@@ -98,6 +98,11 @@ def test_list_response_markers() -> None:
 	assert listing.github_default is None
 
 
+def test_list_response_github_default_schema_description() -> None:
+	description = ListResponse.model_json_schema()["properties"]["github_default"]["description"]
+	assert "Config(github_task" in description
+
+
 def test_check_response_defaults_and_rejects_bad_status() -> None:
 	resp = CheckResponse(status="ok", source="/x/tasks.py", task_count=3, checker="ty")
 	assert (resp.diagnostics, resp.task_count, resp.warnings) == (None, 3, ())
@@ -109,6 +114,12 @@ def test_check_response_warnings_round_trip() -> None:
 	resp = CheckResponse(
 		status="ok", source="/x/tasks.py", task_count=1, warnings=("inert paths on 'cargo'",)
 	)
+	assert CheckResponse.model_validate(resp.model_dump()) == resp
+
+
+def test_check_response_server_version_round_trip() -> None:
+	assert CheckResponse(status="ok").server_version is None
+	resp = CheckResponse(status="ok", server_version="1.2.3")
 	assert CheckResponse.model_validate(resp.model_dump()) == resp
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -11,6 +11,7 @@ DEFAULT = Task("default", name="default")
 GH = Task("gh", name="gh")
 FIX = Task("fix", name="fix", mutates=True)
 CHECK = Task("check", name="check")
+RUNDEF = Task("rundef", name="rundef")
 
 
 @pytest.mark.parametrize(
@@ -61,3 +62,30 @@ def test_gate_check_prefers_agent_check_else_bare_task() -> None:
 def test_gate_fix_is_the_agent_fix_node_or_none() -> None:
 	assert Config(agent=Claude(fix=FIX)).gate_fix() is FIX
 	assert Config(default_task=DEFAULT).gate_fix() is None
+
+
+@pytest.mark.parametrize(
+	("config", "expected"),
+	[
+		(Config(), None),
+		(Config(default_task=DEFAULT), DEFAULT),
+		(Config(github_task=GH), GH),
+		(Config(default_task=DEFAULT, github_task=GH), GH),
+		(Config(default_task=DEFAULT, agent=Claude(fix=FIX)), DEFAULT),
+		(Config(default_task=DEFAULT, agent=Claude(fix=FIX, check=CHECK)), CHECK),
+		(Config(default_task=DEFAULT, agent=Claude(fix=FIX, default=RUNDEF)), RUNDEF),
+		(
+			Config(
+				default_task=DEFAULT,
+				github_task=GH,
+				agent=Claude(fix=FIX, check=CHECK, default=RUNDEF),
+			),
+			RUNDEF,
+		),
+	],
+)
+def test_run_default_resolves_the_chain(config: Config, expected: Task | None) -> None:
+	"""``run_default`` prefers the agent's ``default``, then ``check``, then the
+	github or default task.
+	"""
+	assert config.run_default() is expected


### PR DESCRIPTION
> [!WARNING]
> **LLM Disclosure**
>
> This PR was authored by claude-fable-5 on behalf of @JPHutchins. She asked me to drive resolution of #177 end to end — branch, implementation, and PR — coordinating opus planner/reviewer agents over sonnet implementers, and to exercise the new review.yaml flow on the result.

Resolves the approved items from the code-review dogfooding field report (#177).

## F3 — `camas_run` default task (high priority)

- New `Claude(default=...)` field; `Config.run_default()` resolves the chain **`Claude.default` → `Claude.check` → `Config.github_task` → `Config.default_task`** (implemented as `agent.default` else `gate_check(github=True)`, so the chain is exactly the approved order with no duplicated fallback logic).
- All three no-task paths are unified on that resolver: plain `camas_run`, `dry_run=true`, and `under=` budgeting. Previously they disagreed (dry_run used `gate_check(github=False)`, budget used `default_task` only, plain run just errored).
- `matrix_overrides` and `args` now apply to the resolved default exactly as they would to a named task (caught by the opus review pass — the first cut dropped them silently on the no-task path).
- When nothing resolves, the error is actionable: `camas_run has no task to run: name a task, or set a project default in tasks.py — Config(default_task=…), Config(github_task=…), or Config(agent=Claude(fix=…, default=…)).`
- Gate semantics (`gate_check`/`gate_fix`) are untouched; `under=` with a named task is untouched.

## F1/F2 — load-error version-skew diagnostics

- A tasks-file load error on `camas_list`/`camas_run`/`camas_gate`/`camas_fix` now leads with, when the running server fails the PEP-723 pin:

  > MCP server is running camas 0.1.21 but tasks.py pins camas==0.1.22 — reconnect the MCP server to pick up the new version.
  >
  > Run the task directly with `uv run tasks.py <task>` in the meantime: it resolves the pinned camas version fresh per invocation, so it works while the server is stale.

  followed by the existing `Tasks unavailable — …` text. Non-skew load errors are unchanged (the CLI fallback would fail identically on a genuinely broken file, so it isn't suggested there).
- One deliberate deviation from the issue's literal wording: the pin renders as `camas==0.1.22` rather than bare `0.1.22`, so non-`==` specifiers (`>=`, `<`) read accurately.
- The headless `camas mcp gate` load error gets the same skew + `uv run tasks.py` note (reconnect advice would be meaningless for a fresh subprocess).
- Internals: `check_version_pin` is refactored to delegate to a structural `version_skew() -> VersionSkew | None`; its success-path warning string is byte-identical to before.
- Bonus (approved): every `camas_check` payload now carries `server_version` (`null` when distribution metadata is unavailable), and `check_text` renders it as `camas server version: X`.

## F6 — `github_default` is declarative (docs only)

All four surfaces now state that `github_default` is declared via `Config(github_task=...)`, is `null` when unset, and is never inferred from CI workflow files: the `camas_docs` tutorial (`__init__` docstring), README, the `camas_list` tool description, and a schema-visible `Field(description=...)` on `ListResponse.github_default`.

## Out of scope

- **F7** (contention hint on Parallel leaves): dropped as consumer-side — the fix is raising the test timeout or isolating working dirs, not a camas feature.
- **F4/F5 positives**: nothing to do.

## Verification

- Full local gate green twice (post-implementation and post-review-fix): ruff fix/format, mypy + pyright + ty + zuban + pyrefly, coverage at 100% branch (`uv run camas`).
- 1300+ tests pass including ~20 new ones covering every new branch: the full `run_default` precedence chain, promotion of the new field, no-task run/dry_run/under behavior (named, anonymous, absent defaults; overrides; unknown axis; args), skew vs no-skew load errors on all four tools plus gate CLI, `server_version` presence/degradation, and doc-surface guards (including that the `github_default` description reaches `model_json_schema()`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)