### PR TITLE
feat(scope): when= accepts Path and falls back to cwd (#186)

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,11 +228,12 @@ _ = Config(agent=Claude(fix=Sequential(py, web, autofix)))
 
 `--paths` works on any task — `camas check --paths src/a.py`. Without it, every `{paths}` resolves to its full-run default (`ruff format src`); with it, each `{paths}` command runs only over the changed files it covers, and one covering none is dropped. A command **without** `{paths}` can't be narrowed, so its `paths=` is a no-op and it always runs — unless it declares `when=` (below), camas errs on correctness (a tool it can't narrow might be affected by the edit). `--paths` is repeatable, or comma-separated.
 
-A command that can't take `{paths}` (`cargo build`, `nix flake check`, `ctest`) is scoped with `when=` instead — a directory-prefix string, a tuple of prefixes, or a `(changed) -> bool` callable. On a scoped run a leaf whose `when=` doesn't match the changed set is dropped; a full run never consults it. Like `paths=`, a group's `when=` is the default for descendant leaves that set none:
+A command that can't take `{paths}` (`cargo build`, `nix flake check`, `ctest`) is scoped with `when=` instead — a directory-prefix string or `Path` (coerced to its POSIX prefix), a tuple of those, or a `(changed) -> bool` callable. On a scoped run a leaf whose `when=` doesn't match the changed set is dropped; a full run never consults it. Like `paths=`, a group's `when=` is the default for descendant leaves that set none. A leaf with a `cwd` but no `when=` gates on its `cwd` directory — the monorepo file-tree default; set `when="."` to opt back into always-run:
 
 ```python
 build = Task("cargo build", when="src")                # runs only when src/ changed
 flake = Task("nix flake check", when=("flake.nix", "nix"))
+tests = Task("cargo test", cwd="code-gen")             # when= defaults to "code-gen"
 ```
 
 A `paths=` callable is called with `()` on a full run — one that filters the changed set would return `()` and strip the command's arguments entirely (a formatter reading stdin on no args hangs). `by_suffix(suffixes, default=...)` is the safe factory: it filters the changed files by suffix on a scoped run and returns `default` on a full run:
@@ -275,7 +276,7 @@ _ = Config(
 
 A reference composes the child's **matching field**: the same bare `libs` grabs the child's `default_task` in `default_task`, its `github_task` in `github_task`, its fix node in `agent.fix`, its check node in `agent.check` — the slot the reference sits in selects which field of the child's own `Config` it contributes. So a `Parallel` of references in any slot is that slot composed across the monorepo, each child contributing its own. A binding name resolves by context instead — `camas libs` runs whatever a bare `camas` runs in that directory (its default locally, its `github_task` under CI, its agent default under an agent). `camas libs.search.lint` reaches a task the child exposes (because `libs/tasks.py` itself did `search = Project("search")`), and expressions compose across namespaces (`camas '{libs.search.lint, api.deploy}'`).
 
-Nodes stay anchored where they were authored: a leaf's `cwd` and its `paths=`/`when=` scopes are relative to its own `tasks.py`, rebased across the boundary no matter where `camas` is invoked from. Children are referenced by path relative to the importing file and live within its directory. The [monorepo fixture](https://github.com/JPHutchins/camas/tree/main/tests/fixtures/monorepo) exercises the permutations.
+Nodes stay anchored where they were authored: a leaf's `cwd` and its `paths=`/`when=` scopes are relative to its own `tasks.py`, rebased across the boundary no matter where `camas` is invoked from. Because a leaf's `when=` defaults to its `cwd`, a scoped run (the gate, or `--paths`) automatically runs only the children whose directory changed — no per-leaf `when=` anywhere in a child's `tasks.py`. Children are referenced by path relative to the importing file and live within its directory. The [monorepo fixture](https://github.com/JPHutchins/camas/tree/main/tests/fixtures/monorepo) exercises the permutations.
 
 ## Effects plugins
 

--- a/src/camas/core/matrix.py
+++ b/src/camas/core/matrix.py
@@ -323,6 +323,19 @@ def expand_parallel_matrix(
 	)
 
 
+def _when_from_cwd(cwd: Path | None) -> str | None:
+	"""The ``when`` prefix a leaf falls back to when it sets none: a relative ``cwd`` as its own
+	POSIX prefix, so a task rooted in a subdir runs only when that subdir changed. An absolute
+	``cwd`` — which could never match the repo-relative changed set — has no fallback.
+
+	>>> _when_from_cwd(Path("code-gen"))
+	'code-gen'
+	>>> _when_from_cwd(None) is None
+	True
+	"""
+	return cwd.as_posix() if cwd is not None and not cwd.is_absolute() else None
+
+
 def expand_matrix(
 	task: TaskNode,
 	ancestor_env: Mapping[str, str] | None = None,
@@ -336,7 +349,9 @@ def expand_matrix(
 	Execution and scoping read the accumulated values from leaves. A group rebuilt without a
 	matrix retains its own env/cwd/paths/when for display; a matrix expansion's synthesized
 	wrapper nodes carry env/cwd only — paths and when live on the specialized leaves. A child's
-	own ``cwd``/``paths``/``when`` takes precedence over an ancestor's.
+	own ``cwd``/``paths``/``when`` takes precedence over an ancestor's. A leaf that ends up with a
+	relative ``cwd`` but no ``when`` falls back to gating on its ``cwd`` directory
+	(:func:`_when_from_cwd`); set ``when="."`` to opt back into always-run.
 
 	>>> expand_matrix(Task("echo hi"))
 	Task(cmd='echo hi', name=None, env={}, cwd=None)
@@ -351,19 +366,25 @@ def expand_matrix(
 	'.'
 	>>> expand_matrix(Parallel(Task("cargo build"), when="src")).tasks[0].when  # type: ignore[union-attr]
 	'src'
+	>>> expand_matrix(Task("cargo build", cwd="code-gen")).when
+	'code-gen'
+	>>> expand_matrix(Task("cargo build", cwd="code-gen", when="only")).when
+	'only'
 	"""
 	parent_env: Final = dict(ancestor_env) if ancestor_env else {}
 	match task:
 		case Task():
+			leaf_cwd: Final = task.cwd if task.cwd is not None else ancestor_cwd
+			leaf_when: Final = task.when if task.when is not None else ancestor_when
 			return Task(
 				cmd=task.cmd,
 				name=task.name,
 				env={**parent_env, **task.env},
-				cwd=task.cwd if task.cwd is not None else ancestor_cwd,
+				cwd=leaf_cwd,
 				help=task.help,
 				mutates=task.mutates,
 				paths=task.paths if task.paths is not None else ancestor_paths,
-				when=task.when if task.when is not None else ancestor_when,
+				when=leaf_when if leaf_when is not None else _when_from_cwd(leaf_cwd),
 				agent_format=task.agent_format,
 			)
 		case Sequential(tasks=tasks, matrix=matrix, env=env, cwd=cwd, paths=paths, when=when):

--- a/src/camas/core/scope.py
+++ b/src/camas/core/scope.py
@@ -16,7 +16,9 @@ A command with **no** ``{paths}`` can't be narrowed, so it always runs — unles
 predicate (own or inherited) excludes the changed set — and its ``paths`` (own or inherited) is
 a no-op regardless; camas errs on correctness otherwise: a tool that can't narrow might be
 affected by the edit. ``paths`` only ever prunes a ``{paths}`` command; ``when`` can prune either
-kind of leaf, on a scoped run, gating before any ``paths`` narrowing — never on a full run.
+kind of leaf, on a scoped run, gating before any ``paths`` narrowing — never on a full run. A
+leaf with a ``cwd`` but no explicit ``when`` gates on its ``cwd`` directory (baked by
+:func:`camas.core.matrix.expand_matrix`); ``when="."`` opts back into always-run.
 
 :func:`with_default_paths` resolves the full-run default and is applied before every run.
 :func:`scope_to_changed` resolves and prunes against a changed set — the entry point for

--- a/src/camas/v0/task.py
+++ b/src/camas/v0/task.py
@@ -24,6 +24,40 @@ WhenPredicate: TypeAlias = "Callable[[tuple[str, ...]], bool]"
 changed set and is never called for a full run (``changed == ()``)."""
 
 
+def _prefix(value: str | Path) -> str:
+	"""A ``when`` prefix in its stored form: a ``Path`` as POSIX, a string unchanged.
+
+	>>> _prefix(Path("code-gen")), _prefix("src")
+	('code-gen', 'src')
+	"""
+	return value.as_posix() if isinstance(value, Path) else value
+
+
+def _coerce_when(
+	when: str | Path | tuple[str | Path, ...] | WhenPredicate | None,
+) -> str | tuple[str, ...] | WhenPredicate | None:
+	"""Coerce a ``when`` argument to its stored form: a ``Path`` (or a ``Path`` inside a tuple)
+	becomes its POSIX prefix; a string, tuple of strings, callable, or ``None`` is unchanged.
+
+	>>> _coerce_when(Path("code-gen"))
+	'code-gen'
+	>>> _coerce_when((Path("src"), "include"))
+	('src', 'include')
+	>>> _coerce_when("src"), _coerce_when(None)
+	('src', None)
+	"""
+	match when:
+		case str() | Path():
+			return _prefix(when)
+		case tuple():
+			return tuple(
+				_prefix(w)  # ty: ignore[invalid-argument-type]
+				for w in when
+			)
+		case _:
+			return when
+
+
 def by_suffix(suffixes: tuple[str, ...], default: tuple[str, ...] = (".",)) -> PathScope:
 	"""A ``PathScope`` that filters the changed files by suffix on a scoped run and returns
 	``default`` on a full run, so a ``{paths}`` command never loses its arguments to an empty
@@ -90,10 +124,13 @@ class Task:
 	``paths`` is a no-op and the command always runs unless a ``when`` predicate (below) prunes it.
 
 	``when`` is a run-if-changed predicate (:mod:`camas.core.scope`) for a leaf whose command
-	can't take ``{paths}`` (``cargo build``, ``nix flake check``): a directory-prefix string, a
-	tuple of prefixes (OR'd), or a ``(changed) -> bool`` callable. On a scoped run a leaf whose
-	``when`` doesn't match the changed set is pruned; a full run never consults ``when``. A leaf
-	that also sets ``paths``/``{paths}`` is gated by ``when`` first, then narrowed as usual.
+	can't take ``{paths}`` (``cargo build``, ``nix flake check``): a directory-prefix string or
+	``Path`` (coerced to its POSIX prefix), a tuple of those (OR'd), or a ``(changed) -> bool``
+	callable. On a scoped run a leaf whose ``when`` doesn't match the changed set is pruned; a
+	full run never consults ``when``. A leaf that also sets ``paths``/``{paths}`` is gated by
+	``when`` first, then narrowed as usual. When ``when`` is unset, a leaf with a ``cwd`` gates on
+	its ``cwd`` directory (:func:`camas.core.matrix.expand_matrix`) — a monorepo file-tree default;
+	set ``when="."`` to opt back into always-run.
 
 	``agent_format`` is the agent-only structured-output variant (:class:`AgentFormat`): the gate
 	appends its ``args`` and tags the diagnostics ``kind``; a human run leaves the command as-is.
@@ -115,6 +152,10 @@ class Task:
 	Task(cmd='ruff format {paths}', name=None, env={}, cwd=None, mutates=True, paths='.')
 	>>> Task("cargo build", when=("src", "include"))
 	Task(cmd='cargo build', name=None, env={}, cwd=None, when=('src', 'include'))
+	>>> Task("cargo build", when=Path("src")).when
+	'src'
+	>>> Task("cargo build", when=(Path("src"), "include")).when
+	('src', 'include')
 	>>> Task("ruff check .", agent_format=AgentFormat("--output-format sarif", "sarif"))
 	Task(cmd='ruff check .', name=None, env={}, cwd=None, agent_format=AgentFormat(args='--output-format sarif', kind='sarif'))
 	>>> Task("ruff check .", agent_format=("--output-format sarif", "sarif")).agent_format
@@ -144,7 +185,7 @@ class Task:
 		help: str | None = None,
 		mutates: bool = False,
 		paths: str | PathScope | None = None,
-		when: str | tuple[str, ...] | WhenPredicate | None = None,
+		when: str | Path | tuple[str | Path, ...] | WhenPredicate | None = None,
 		agent_format: AgentFormat | tuple[str, OutputKind] | None = None,
 	) -> None:
 		put = object.__setattr__
@@ -155,7 +196,7 @@ class Task:
 		put(self, "help", help)
 		put(self, "mutates", mutates)
 		put(self, "paths", paths)
-		put(self, "when", when)
+		put(self, "when", _coerce_when(when))
 		put(
 			self,
 			"agent_format",
@@ -234,7 +275,7 @@ class Group:
 		cwd: str | Path | None = None,
 		help: str | None = None,
 		paths: str | PathScope | None = None,
-		when: str | tuple[str, ...] | WhenPredicate | None = None,
+		when: str | Path | tuple[str | Path, ...] | WhenPredicate | None = None,
 	) -> None:
 		put = object.__setattr__
 		put(self, "tasks", tuple(Task(cmd=t) if isinstance(t, str) else t for t in tasks))
@@ -244,7 +285,7 @@ class Group:
 		put(self, "cwd", Path(cwd) if isinstance(cwd, str) else cwd)
 		put(self, "help", help)
 		put(self, "paths", paths)
-		put(self, "when", when)
+		put(self, "when", _coerce_when(when))
 
 	def __hash__(self) -> int:
 		matrix_key = None if self.matrix is None else tuple(sorted(self.matrix.items()))

--- a/tests/core/test_matrix.py
+++ b/tests/core/test_matrix.py
@@ -3,11 +3,18 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
 from camas import Parallel, Sequential, Task
 from camas.core.matrix import expand_matrix
 from camas.core.traversal import flatten_leaves
+
+
+def _leaf(node: object) -> Task:
+	assert isinstance(node, Task)
+	return node
 
 
 def test_no_matrix_passthrough() -> None:
@@ -312,3 +319,25 @@ def test_callable_when_survives_specialization() -> None:
 			assert when is predicate
 		case _:
 			raise AssertionError(f"unexpected: {result}")
+
+
+def test_relative_cwd_becomes_when_fallback() -> None:
+	assert _leaf(expand_matrix(Task("cargo build", cwd="code-gen"))).when == "code-gen"
+
+
+def test_container_cwd_becomes_leaf_when_fallback() -> None:
+	result = expand_matrix(Parallel(Task("cargo build", name="cargo"), cwd="code-gen"))
+	assert isinstance(result, Parallel)
+	assert _leaf(result.tasks[0]).when == "code-gen"
+
+
+def test_explicit_when_wins_over_cwd_fallback() -> None:
+	assert _leaf(expand_matrix(Task("cargo build", cwd="code-gen", when="only"))).when == "only"
+
+
+def test_when_dot_opts_out_of_cwd_fallback() -> None:
+	assert _leaf(expand_matrix(Task("cargo build", cwd="code-gen", when="."))).when == "."
+
+
+def test_absolute_cwd_has_no_when_fallback() -> None:
+	assert _leaf(expand_matrix(Task("cargo build", cwd=Path.cwd()))).when is None

--- a/tests/core/test_scope.py
+++ b/tests/core/test_scope.py
@@ -200,6 +200,25 @@ def test_group_when_inherited_via_expand_matrix() -> None:
 	assert kept.tasks == (Task("cargo build", name="cargo", when="src"),)
 
 
+def test_cwd_fallback_gates_tokenless_leaf_to_its_directory() -> None:
+	tree = expand_matrix(Task("cargo build", name="cargo", cwd="code-gen"))
+	assert scope_to_changed(tree, ("code-gen/main.rs",)) == tree
+	assert scope_to_changed(tree, ("docs/readme.md",)) is None
+
+
+def test_cwd_fallback_gates_paths_leaf_that_paths_alone_would_not_prune() -> None:
+	"""A ``{paths}`` leaf with a ``cwd`` and a broad ``paths="."`` gates on its own directory
+	first, then narrows the surviving changes into its ``cwd`` frame."""
+	tree = expand_matrix(Task("ruff check {paths}", name="lint", cwd="pkg", paths="."))
+	assert scope_to_changed(tree, ("other/x.py",)) is None
+	assert _cmd(scope_to_changed(tree, ("pkg/a.py",))) == "ruff check a.py"
+
+
+def test_when_dot_opts_cwd_leaf_back_into_always_run() -> None:
+	tree = expand_matrix(Task("cargo build", name="cargo", cwd="pkg", when="."))
+	assert scope_to_changed(tree, ("other/x.py",)) == tree
+
+
 def test_by_suffix_full_run_default() -> None:
 	scope = by_suffix((".c", ".h"), default=("src", "include"))
 	assert scope(()) == ("src", "include")

--- a/tests/test_monorepo_fixture.py
+++ b/tests/test_monorepo_fixture.py
@@ -179,6 +179,22 @@ def test_paths_outside_namespace_runs_nothing() -> None:
 	assert "nothing to run" in r.stdout, r.stdout
 
 
+def test_scoped_run_gates_composed_child_by_its_directory() -> None:
+	r = _camas(SHOW_OUTPUT, "--paths", "libs/x.py")
+	assert r.returncode == 0
+	assert "libs-build" in r.stdout, r.stdout
+	assert "api-deploy" not in r.stdout, r.stdout
+	assert "web-build" not in r.stdout, r.stdout
+
+
+def test_scoped_run_gates_other_composed_child_by_its_directory() -> None:
+	r = _camas(SHOW_OUTPUT, "--paths", "services/api/x.py")
+	assert r.returncode == 0
+	assert "api-deploy" in r.stdout, r.stdout
+	assert "libs-build" not in r.stdout, r.stdout
+	assert "web-build" not in r.stdout, r.stdout
+
+
 def test_run_from_child_subdir_gets_local_view() -> None:
 	r = _camas(SHOW_OUTPUT, "lint", cwd=FIXTURE / "libs" / "search" / "src")
 	assert r.returncode == 0


### PR DESCRIPTION
## What

Closes the `when=` half of #186 (the hierarchical-`tasks.py` half already shipped via the `Project` system in #189/#190/#192).

Two ergonomics fixes to `when=`, motivated by the monorepo kludge where every leaf repeats `cwd=CODE_GEN, when=CODE_GEN_DIR`:

1. **`when=` accepts `Path`** — coerced to its POSIX prefix, mirroring how `cwd` coerces `str`→`Path`. Works for a bare `Path` and for `Path` elements inside a `tuple`.
2. **`when=` falls back to `cwd`** when unset — a leaf rooted at `cwd=code-gen` gates on `code-gen/` on a scoped run. An absolute `cwd` (which could never match the repo-relative changed set) has no fallback; set `when="."` to opt a `cwd`-bearing leaf back into always-run.

## Why it composes with `Project`

`rebase_tree` already anchors every composed child's root node at `cwd=<child-dir>`, so the fallback makes each child's tasks gate on their own directory automatically — a scoped run (gate or `--paths`) runs only the children whose directory changed, with **no per-leaf `when=` anywhere in a child's `tasks.py`**.

Before (from the issue):

```python
code_gen_test = Task("cargo test", cwd=CODE_GEN, when=CODE_GEN_DIR)
```

After:

```python
code_gen_test = Task("cargo test", cwd=CODE_GEN)   # when= defaults to code-gen
```

## Implementation

- `src/camas/v0/task.py`: `_coerce_when` (+ `_prefix`) applied in `Task`/`Group.__init__`; `when` param widened to `str | Path | tuple[str | Path, ...] | WhenPredicate | None`, stored form unchanged.
- `src/camas/core/matrix.py`: `_when_from_cwd` fallback in `expand_matrix`'s leaf case — leaf-level, so own-cwd, inherited-group-cwd, and most-specific-cwd-wins all fall out of the existing effective-cwd resolution. Group `when` is only a default-provider (`scope_to_changed` never reads it), so no group-level handling is needed.
- Docs: `Task`/`expand_matrix`/`scope.py` docstrings + README `when=`/Monorepos sections.

## Behavior change

A `cwd`-bearing, `when=`-less leaf flips from *always-runs-on-scoped* to *runs-only-when-its-dir-changed*. The existing suite stays green: no unit test combines `cwd=` with a scoped run, and the monorepo fixture's scoped tests target a `{paths}` leaf already gated by its `paths` scope, while its non-`{paths}` child leaves are only exercised via full runs (which never consult `when`).

## Verification

- `camas` full gate: format, lint, 5 typecheckers (mypy/pyright/ty/zuban/pyrefly), 1409 tests, **100% coverage**.
- mypyc wheel built locally (`CAMAS_USE_MYPYC=1`) — compiles clean.
- Dogfooded the issue's exact shape: `--paths code-gen/x.rs` runs the code-gen leaves, `--paths other/y.py` prunes them — both with `cwd=` only and no `when=`.

New tests: `tests/core/test_matrix.py` (fallback, inherited-group-cwd, explicit-wins, `when="."` opt-out, absolute-cwd), `tests/core/test_scope.py` (end-to-end gate + `{paths}`-leaf interaction), `tests/test_monorepo_fixture.py` (composed children gate by directory).

> [!WARNING]
> **LLM Disclosure**
>
> This post was authored by claude-opus-4-8 on behalf of @JPHutchins. JP asked me to tackle issue #186 — make `when=` accept `Path` and fall back to `cwd`, with "fixtures for everything". This PR implements that after a plan-mode design she approved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
