### PR TITLE
DX quickfixes: task-name suggestions, actionlint, harness approval gate

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,7 +30,7 @@ jobs:
         run: |
           uv run camas 'Sequential(
             "uv sync",
-            {format_check, lint, mypy, pyright, ty, pyrefly, test},
+            {format_check, lint, actionlint, mypy, pyright, ty, pyrefly, test},
             env={"UV_PROJECT_ENVIRONMENT": ".venv-{PY}", "UV_PYTHON": "{PY}"},
             matrix={"PY": ("3.10", "3.11", "3.12", "3.13", "3.14", "3.15")},
           )'
@@ -166,7 +166,8 @@ jobs:
             https://github.com/mvdan/sh/releases/download/v3.13.1/shfmt_v3.13.1_linux_amd64
           chmod +x "$HOME/.local/bin/shfmt"
 
-      - run: $HOME/.local/bin/shfmt -d .github/scripts/*.sh
+      - run: |
+          "$HOME/.local/bin/shfmt" -d .github/scripts/*.sh
         working-directory: .
 
       - name: Install demo recording tools
@@ -200,7 +201,7 @@ jobs:
             git worktree add storage gh-storage
           else
             git worktree add --orphan -b gh-storage storage
-            (cd storage && git rm -rf . >/dev/null 2>&1 || true)
+            git -C storage rm -rf . >/dev/null 2>&1 || true
           fi
 
           mkdir -p storage/demos/archive

--- a/.github/workflows/claude-code-harness.yaml
+++ b/.github/workflows/claude-code-harness.yaml
@@ -46,7 +46,7 @@ jobs:
       - name: Install uv (pinned)
         run: |
           pipx install --force uv==0.9.15
-          echo "$(pipx environment --value PIPX_BIN_DIR)" >> "$GITHUB_PATH"
+          pipx environment --value PIPX_BIN_DIR >> "$GITHUB_PATH"
       - run: uv --version
 
       - run: npm install -g @anthropic-ai/claude-code@2.1.197

--- a/.github/workflows/claude-code-harness.yaml
+++ b/.github/workflows/claude-code-harness.yaml
@@ -75,7 +75,9 @@ jobs:
       # The contract suite needs any interpreter >=3.10; --python 3.12 pins the runner's system
       # Python so uv does not download the .python-version default (3.14) from a GitHub release
       # asset host that is not on the allowlist. UV_PYTHON_DOWNLOADS=never makes a missing one fail
-      # fast, before the DeepSeek-billed run.
+      # fast, before the DeepSeek-billed run. --no-group lint drops actionlint-py, which the suite
+      # does not use and which builds by downloading its binary from a release host off the
+      # allowlist (it would fail the egress lock).
       - name: Run the Claude Code integration suite
         env:
           CAMAS_CC_E2E: "1"
@@ -89,4 +91,4 @@ jobs:
           UV_PYTHON_DOWNLOADS: never
         run: |
           [ -n "$ANTHROPIC_AUTH_TOKEN" ] || { echo "::error::MODEL_API_KEY secret is not set"; exit 1; }
-          uv run --python 3.12 pytest tests/claude_code/ -v --no-cov -p no:cacheprovider
+          uv run --python 3.12 --no-group lint pytest tests/claude_code/ -v --no-cov -p no:cacheprovider

--- a/.github/workflows/claude-code-harness.yaml
+++ b/.github/workflows/claude-code-harness.yaml
@@ -30,6 +30,13 @@ jobs:
   harness:
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    # A required-reviewers rule on this environment (repo Settings → Environments →
+    # model-api-e2e) holds MODEL_API_KEY back until a maintainer approves the run. Agent pushes
+    # made with the maintainer's token report the maintainer as github.actor, so an actor guard
+    # would not gate them; the environment approval pauses every run — push, schedule, dispatch —
+    # before the job starts. The environment must exist with @JPHutchins as a required reviewer;
+    # until then this name resolves to an unprotected auto-created environment (no gate).
+    environment: model-api-e2e
     permissions:
       contents: read
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,6 @@ dev = [
 "pytest-cov>=7,<8",
 "cyclopts>=4,<5",
 "ruff>=0.12,<1",
-"actionlint-py>=1.7,<2",
 "zuban>=0.7,<1",
 "pyrefly>=0.61,<1",
 "types-setuptools",
@@ -90,6 +89,13 @@ dev = [
 "tomli>=2",
 "typing_extensions>=4.12",
 ]
+# actionlint-py is sdist-only and downloads the actionlint binary from GitHub releases at build
+# time; kept in its own default group so the egress-locked harness job can drop it with
+# --no-group lint (it does not use actionlint), while every other flow still syncs it.
+lint = ["actionlint-py>=1.7,<2"]
+
+[tool.uv]
+default-groups = ["dev", "lint"]
 
 [tool.pytest.ini_options]
 testpaths = ["src", "tests"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,7 @@ dev = [
 "pytest-cov>=7,<8",
 "cyclopts>=4,<5",
 "ruff>=0.12,<1",
+"actionlint-py>=1.7,<2",
 "zuban>=0.7,<1",
 "pyrefly>=0.61,<1",
 "types-setuptools",

--- a/src/camas/core/task.py
+++ b/src/camas/core/task.py
@@ -1,13 +1,15 @@
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: 2026 JP Hutchins
 
-"""Engine-side task helpers: matrix bindings and the task display label."""
+"""Engine-side task helpers: matrix bindings, the task display label, and name suggestions."""
 
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, NamedTuple, TypeAlias
 
 if TYPE_CHECKING:
+	from collections.abc import Iterable
+
 	from ..v0.task import Task
 
 
@@ -37,3 +39,17 @@ def task_label(task: Task) -> str:
 	if task.name is not None:
 		return task.name
 	return task.cmd if isinstance(task.cmd, str) else " ".join(task.cmd)
+
+
+def did_you_mean(name: str, known: Iterable[str]) -> str:
+	"""Return a ``; did you mean 'x'?`` clause for the closest ``known`` name, else ``""``.
+
+	>>> did_you_mean("libs-fix", ("libs.fix", "libs.build", "api"))
+	"; did you mean 'libs.fix'?"
+	>>> did_you_mean("totally-unrelated", ("libs.fix", "api"))
+	''
+	"""
+	from difflib import get_close_matches
+
+	closest = get_close_matches(name, sorted(known), n=1)
+	return f"; did you mean {closest[0]!r}?" if closest else ""

--- a/src/camas/main/dispatch.py
+++ b/src/camas/main/dispatch.py
@@ -26,7 +26,7 @@ from ..core.hook_event import stdin_changed
 from ..core.matrix import expand_matrix, matrix_axes, override_matrix
 from ..core.render import print_tree, render_tree_lines
 from ..core.scope import scope_to_changed, to_changed, with_default_paths
-from ..core.task import task_label
+from ..core.task import did_you_mean, task_label
 from ..v0.config import Config
 from .argv import apply_passthrough, parse_axis_values, parse_matrix_kv, split_passthrough
 from .compose import load_py_tasks_state, state_from_scope
@@ -74,7 +74,10 @@ def dispatch_arg(arg: str, tasks: Mapping[str, TaskNode]) -> TaskNode:
 			return tasks[candidate]
 	if _NAME_LIKE.match(arg):
 		known = ", ".join(sorted(tasks)) or "none"
-		print(f"error: no task named {arg!r} (known: {known})", file=sys.stderr)
+		print(
+			f"error: no task named {arg!r}{did_you_mean(arg, tasks)} (known: {known})",
+			file=sys.stderr,
+		)
 		sys.exit(2)
 	return parse_expression(arg, tasks=tasks)
 

--- a/src/camas/main/expression.py
+++ b/src/camas/main/expression.py
@@ -16,6 +16,7 @@ if sys.version_info >= (3, 11):
 else:  # pragma: no cover
 	from typing_extensions import assert_never
 
+from ..core.task import did_you_mean
 from ..v0.task import AgentFormat, Group, OutputKind, Parallel, Sequential, Task, TaskNode
 
 if TYPE_CHECKING:
@@ -532,7 +533,9 @@ def resolve_refs(
 				raise ValueError(f"cycle in task refs: {chain}")
 			if name not in defs:
 				known = ", ".join(sorted(defs)) or "none"
-				raise ValueError(f"unknown task ref {name!r} (known: {known})")
+				raise ValueError(
+					f"unknown task ref {name!r}{did_you_mean(name, defs)} (known: {known})"
+				)
 			return resolve_refs(defs[name], defs, visiting | {name})
 		case Task():
 			return node

--- a/src/camas/mcp/serve.py
+++ b/src/camas/mcp/serve.py
@@ -33,7 +33,7 @@ from ..core.hook_event import changed_from_stdin
 from ..core.matrix import expand_matrix, override_matrix
 from ..core.render import render_tree_lines, strip_ansi
 from ..core.scope import scope_to_changed, to_changed, with_default_paths
-from ..core.task import task_label
+from ..core.task import did_you_mean, task_label
 from ..main.argv import apply_passthrough
 from ..main.compose import load_py_tasks_state
 from ..main.format import format_load_error_hint, format_version_skew_hint
@@ -664,7 +664,9 @@ def resolve_run_node(
 		name, node = default.name or "default task", default
 	elif req.task not in tasks:
 		known = ", ".join(sorted(tasks)) or "none"
-		raise ValueError(f"no task named {req.task!r} (known: {known})")
+		raise ValueError(
+			f"no task named {req.task!r}{did_you_mean(req.task, tasks)} (known: {known})"
+		)
 	else:
 		name, node = req.task, tasks[req.task]
 	if req.matrix_overrides:
@@ -732,7 +734,7 @@ def budget_source(
 	if task is not None:
 		if task not in tasks:
 			known = ", ".join(sorted(tasks)) or "none"
-			raise ValueError(f"no task named {task!r} (known: {known})")
+			raise ValueError(f"no task named {task!r}{did_you_mean(task, tasks)} (known: {known})")
 		return tasks[task]
 	default = config.run_default() if config is not None else None
 	if default is None:
@@ -750,7 +752,7 @@ def gate_source(tasks: Mapping[str, TaskNode], config: Config | None, task: str 
 	if task is not None:
 		if task not in tasks:
 			known = ", ".join(sorted(tasks)) or "none"
-			raise ValueError(f"no task named {task!r} (known: {known})")
+			raise ValueError(f"no task named {task!r}{did_you_mean(task, tasks)} (known: {known})")
 		return tasks[task]
 	check = config.gate_check(github=False) if config is not None else None
 	if check is None:
@@ -1229,7 +1231,9 @@ async def fix_for(
 	if req.task is not None:
 		if req.task not in tasks:
 			known = ", ".join(sorted(tasks)) or "none"
-			return error_result(f"no task named {req.task!r} (known: {known})")
+			return error_result(
+				f"no task named {req.task!r}{did_you_mean(req.task, tasks)} (known: {known})"
+			)
 		fix_node = tasks[req.task]
 	else:
 		fix_node = config.gate_fix() if config is not None else None

--- a/tasks.py
+++ b/tasks.py
@@ -9,6 +9,7 @@ format_check = Task("uv run ruff format --check {paths}", paths=".")
 lint = Task("uv run ruff check {paths}", paths=".")
 lint_fix = Task("uv run ruff check --fix {paths}", mutates=True, paths=".")
 fix = Sequential(lint_fix, format)
+actionlint = Task("uv run actionlint")
 mypy = Task("uv run mypy .")
 ty = Task("uv run ty check")
 zuban = Task("uv run zuban check src tests --exclude tests.fixtures")
@@ -28,8 +29,8 @@ release = Task(
 	help="assert clean synced main, bump VERSION, commit, tag (camas release -- X.Y.Z)",
 )
 
-all = Sequential(fix, Parallel(typecheck, coverage))
-check = Parallel(format_check, lint, typecheck, test)
+all = Sequential(fix, Parallel(actionlint, typecheck, coverage))
+check = Parallel(format_check, lint, actionlint, typecheck, test)
 
 matrix = Sequential(
 	Task("uv sync"),

--- a/tasks.py
+++ b/tasks.py
@@ -2,7 +2,7 @@
 
 from pathlib import Path
 
-from camas import Config, Parallel, Sequential, Task
+from camas import Claude, Config, Parallel, Sequential, Task
 
 format = Task("uv run ruff format {paths}", mutates=True, paths=".")
 format_check = Task("uv run ruff format --check {paths}", paths=".")
@@ -31,6 +31,7 @@ release = Task(
 
 all = Sequential(fix, Parallel(actionlint, typecheck, coverage))
 check = Parallel(format_check, lint, actionlint, typecheck, test)
+gate = Parallel(format_check, lint, actionlint, typecheck, coverage)
 
 matrix = Sequential(
 	Task("uv sync"),
@@ -45,4 +46,4 @@ matrix = Sequential(
 	},
 )
 
-_ = Config(default_task=all, github_task=check)
+_ = Config(default_task=all, github_task=check, agent=Claude(fix=fix, check=gate))

--- a/tests/main/test_tasks.py
+++ b/tests/main/test_tasks.py
@@ -353,6 +353,13 @@ def test_dispatch_arg_hyphenated_unknown_errors(capsys: pytest.CaptureFixture[st
 	assert "no task named 'test-all'" in capsys.readouterr().err
 
 
+def test_dispatch_arg_unknown_suggests_closest(capsys: pytest.CaptureFixture[str]) -> None:
+	# #193: lead the "no task named" error with the nearest known task name.
+	with pytest.raises(SystemExit, match="2"):
+		dispatch_arg("libs-fix", {"libs.fix": Task("x"), "libs.build": Task("y")})
+	assert "did you mean 'libs.fix'?" in capsys.readouterr().err
+
+
 def test_dispatch_arg_unknown_name() -> None:
 	with pytest.raises(SystemExit, match="2"):
 		dispatch_arg("nope", {"a": Task("x")})

--- a/uv.lock
+++ b/uv.lock
@@ -87,7 +87,6 @@ mcp = [
 
 [package.dev-dependencies]
 dev = [
-    { name = "actionlint-py" },
     { name = "camas", extra = ["all"] },
     { name = "cyclopts" },
     { name = "exceptiongroup" },
@@ -103,6 +102,9 @@ dev = [
     { name = "types-setuptools" },
     { name = "typing-extensions" },
     { name = "zuban" },
+]
+lint = [
+    { name = "actionlint-py" },
 ]
 
 [package.metadata]
@@ -122,7 +124,6 @@ provides-extras = ["github-checks", "ctrf", "check", "mcp", "all"]
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "actionlint-py", specifier = ">=1.7,<2" },
     { name = "camas", extras = ["all"] },
     { name = "cyclopts", specifier = ">=4,<5" },
     { name = "exceptiongroup", specifier = ">=1.2" },
@@ -139,6 +140,7 @@ dev = [
     { name = "typing-extensions", specifier = ">=4.12" },
     { name = "zuban", specifier = ">=0.7,<1" },
 ]
+lint = [{ name = "actionlint-py", specifier = ">=1.7,<2" }]
 
 [[package]]
 name = "certifi"

--- a/uv.lock
+++ b/uv.lock
@@ -8,6 +8,12 @@ resolution-markers = [
 ]
 
 [[package]]
+name = "actionlint-py"
+version = "1.7.12.24"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6f/0b/3f29683dfbe94208fb5c3806806a6ef419972892e25c3c4f95198f68c978/actionlint_py-1.7.12.24.tar.gz", hash = "sha256:7571b0724fde79b2572b98b2b53792c470249d4db29951b57fc49b9cd3eaf11e", size = 12071, upload-time = "2026-03-31T06:21:35.015Z" }
+
+[[package]]
 name = "annotated-types"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -81,6 +87,7 @@ mcp = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "actionlint-py" },
     { name = "camas", extra = ["all"] },
     { name = "cyclopts" },
     { name = "exceptiongroup" },
@@ -115,6 +122,7 @@ provides-extras = ["github-checks", "ctrf", "check", "mcp", "all"]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "actionlint-py", specifier = ">=1.7,<2" },
     { name = "camas", extras = ["all"] },
     { name = "cyclopts", specifier = ">=4,<5" },
     { name = "exceptiongroup", specifier = ">=1.2" },


### PR DESCRIPTION
Four small, independent changes — each its own commit. **Please merge with a
merge commit (do _not_ squash)** so the per-issue commits are preserved.

## Changes

1. **`feat(dispatch)` — suggest the closest task name (#193).** An unknown
   `camas <task>`, expression `Ref`, or MCP task argument now leads its
   "no task named" error with `; did you mean 'x'?` when a close match exists
   (`did_you_mean`, difflib-backed, shared across the CLI, expression resolver,
   and MCP server). E.g. `camas libs-fix` → `no task named 'libs-fix'; did you
   mean 'libs.fix'? (known: …)`.

2. **`feat(ci)` — add actionlint (#183).** New `actionlint-py` dev dep and an
   `actionlint` task, wired into `check` and `all` (so it runs in the gate,
   locally, and in CI). Fixes the three pre-existing shellcheck findings
   actionlint surfaces (SC2005/SC2086/SC2015 in `ci.yaml` and the harness
   workflow) and keeps the Windows inline check expression in sync.

3. **`feat(tasks)` — agent gate check runs coverage.** Registers
   `Config.agent = Claude(fix=fix, check=gate)` with an explicit `gate` node
   that runs `coverage` in place of `test`, so the agent gate exercises the
   100%-coverage floor CI enforces in its own job (easy to forget when split
   out). Also registers `fix` as the deterministic autofix node.

4. **`ci(harness)` — gate `MODEL_API_KEY` behind maintainer approval (#182).**
   Puts the harness job in a `model-api-e2e` environment so a required-reviewers
   rule holds the burner key back until a maintainer approves each run. An actor
   guard can't do this: agent pushes carry the maintainer's token.

## ⚠️ Manual setup required for #182

The workflow references environment `model-api-e2e`. **Until it exists in repo
settings, the name auto-resolves to an unprotected environment (no gate).** To
activate the protection: repo **Settings → Environments → New environment
`model-api-e2e`**, add **@JPHutchins as a required reviewer**, and (optionally)
add `MODEL_API_KEY` as an environment secret. The repo-level secret keeps the
harness working meanwhile.

## Verification

`camas gate` green locally: `format_check`, `lint`, `actionlint`, the five
typecheckers, and `coverage` (100% floor held). `actionlint` clean on all
workflows.

Closes #193
Closes #183
Closes #182

> [!WARNING]
> **LLM Disclosure**
>
> This PR was authored by claude-opus-4-8 on behalf of @JPHutchins, who asked for a branch and PR tackling three low-hanging-fruit issues (#193, #183, #182) plus adding coverage to the agent gate check, each as its own commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)