### PR TITLE
fix(compose): resolve composed Project refs by parent field, not ambient context

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,21 +255,25 @@ For the Claude Code plugin, you **register** the auto-fix node — whatever you 
 
 ## Monorepos
 
-A `tasks.py` composes others with `Project`. Binding one imports a child `tasks.py` as a task node — a self-contained child project — that runs whatever a bare `camas` runs in that directory, and mounts the child's own tasks under the binding name:
+A `tasks.py` composes others with `Project`. Binding one imports a child `tasks.py` as a task node — a self-contained child project — and mounts the child's own tasks under the binding name:
 
 ```python
-from camas import Config, Parallel, Project
+from camas import Claude, Config, Parallel, Project
 
 libs = Project("libs")            # camas libs, camas libs.search.lint, ...
 api  = Project("services/api")    # name the handle whatever you like
 
 _ = Config(
-    default_task=...,                     # what bare `camas` runs here
-    github_task=Parallel(libs, api),      # each child's CI default, composed in parallel
+    default_task=Parallel(libs, api),          # each child's default_task, in parallel
+    github_task=Parallel(libs, api),           # each child's github_task
+    agent=Claude(
+        fix=Parallel(libs, api),               # each child's fix node
+        check=Parallel(libs, api),             # each child's check node
+    ),
 )
 ```
 
-A reference resolves by context — the child's default locally, its `github_task` under CI, its agent default under an agent — so a `Parallel` of references is the composite CI task, each child contributing its own. `camas libs.search.lint` reaches a task the child exposes (because `libs/tasks.py` itself did `search = Project("search")`), and expressions compose across namespaces (`camas '{libs.search.lint, api.deploy}'`).
+A reference composes the child's **matching field**: the same bare `libs` grabs the child's `default_task` in `default_task`, its `github_task` in `github_task`, its fix node in `agent.fix`, its check node in `agent.check` — the slot the reference sits in selects which field of the child's own `Config` it contributes. So a `Parallel` of references in any slot is that slot composed across the monorepo, each child contributing its own. A binding name resolves by context instead — `camas libs` runs whatever a bare `camas` runs in that directory (its default locally, its `github_task` under CI, its agent default under an agent). `camas libs.search.lint` reaches a task the child exposes (because `libs/tasks.py` itself did `search = Project("search")`), and expressions compose across namespaces (`camas '{libs.search.lint, api.deploy}'`).
 
 Nodes stay anchored where they were authored: a leaf's `cwd` and its `paths=`/`when=` scopes are relative to its own `tasks.py`, rebased across the boundary no matter where `camas` is invoked from. Children are referenced by path relative to the importing file and live within its directory. The [monorepo fixture](https://github.com/JPHutchins/camas/tree/main/tests/fixtures/monorepo) exercises the permutations.
 

--- a/src/camas/main/compose/scope.py
+++ b/src/camas/main/compose/scope.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import os
 import runpy
 import sys
+from enum import Enum, auto
 from pathlib import Path, PurePosixPath
 from typing import TYPE_CHECKING, Final
 
@@ -36,26 +37,78 @@ if TYPE_CHECKING:
 	from ..state import TasksState
 
 
-def context_default(config: Config | None, *, github: bool, agent: bool) -> TaskNode | None:
-	"""The node a bare ``camas`` runs for ``config`` in the current context: the agent default
-	under an agent, else the github task under CI, else the plain default task.
-
-	>>> context_default(None, github=False, agent=False) is None
-	True
-	>>> context_default(Config(default_task=Task("d")), github=False, agent=False)
-	Task(cmd='d', name=None, env={}, cwd=None)
-	>>> context_default(
-	...     Config(default_task=Task("d"), github_task=Task("g")), github=True, agent=False
-	... )
-	Task(cmd='g', name=None, env={}, cwd=None)
-	>>> context_default(Config(default_task=Task("d")), github=False, agent=True)
-	Task(cmd='d', name=None, env={}, cwd=None)
+class Field(Enum):
+	"""The parent-``Config`` slot a composed ``Project`` reference is assigned to. A reference
+	grabs the child's *same* field (:func:`child_node`), so ``fix=Parallel(libs, api)`` composes
+	each child's ``fix`` — not whatever a bare ``camas`` happens to run there. ``CONTEXT`` is the
+	odd one out: a binding name (``libs = Project(...)``) runs what a bare ``camas`` runs in that
+	directory for the current invocation's context.
 	"""
-	if config is None:
-		return None
-	if agent:
-		return config.run_default()
-	return config.bare_task(github=github)
+
+	DEFAULT = auto()
+	GITHUB = auto()
+	FIX = auto()
+	CHECK = auto()
+	RUN_DEFAULT = auto()
+	CONTEXT = auto()
+
+
+def child_node(field: Field, config: Config, *, github: bool, agent: bool) -> TaskNode | None:
+	"""The node the child's ``config`` contributes to a parent ``field``: its matching accessor,
+	or, for a binding (``CONTEXT``), the node a bare ``camas`` runs there in this context.
+
+	>>> both = Config(default_task=Task("d"), github_task=Task("g"))
+	>>> child_node(Field.DEFAULT, both, github=True, agent=True)
+	Task(cmd='d', name=None, env={}, cwd=None)
+	>>> child_node(Field.GITHUB, both, github=False, agent=False)
+	Task(cmd='g', name=None, env={}, cwd=None)
+	>>> child_node(Field.CONTEXT, both, github=True, agent=False)
+	Task(cmd='g', name=None, env={}, cwd=None)
+	>>> child_node(Field.RUN_DEFAULT, both, github=False, agent=False)
+	Task(cmd='g', name=None, env={}, cwd=None)
+	>>> child_node(Field.FIX, both, github=False, agent=False) is None
+	True
+	"""
+	match field:
+		case Field.DEFAULT:
+			return config.bare_task(github=False)
+		case Field.GITHUB:
+			return config.bare_task(github=True)
+		case Field.FIX:
+			return config.gate_fix()
+		case Field.CHECK:
+			return config.gate_check(github=False)
+		case Field.RUN_DEFAULT:
+			return config.run_default()
+		case Field.CONTEXT:
+			return config.run_default() if agent else config.bare_task(github=github)
+		case _:
+			assert_never(field)
+
+
+def field_role(field: Field) -> str:
+	"""The role named in the load error a child raises when its ``field`` accessor yields nothing.
+
+	>>> field_role(Field.FIX)
+	'fix'
+	>>> field_role(Field.CONTEXT)
+	'default'
+	>>> [field_role(f) for f in (Field.GITHUB, Field.CHECK, Field.RUN_DEFAULT)]
+	['github', 'check', 'agent default']
+	"""
+	match field:
+		case Field.DEFAULT | Field.CONTEXT:
+			return "default"
+		case Field.GITHUB:
+			return "github"
+		case Field.FIX:
+			return "fix"
+		case Field.CHECK:
+			return "check"
+		case Field.RUN_DEFAULT:
+			return "agent default"
+		case _:
+			assert_never(field)
 
 
 def _compose_scope(
@@ -65,13 +118,14 @@ def _compose_scope(
 	*,
 	seen: frozenset[Path],
 ) -> LoadOk:
-	"""``scope``'s bindings with every ``Project`` resolved and merged: the binding name runs the
-	child's context default, its tasks mount under that name dotted.
+	"""``scope``'s bindings with every ``Project`` resolved and merged: a ``Config`` field grabs
+	each child's same field (its :class:`Field`), a binding name runs the child's context default,
+	and a child's tasks mount under that name dotted.
 	"""
 	github: Final = os.environ.get("GITHUB_ACTIONS") == "true"
 	agent: Final = running_under_agent()
 	child_cache: dict[Path, tuple[PurePosixPath, LoadOk]] = {}
-	node_cache: dict[int, TaskNode] = {}
+	node_cache: dict[tuple[int, Field], TaskNode] = {}
 
 	def child_view(marker: ProjectRef) -> tuple[PurePosixPath, LoadOk]:
 		if base_dir is None:
@@ -96,30 +150,38 @@ def _compose_scope(
 			child_cache[tasks_py] = (rel, child)
 		return child_cache[tasks_py]
 
-	def context_node(marker: ProjectRef) -> TaskNode:
+	def project_node(marker: ProjectRef, field: Field) -> TaskNode:
 		rel, child = child_view(marker)
-		node = context_default(child.config, github=github, agent=agent)
+		node = (
+			child_node(field, child.config, github=github, agent=agent)
+			if child.config is not None
+			else None
+		)
 		if node is None:
 			raise ProjectLoadError(
 				child.source if child.source is not None else Path("tasks.py"),
-				RuntimeError("defines no default task to run for this context"),
+				RuntimeError(f"defines no {field_role(field)} task to run for this context"),
 			)
 		return rebase_tree(node, rel, is_root=True)
 
-	def resolve(node: TaskNode | ProjectRef) -> TaskNode:
-		if id(node) not in node_cache:
-			node_cache[id(node)] = _resolved(node)
-		return node_cache[id(node)]
+	def resolve(node: TaskNode | ProjectRef, field: Field) -> TaskNode:
+		key = (id(node), field)
+		if key not in node_cache:
+			node_cache[key] = _resolved(node, field)
+		return node_cache[key]
 
-	def _resolved(node: TaskNode | ProjectRef) -> TaskNode:
+	def _resolved(node: TaskNode | ProjectRef, field: Field) -> TaskNode:
 		match node:
 			case ProjectRef():
-				return context_node(node)
+				return project_node(node, field)
 			case Task():
 				return node
 			case Group() as group:
+				children = tuple(resolve(child, field) for child in group.tasks)
+				if all(new is old for new, old in zip(children, group.tasks, strict=True)):
+					return group
 				return type(group)(
-					*(resolve(child) for child in group.tasks),
+					*children,
 					name=group.name,
 					matrix=group.matrix,
 					env=group.env,
@@ -131,23 +193,23 @@ def _compose_scope(
 			case _:
 				assert_never(node)
 
-	def resolve_field(node: TaskNode | None) -> TaskNode | None:
-		return None if node is None else resolve(node)
+	def resolve_field(node: TaskNode | None, field: Field) -> TaskNode | None:
+		return None if node is None else resolve(node, field)
 
 	def resolve_config(config: Config) -> Config:
 		agent_cfg = config.agent
 		return Config(
-			default_task=resolve_field(config.default_task),
-			github_task=resolve_field(config.github_task),
+			default_task=resolve_field(config.default_task, Field.DEFAULT),
+			github_task=resolve_field(config.github_task, Field.GITHUB),
 			default_effects=config.default_effects,
 			default_github_effects=config.default_github_effects,
 			camas_dir=config.camas_dir,
 			agent=None
 			if agent_cfg is None
 			else Claude(
-				fix=resolve(agent_cfg.fix),
-				check=resolve_field(agent_cfg.check),
-				default=resolve_field(agent_cfg.default),
+				fix=resolve(agent_cfg.fix, Field.FIX),
+				check=resolve_field(agent_cfg.check, Field.CHECK),
+				default=resolve_field(agent_cfg.default, Field.RUN_DEFAULT),
 			),
 		)
 
@@ -161,12 +223,12 @@ def _compose_scope(
 		):
 			resolved_scope[name] = value
 		elif isinstance(value, ProjectRef):
-			resolved_scope[name] = resolve(value)
+			resolved_scope[name] = resolve(value, Field.CONTEXT)
 			rel, child = child_view(value)
-			for key, child_node in child.tasks.items():
-				namespaces[f"{name}.{key}"] = rebase_tree(child_node, rel, is_root=True)
+			for key, mounted in child.tasks.items():
+				namespaces[f"{name}.{key}"] = rebase_tree(mounted, rel, is_root=True)
 		else:
-			resolved_scope[name] = resolve(value)
+			resolved_scope[name] = resolve(value, Field.CONTEXT)
 
 	own: Final = LoadOk(
 		tasks=name_scope_bindings(resolved_scope),

--- a/tests/fixtures/monorepo/libs/tasks.py
+++ b/tests/fixtures/monorepo/libs/tasks.py
@@ -1,6 +1,8 @@
-from camas import Config, Project, Task
+from camas import Claude, Config, Project, Task
 
 build = Task(("python", "-c", "import os; print('libs-build', os.getcwd())"), name="build")
+fix = Task(("python", "-c", "import os; print('libs-fix', os.getcwd())"), name="fix")
+check = Task(("python", "-c", "import os; print('libs-check', os.getcwd())"), name="check")
 search = Project("search")
 
-_ = Config(default_task=build)
+_ = Config(default_task=build, agent=Claude(fix=fix, check=check))

--- a/tests/fixtures/monorepo/services/api/tasks.py
+++ b/tests/fixtures/monorepo/services/api/tasks.py
@@ -1,5 +1,7 @@
-from camas import Config, Task
+from camas import Claude, Config, Task
 
 deploy = Task(("python", "-c", "import os; print('api-deploy', os.getcwd())"), name="deploy")
+fix = Task(("python", "-c", "import os; print('api-fix', os.getcwd())"), name="fix")
+check = Task(("python", "-c", "import os; print('api-check', os.getcwd())"), name="check")
 
-_ = Config(default_task=deploy)
+_ = Config(default_task=deploy, agent=Claude(fix=fix, check=check))

--- a/tests/fixtures/monorepo/tasks.py
+++ b/tests/fixtures/monorepo/tasks.py
@@ -1,8 +1,15 @@
-from camas import Config, Parallel, Project, Task
+from camas import Claude, Config, Parallel, Project, Task
 
 hello = Task(("python", "-c", "import os; print('hello', os.getcwd())"), name="hello")
 libs = Project("libs")
 api = Project("services/api")
 web = Project("web")
 
-_ = Config(default_task=hello, github_task=Parallel(libs, api, web))
+_ = Config(
+	default_task=Parallel(libs, api, web, name="all"),
+	github_task=Parallel(libs, api, web, name="ci"),
+	agent=Claude(
+		fix=Parallel(libs, api, web, name="fix-all"),
+		check=Parallel(libs, api, web, name="check-all"),
+	),
+)

--- a/tests/fixtures/monorepo/web/tasks.py
+++ b/tests/fixtures/monorepo/web/tasks.py
@@ -1,4 +1,4 @@
-from camas import Config, Task
+from camas import Claude, Config, Task
 
 build = Task(
 	("python", "-c", "import sys; print('web-build', *sys.argv[1:])", "{paths}"),
@@ -6,5 +6,7 @@ build = Task(
 	paths=".",
 )
 ship = Task(("python", "-c", "import os; print('web-ship', os.getcwd())"), name="ship")
+fix = Task(("python", "-c", "import os; print('web-fix', os.getcwd())"), name="fix")
+check = Task(("python", "-c", "import os; print('web-check', os.getcwd())"), name="check")
 
-_ = Config(default_task=build, github_task=ship)
+_ = Config(default_task=build, github_task=ship, agent=Claude(fix=fix, check=check))

--- a/tests/main/test_compose.py
+++ b/tests/main/test_compose.py
@@ -169,14 +169,122 @@ def test_config_agent_fields_resolved(tmp_path: Path) -> None:
 		tmp_path / "tasks.py",
 		"from camas import Claude, Config, Project\n"
 		"child = Project('child')\n"
-		"fix = child\n"
 		"_ = Config(default_task=child, agent=Claude(fix=child))\n",
 	)
-	_write(tmp_path / "child" / "tasks.py", _leaf("build"))
+	_write(
+		tmp_path / "child" / "tasks.py",
+		"from camas import Claude, Config, Task\n"
+		"build = Task(('python', '-c', 'pass'), name='build')\n"
+		"fixer = Task(('python', '-c', 'pass'), name='fixer')\n"
+		"_ = Config(default_task=build, agent=Claude(fix=fixer))\n",
+	)
 	config = load_scope(tmp_path / "tasks.py").config
 	assert config is not None
 	assert config.agent is not None
-	assert config.agent.fix.name == "build"
+	assert config.agent.fix.name == "fixer"
+
+
+def test_each_field_composes_the_childs_matching_field(
+	tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+	monkeypatch.delenv("GITHUB_ACTIONS", raising=False)
+	monkeypatch.delenv("CLAUDECODE", raising=False)
+	monkeypatch.delenv("CAMAS_AGENT", raising=False)
+	_write(
+		tmp_path / "tasks.py",
+		"from camas import Claude, Config, Parallel, Project\n"
+		"child = Project('child')\n"
+		"_ = Config(\n"
+		"    default_task=Parallel(child),\n"
+		"    github_task=Parallel(child),\n"
+		"    agent=Claude(fix=Parallel(child), check=Parallel(child)),\n"
+		")\n",
+	)
+	_write(
+		tmp_path / "child" / "tasks.py",
+		"from camas import Claude, Config, Task\n"
+		"default = Task(('python', '-c', 'pass'), name='c-default')\n"
+		"github = Task(('python', '-c', 'pass'), name='c-github')\n"
+		"fixer = Task(('python', '-c', 'pass'), name='c-fix')\n"
+		"checker = Task(('python', '-c', 'pass'), name='c-check')\n"
+		"_ = Config(\n"
+		"    default_task=default,\n"
+		"    github_task=github,\n"
+		"    agent=Claude(fix=fixer, check=checker),\n"
+		")\n",
+	)
+	config = load_scope(tmp_path / "tasks.py").config
+	assert config is not None
+	assert config.agent is not None
+	assert isinstance(config.default_task, Parallel)
+	assert isinstance(config.github_task, Parallel)
+	assert isinstance(config.agent.fix, Parallel)
+	assert isinstance(config.agent.check, Parallel)
+	assert config.default_task.tasks[0].name == "c-default"
+	assert config.github_task.tasks[0].name == "c-github"
+	assert config.agent.fix.tasks[0].name == "c-fix"
+	assert config.agent.check.tasks[0].name == "c-check"
+
+
+def test_field_slot_is_independent_of_ambient_context(
+	tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+	monkeypatch.delenv("GITHUB_ACTIONS", raising=False)
+	monkeypatch.delenv("CLAUDECODE", raising=False)
+	monkeypatch.delenv("CAMAS_AGENT", raising=False)
+	_write(
+		tmp_path / "tasks.py",
+		"from camas import Config, Parallel, Project\n"
+		"web = Project('web')\n"
+		"_ = Config(github_task=Parallel(web))\n",
+	)
+	_write(tmp_path / "web" / "tasks.py", _leaf("build", github="ship"))
+	config = load_scope(tmp_path / "tasks.py").config
+	assert config is not None
+	assert isinstance(config.github_task, Parallel)
+	assert config.github_task.tasks[0].name == "build-gh"
+
+
+def test_composing_a_missing_child_fix_is_attributed_to_child(tmp_path: Path) -> None:
+	_write(
+		tmp_path / "tasks.py",
+		"from camas import Claude, Config, Project, Task\n"
+		"root = Task(('python', '-c', 'pass'), name='root')\n"
+		"child = Project('child')\n"
+		"_ = Config(default_task=root, agent=Claude(fix=child))\n",
+	)
+	_write(tmp_path / "child" / "tasks.py", _leaf("build"))
+	state = load_py_tasks_state(tmp_path / "tasks.py")
+	assert isinstance(state, LoadErr)
+	assert state.source == tmp_path / "child" / "tasks.py"
+	assert "defines no fix task" in str(state.exception)
+
+
+def test_agent_default_composes_each_child_run_default(
+	tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+	monkeypatch.delenv("GITHUB_ACTIONS", raising=False)
+	monkeypatch.delenv("CLAUDECODE", raising=False)
+	monkeypatch.delenv("CAMAS_AGENT", raising=False)
+	_write(
+		tmp_path / "tasks.py",
+		"from camas import Claude, Config, Parallel, Project, Task\n"
+		"root = Task(('python', '-c', 'pass'), name='root')\n"
+		"child = Project('child')\n"
+		"_ = Config(default_task=root, agent=Claude(fix=root, default=Parallel(child)))\n",
+	)
+	_write(
+		tmp_path / "child" / "tasks.py",
+		"from camas import Claude, Config, Task\n"
+		"work = Task(('python', '-c', 'pass'), name='work')\n"
+		"agent_default = Task(('python', '-c', 'pass'), name='agent-default')\n"
+		"_ = Config(default_task=work, agent=Claude(fix=work, default=agent_default))\n",
+	)
+	config = load_scope(tmp_path / "tasks.py").config
+	assert config is not None
+	assert config.agent is not None
+	assert isinstance(config.agent.default, Parallel)
+	assert config.agent.default.tasks[0].name == "agent-default"
 
 
 def test_duplicate_project_reference_shares_load(tmp_path: Path) -> None:

--- a/tests/test_monorepo_fixture.py
+++ b/tests/test_monorepo_fixture.py
@@ -9,6 +9,9 @@ import sys
 from pathlib import Path
 from typing import Final
 
+from camas import Parallel
+from camas.main.compose import load_scope
+
 FIXTURE: Final = Path(__file__).parent / "fixtures" / "monorepo"
 BADCHILD: Final = Path(__file__).parent / "fixtures" / "monorepo-badchild"
 
@@ -33,6 +36,7 @@ def _camas(
 		text=True,
 		encoding="utf-8",
 		env=env,
+		stdin=subprocess.DEVNULL,
 		check=False,
 	)
 
@@ -44,20 +48,34 @@ def test_list_shows_composed_namespaces() -> None:
 		"hello",
 		"libs",
 		"libs.build",
+		"libs.fix",
+		"libs.check",
 		"libs.search",
 		"libs.search.lint",
 		"libs.search.test",
 		"api",
 		"api.deploy",
+		"api.fix",
+		"api.check",
 		"web",
 		"web.build",
 		"web.ship",
+		"web.fix",
+		"web.check",
 	):
 		assert name in r.stdout, r.stdout
 
 
-def test_bare_default_runs_at_root() -> None:
+def test_bare_default_composes_each_child_default() -> None:
 	r = _camas(SHOW_OUTPUT)
+	assert r.returncode == 0
+	assert f"libs-build {FIXTURE / 'libs'}" in r.stdout, r.stdout
+	assert f"api-deploy {FIXTURE / 'services' / 'api'}" in r.stdout, r.stdout
+	assert "web-build ." in r.stdout, r.stdout
+
+
+def test_named_root_task_runs_at_root() -> None:
+	r = _camas(SHOW_OUTPUT, "hello")
 	assert r.returncode == 0
 	assert f"hello {FIXTURE}" in r.stdout, r.stdout
 
@@ -117,6 +135,29 @@ def test_github_composite_runs_each_child_github_default() -> None:
 	assert f"libs-build {FIXTURE / 'libs'}" in r.stdout, r.stdout
 	assert f"api-deploy {FIXTURE / 'services' / 'api'}" in r.stdout, r.stdout
 	assert f"web-ship {FIXTURE / 'web'}" in r.stdout, r.stdout
+
+
+def test_fix_composite_runs_each_child_fix() -> None:
+	r = _camas("mcp", "fix", "--dry-run")
+	assert r.returncode == 0
+	for cwd, printed in (("libs", "libs-fix"), ("services/api", "api-fix"), ("web", "web-fix")):
+		assert f"'{printed}'" in r.stdout, r.stdout
+		assert f"(cwd: {Path(cwd)})" in r.stdout, r.stdout
+
+
+def test_each_config_field_composes_the_childs_matching_field() -> None:
+	config = load_scope(FIXTURE / "tasks.py").config
+	assert config is not None
+	assert config.agent is not None
+	fields = (
+		(config.default_task, ["build", "deploy", "build"]),
+		(config.github_task, ["build", "deploy", "ship"]),
+		(config.agent.fix, ["fix", "fix", "fix"]),
+		(config.agent.check, ["check", "check", "check"]),
+	)
+	for node, expected in fields:
+		assert isinstance(node, Parallel)
+		assert [leaf.name for leaf in node.tasks] == expected
 
 
 def test_expression_composes_dotted_refs() -> None:


### PR DESCRIPTION
> [!WARNING]
> **LLM Disclosure**
>
> This post was authored by claude-opus-4-8 on behalf of @JPHutchins. JP asked to make it possible to compose a `Project` node into a parent's default run and to confirm it via the fixture; investigating together, we found composition was field-blind (it resolved every field to the child's context default) — the failed original design intent. Opus implemented slot-based resolution and fixtures for every field.

Follow-up to #190.

## Problem

A `Project` reference composed into a parent `Config` field resolved to *whatever a bare `camas` runs in the child for the current context* — its `default_task` locally, `github_task` under CI, `run_default()` under an agent — **the same node no matter which field it sat in**. So:

- `agent.fix = Parallel(libs, api, web)` composed each child's **default**, never its fix node — a fixer hook would run each child's checks (or a CI deploy task), never their fixers.
- `agent.check` likewise.
- `github_task = Parallel(...)` composed each child's default unless the *load itself* happened under CI.
- Only `default_task` looked correct — and only because a human load's ambient context coincides with the default slot.

Single-context proof (one human load, so ambient can't mask the slot):

| parent field | resolved to (before) | correct (slot) |
|---|---|---|
| `default_task` | child default | child default ✅ |
| `github_task` | child default | child `github_task` ❌ |
| `agent.fix` | child default | child fix ❌ |
| `agent.check` | child default | child check ❌ |

## Fix

Resolve each reference through the `Config` field (a `Field` slot) it is assigned to — it grabs the child's *same* field:

```
default_task  -> child bare_task(github=False)
github_task   -> child bare_task(github=True)
agent.fix     -> child gate_fix()
agent.check   -> child gate_check()
agent.default -> child run_default()
```

So `fix=Parallel(libs, api, web)` at the root is now a real parallel fixer across the monorepo, each child contributing its own fix node.

A binding name (`libs = Project(...)`) still resolves by context (the `CONTEXT` slot), so `camas libs` / `camas web` are unchanged. Group resolution now returns the original node when its subtree has no `ProjectRef`, preserving the object identity the binding-name promotion pass depends on.

## Fixtures & tests

- `tests/fixtures/monorepo` children gain distinct `fix`/`check` nodes and agent configs; the root composes **every** field.
- `test_each_config_field_composes_the_childs_matching_field`, `test_fix_composite_runs_each_child_fix`, plus compose-level slot tests assert each parent field grabs the child's matching field, independent of ambient context.

Verify locally:

```
cd tests/fixtures/monorepo
camas                      # default composite -> each child's default_task
camas mcp fix --dry-run    # fix composite -> each child's fix node
```

Full `camas check` green: format, lint, mypy/pyright/ty/zuban/pyrefly, 1395 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
